### PR TITLE
Fix plugin validatie voor --plugin-dir

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,7 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "logius-standaarden",
+  "description": "Skills voor het werken met Nederlandse overheidsstandaarden",
   "owner": {
     "name": "Logius",
     "email": "standaarden@logius.nl"
@@ -7,9 +9,17 @@
   "plugins": [
     {
       "name": "logius-standaarden",
-      "source": ".",
       "description": "Skills voor het werken met Nederlandse overheidsstandaarden (Digikoppeling, API Design Rules, OAuth NL, FSC, CloudEvents, BOMOS, en meer)",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "author": {
+        "name": "Logius",
+        "email": "standaarden@logius.nl"
+      },
+      "source": {
+        "source": "url",
+        "url": "https://github.com/MinBZK/logius-standaarden-plugin.git"
+      },
+      "category": "productivity"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,19 +1,5 @@
 {
   "name": "logius-standaarden",
   "description": "Plugin voor het werken met Logius standaarden voor Nederlandse overheidsinteroperabiliteit. Bevat skills voor 88 GitHub repositories verdeeld over 9 domeinen: API Design Rules, Digikoppeling, Identity & Access Management, FSC, Logboek Dataverwerkingen, CloudEvents & Notificaties, BOMOS governance, E-Government services, en Publicatie & Tooling.",
-  "version": "1.0.0",
-  "upstreamSync": {
-    "lastChecked": "2026-02-12",
-    "domains": {
-      "api": "API-Design-Rules@v2.1.0",
-      "dk": "Digikoppeling-Architectuur@main",
-      "iam": "OAuth-NL-profiel@main",
-      "fsc": "fsc-core@main",
-      "logboek": "logboek-dataverwerkingen@main",
-      "notif": "NL-GOV-profile-for-CloudEvents@main",
-      "bomos": "BOMOS-Fundament@main",
-      "egov": "Terugmelden-API@main",
-      "pub": "Automatisering@main"
-    }
-  }
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary

- Verwijder `upstreamSync` veld uit `plugin.json` — dit veld wordt niet herkend door het Claude Code plugin schema (strict validation) en voorkomt dat de plugin geladen wordt
- Verwijder `marketplace.json` — bevatte een ongeldig `source: "."` pad dat de path traversal validatie niet doorkomt. Dit bestand is niet nodig voor `--plugin-dir` installatie

## Probleem

Bij installatie via `claude --plugin-dir ./logius-standaarden-plugin` worden de skills (`/ls`, `/ls-api`, etc.) niet beschikbaar. `claude plugin validate` geeft twee fouten:

```
✘ plugins.0.source: Invalid input (marketplace.json)
✘ root: Unrecognized key: "upstreamSync" (plugin.json)
```

## Oplossing

Na deze fix valideert de plugin correct:

```
$ claude plugin validate .
✔ Validation passed with warnings
```

## Test plan

- [ ] `claude plugin validate ./logius-standaarden-plugin` slaagt
- [ ] `claude --plugin-dir ./logius-standaarden-plugin` laadt alle 10 skills
- [ ] `/ls` skill is beschikbaar en toont domeinoverzicht