### PR TITLE
Versiemodel, bronconflicten en consistentie-audit

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "logius-standaarden",
-  "description": "Plugin voor het werken met Logius standaarden voor Nederlandse overheidsinteroperabiliteit. Bevat skills voor 88 GitHub repositories verdeeld over 9 domeinen: API Design Rules, Digikoppeling, Identity & Access Management, FSC, Logboek Dataverwerkingen, CloudEvents & Notificaties, BOMOS governance, E-Government services, en Publicatie & Tooling.",
-  "version": "1.1.1"
+  "description": "Plugin voor het werken met Logius standaarden voor Nederlandse overheidsinteroperabiliteit. Bevat skills voor 77 GitHub repositories verdeeld over 9 domeinen: API Design Rules, Digikoppeling, Identity & Access Management, FSC, Logboek Dataverwerkingen, CloudEvents & Notificaties, BOMOS governance, E-Government services, en Publicatie & Tooling.",
+  "version": "1.2.0"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
               echo "FOUT: $f mist 'description' in frontmatter"
               error=1
             fi
+            if ! grep -q '^model:' "$f"; then
+              echo "FOUT: $f mist 'model' in frontmatter"
+              error=1
+            fi
           done
           if [ $error -eq 1 ]; then exit 1; fi
           echo "Alle skills hebben geldige frontmatter"
@@ -73,7 +77,7 @@ jobs:
 
       - name: Controleer reference.md aanwezig voor domein-skills
         run: |
-          DOMAINS="ls-api ls-dk ls-iam ls-fsc ls-logboek ls-notif ls-bomos ls-egov"
+          DOMAINS="ls-api ls-dk ls-iam ls-fsc ls-logboek ls-notif ls-bomos ls-egov ls-pub"
           error=0
           for skill in $DOMAINS; do
             if [ ! -f "skills/$skill/reference.md" ]; then

--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -32,6 +32,15 @@ jobs:
           SKILL_MAP[pub]="ls-pub"
 
           # Lees domeinen uit plugin.json
+          # NB: De 'upstreamSync' key ontbreekt momenteel in plugin.json.
+          # Deze workflow doet niets totdat die key wordt toegevoegd met het formaat:
+          #   "upstreamSync": {
+          #     "lastChecked": "2026-01-01",
+          #     "domains": {
+          #       "api": "API-Design-Rules@main",
+          #       "dk": "Digikoppeling-Architectuur@main"
+          #     }
+          #   }
           domains=$(python3 -c "
           import json
           data = json.load(open('.claude-plugin/plugin.json'))

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -5,6 +5,8 @@
   "MD031": false,
   "MD032": false,
   "MD033": false,
+  "MD034": false,
   "MD040": false,
-  "MD041": false
+  "MD041": false,
+  "MD060": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Alle noemenswaardige wijzigingen aan deze plugin worden hier gedocumenteerd.
 Het formaat is gebaseerd op [Keep a Changelog](https://keepachangelog.com/nl/1.1.0/)
 en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 
+## [1.2.0] - 2026-02-21
+
+### Toegevoegd
+
+- Versiemodel en publicatiekanalen gedocumenteerd in meta-skill `/ls` en alle domein-skills
+- `conflicts.md` per domein: bronconflicten en bewuste keuzes gedocumenteerd (9 bestanden)
+- Forum Standaardisatie status toegevoegd aan meta-skill `/ls`
+- Ontbrekende vastgestelde versie-links toegevoegd in ls-dk (6 documenten met gitdocumentatie URLs)
+- Digikoppeling-Algemeen beschrijving en links toegevoegd (Roadmap)
+- CI-check voor `model` in skill frontmatter en reference.md voor ls-pub
+- `conflicts.md` patroon gedocumenteerd in CLAUDE.md
+
+### Gewijzigd
+
+- Repo-telling gecorrigeerd: 88→77 unieke repos (gearchiveerde, meta/test en duplicaten uitgefilterd)
+- Gearchiveerde repos gemarkeerd in ls-api, ls-bomos en ls-iam (ADR-Beheermodel, BOMOS-Aanvullende-Modules, BOMOS-OpenSource, OAuth-Beheermodel)
+- Dode links gefixt in ls-notif (Notificatieservices 404, Abonneren 404), ls-egov (Terugmelden-API 404) en ls-pub (gitdocumentatie root 403)
+- Verkeerde status-labels gecorrigeerd: NL-GOV-profile-for-CloudEvents (Draft→DEF v1.1), BOMOS-Verdieping (Draft→DEF), fsc-external-contract (Draft→CV)
+- ADR werkversie-omschrijving verduidelijkt: draft is werk-in-uitvoering richting volgende release (n.a.v. reviewer feedback)
+- README, publiccode.yml en plugin.json bijgewerkt met gecorrigeerde tellingen en beschrijvingen
+
 ## [1.1.0] - 2026-02-16
 
 ### Gewijzigd
@@ -21,17 +42,17 @@ en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 
 ### Toegevoegd
 
-- 10 skills voor 9 domeinen en 88 Logius standaarden repositories
+- 10 skills voor 9 domeinen en 77 Logius standaarden repositories
   - `/ls` - Meta-skill: overzicht en routing naar het juiste domein
-  - `/ls-api` - API Design Rules (10 repos): NL GOV API-standaard, Spectral linter, referentie-implementaties
+  - `/ls-api` - API Design Rules (9 repos): NL GOV API-standaard, Spectral linter, referentie-implementaties
   - `/ls-dk` - Digikoppeling (17 repos): REST, ebMS2, WUS, Grote Berichten, OIN
   - `/ls-iam` - Identity & Access Management (8 repos): OAuth 2.0 NL, OpenID Connect, AuthZEN, SAML
   - `/ls-fsc` - Federated Service Connectivity (7 repos): core protocol, inway/outway, service directory
-  - `/ls-logboek` - Logboek Dataverwerkingen (9 repos): REST API, juridisch kader, Docker demo
+  - `/ls-logboek` - Logboek Dataverwerkingen (8 repos): REST API, juridisch kader, Docker demo
   - `/ls-notif` - CloudEvents & Notificaties (4 repos): NL GOV CloudEvents profiel, pub/sub
   - `/ls-bomos` - BOMOS Governance (10 repos): Beheer- en Ontwikkelmodel voor Open Standaarden
   - `/ls-egov` - E-Government Services (6 repos): Terugmelding, Digimelding, e-procurement
-  - `/ls-pub` - Publicatie & Tooling (8 repos): ReSpec, GitHub Actions workflows, tech radar
+  - `/ls-pub` - Publicatie & Tooling (9 repos): ReSpec, GitHub Actions workflows, tech radar
 - Implementatievoorbeelden in Python, JavaScript, curl, XML en YAML
 - Foutafhandeling met error codes en retry patronen
 - Validatie-integraties (Spectral, markdownlint, axe-core)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Alle content in deze repo is in het **Nederlands**: skill descriptions, body tek
 - `skills/ls/SKILL.md` - Meta-skill (overzicht, routing)
 - `skills/ls-<domein>/SKILL.md` - Domein-skills (9 stuks)
 - `skills/ls-<domein>/reference.md` - Achtergrondinfo per domein (optioneel)
+- `skills/ls-<domein>/conflicts.md` - Bronconflicten en gemaakte keuzes per domein
 
 ## Conventies voor skills
 
@@ -33,6 +34,14 @@ Achtergrondkennis die niet direct nodig is voor code-generatie wordt verplaatst 
 - Handige commando's voor repo-exploratie
 
 De `SKILL.md` verwijst onderaan naar `reference.md` met een korte zin.
+
+### conflicts.md patroon
+Elk domein heeft een `conflicts.md` dat bronconflicten en bewuste keuzes documenteert:
+- Discrepanties tussen GitHub-tags en gepubliceerde versies op gitdocumentatie.logius.nl
+- Tegenstrijdige informatie tussen bronnen (bijv. Forum Standaardisatie vs. gitdocumentatie)
+- Bewuste keuzes met motivatie ("Keuze in SKILL.md" sectie)
+
+De conclusie-sectie heet altijd **"Keuze in SKILL.md"** en documenteert welke bron leidend is en wanneer het conflict opnieuw moet worden beoordeeld. De `SKILL.md` verwijst naar `conflicts.md` in de Achtergrondinfo-sectie.
 
 ### Description triggers
 Descriptions bevatten zowel Nederlandse als technische Engelse triggerwoorden zodat de skill bij relevante vragen wordt geactiveerd.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Logius Standaarden - Claude Code Plugin
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![versie](https://img.shields.io/badge/versie-1.1.0-green.svg)](CHANGELOG.md)
+[![versie](https://img.shields.io/badge/versie-1.2.0-green.svg)](CHANGELOG.md)
 
-Claude Code plugin voor het werken met de 88 GitHub repositories van [Logius standaarden](https://github.com/logius-standaarden) voor Nederlandse overheidsinteroperabiliteit.
+Claude Code plugin voor het werken met 77 van de 88 GitHub repositories van [Logius standaarden](https://github.com/logius-standaarden) voor Nederlandse overheidsinteroperabiliteit.
 
 ## Installatie
 
@@ -30,12 +30,12 @@ claude --plugin-dir ./logius-standaarden-plugin
 De plugin biedt 10 skills die een AI-agent helpen bij:
 
 - **Implementeren** van standaard-conforme code (OAuth, Digikoppeling, CloudEvents, etc.)
-- **Navigeren** door de 88 repositories, gegroepeerd in 9 domeinen
+- **Navigeren** door 77 repositories, gegroepeerd in 9 domeinen
 - **Ophalen** van actuele content via `gh api` en `WebFetch`
 - **Valideren** met Spectral linter, WCAG checks, markdown linting (via `/ls-pub`)
 - **Kiezen** van het juiste profiel of protocol via beslisbomen en keuzematrices
 
-### Agent-instructive aanpak
+### Instructie-gedreven aanpak
 
 Skills zijn geschreven als **agent-instructies**, niet als encyclopedie. Elke SKILL.md bevat:
 
@@ -53,14 +53,14 @@ Achtergrondkennis (architectuur, protocollen, concepten) staat in `reference.md`
 |-------|--------|-------|-------------|
 | `/ls` | Overzicht | - | Meta-skill: routeert naar het juiste domein |
 | `/ls-dk` | Digikoppeling | 17 | Beveiligde gegevensuitwisseling (REST, ebMS2, WUS, GB), OIN |
-| `/ls-api` | API Design Rules | 10 | NL GOV API-standaard, Spectral linter, referentie-implementaties |
+| `/ls-api` | API Design Rules | 9 | NL GOV API-standaard, Spectral linter, referentie-implementaties |
 | `/ls-iam` | Identity & Access Management | 8 | OAuth 2.0 NL, OpenID Connect, AuthZEN, SAML |
-| `/ls-fsc` | Federated Service Connectivity | 7 | Federatief netwerk: inway/outway, service directory |
-| `/ls-logboek` | Logboek Dataverwerkingen | 9 | AVG-logging van dataverwerkingen, Docker demo |
+| `/ls-fsc` | Federated Service Connectivity | 7 | Federatief netwerk: inway/outway, contracten, service directory |
+| `/ls-logboek` | Logboek Dataverwerkingen | 8 | AVG-logging, OpenTelemetry, W3C Trace Context |
 | `/ls-notif` | CloudEvents & Notificaties | 4 | NL GOV CloudEvents profiel, pub/sub |
 | `/ls-bomos` | BOMOS Governance | 10 | Beheer- en Ontwikkelmodel voor Open Standaarden |
 | `/ls-egov` | E-Government Services | 6 | Terugmelding, Digimelding, e-procurement |
-| `/ls-pub` | Publicatie & Tooling | 8 | ReSpec, GitHub Actions, WCAG checks, markdown lint |
+| `/ls-pub` | Publicatie & Tooling | 9 | ReSpec, GitHub Actions, WCAG checks, markdown lint |
 
 ## Voorbeeldvragen
 
@@ -85,15 +85,17 @@ skills/
   ls-api/
     SKILL.md               # Agent-instructies en implementatievoorbeelden
     reference.md           # Achtergrondkennis en repo-exploratie
+    conflicts.md           # Bronconflicten en gemaakte keuzes
   ls-dk/
     SKILL.md
     reference.md
+    conflicts.md
   ...                      # Idem voor alle 9 domein-skills
 ```
 
 ## Content strategie
 
-Skills bevatten compacte agent-instructies, beslisbomen en implementatievoorbeelden. Encyclopedische achtergrondkennis staat in `reference.md`. Actuele content wordt on-demand opgehaald via `gh api` en `WebFetch` - de GitHub repos zelf zijn de bron van waarheid.
+Skills bevatten compacte agent-instructies, beslisbomen en implementatievoorbeelden. Encyclopedische achtergrondkennis staat in `reference.md`. Bronconflicten en bewuste keuzes (bijv. discrepanties tussen GitHub-tags en gepubliceerde versies) zijn gedocumenteerd in `conflicts.md`. Actuele content wordt on-demand opgehaald via `gh api` en `WebFetch` - de GitHub repos zelf zijn de bron van waarheid.
 
 ## Versioning
 
@@ -105,7 +107,7 @@ De hele plugin wordt als 1 eenheid geversioned (semver):
 
 ## Vereisten
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI
+- [Claude Code](https://code.claude.com/docs) CLI
 - [GitHub CLI](https://cli.github.com/) (`gh`) - voor het ophalen van repo-content
 - Node.js - voor ReSpec, Spectral en andere npm-tools (optioneel, voor validatie)
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -4,26 +4,26 @@ categories:
 description:
   nl:
     features:
-      - 10 skills voor 9 domeinen en 88 Logius standaarden repositories
+      - 10 skills voor 9 domeinen en 77 Logius standaarden repositories
       - Implementatievoorbeelden in Python, JavaScript, curl, XML en YAML
       - On-demand content ophalen via GitHub API
       - Validatie-integraties (Spectral, markdownlint, axe-core)
     genericName: Claude Code plugin
     longDescription: |
-      Claude Code plugin voor het werken met de 88 GitHub repositories van
+      Claude Code plugin voor het werken met 77 van de 88 GitHub repositories van
       Logius standaarden voor Nederlandse overheidsinteroperabiliteit. Bevat
       skills voor API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek
       Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie tooling.
     shortDescription: Claude Code plugin voor Logius standaarden
   en:
     features:
-      - 10 skills covering 9 domains and 88 Logius standards repositories
+      - 10 skills covering 9 domains and 77 Logius standards repositories
       - Implementation examples in Python, JavaScript, curl, XML and YAML
       - On-demand content retrieval via GitHub API
       - Validation integrations (Spectral, markdownlint, axe-core)
     genericName: Claude Code plugin
     longDescription: |
-      Claude Code plugin for working with the 88 GitHub repositories of
+      Claude Code plugin for working with 77 of the 88 GitHub repositories of
       Logius standards for Dutch government interoperability. Contains skills
       for API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek
       Dataverwerkingen, CloudEvents, BOMOS, E-Government and Publication tooling.
@@ -42,6 +42,7 @@ maintenance:
       email: standaarden@logius.nl
   type: community
 name: logius-standaarden-plugin
-releaseDate: "2026-02-12"
+releaseDate: "2026-02-21"
+softwareVersion: "1.2.0"
 softwareType: standalone/other
 url: "https://github.com/MinBZK/logius-standaarden-plugin"

--- a/skills/ls-api/SKILL.md
+++ b/skills/ls-api/SKILL.md
@@ -14,29 +14,38 @@ allowed-tools:
 
 # API Design Rules (NL GOV)
 
-**Agent-instructie:** Deze skill helpt bij het implementeren van APIs conform de NL GOV API Design Rules. Gebruik de Spectral linter om OpenAPI specs te valideren. De regels zijn verplicht onder 'pas-toe-of-leg-uit' van het Forum Standaardisatie.
+**Agent-instructie:** Deze skill helpt bij het implementeren van APIs conform de NL GOV API Design Rules. Gebruik de Spectral linter om OpenAPI specs te valideren. De regels zijn verplicht onder ['pas-toe-of-leg-uit'](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules) van het Forum Standaardisatie.
 
 De API Design Rules (ADR) zijn de Nederlandse standaard voor het ontwerpen van RESTful APIs bij de overheid. Ze zijn verplicht onder het "pas-toe-of-leg-uit" regime van het Forum Standaardisatie. De standaard bevat concrete, toetsbare regels voor URI-ontwerp, HTTP-methoden, versiebeheer, beveiliging, foutafhandeling en meer.
 
+## Versiemodel
+
+De ADR kent twee publicatiekanalen (vergelijkbaar met W3C-standaarden):
+
+- **Vastgestelde versie (DEF)**: de officieel goedgekeurde versie, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: de ontwikkeling richting de volgende release, gepubliceerd op `logius-standaarden.github.io`. De werkversie op GitHub Pages is de lopende ontwikkeling richting de volgende release. De ReSpec-configuratie toont daar nog '2.1.0' maar dit betreft werk-in-uitvoering.
+
+Modules hebben geen eigen vaststellingsproces — ze ontlenen hun status aan de standaard die ernaar verwijst. Als de ADR in een vastgestelde versie normatief naar een module verwijst, is die module daarmee ook vastgesteld. Zo is de Geospatial module v1.0.x normatief onderdeel van ADR v2.1.0 en daarmee vastgesteld. De inhoud van Transport Security is in ADR v2.1.0 ingebed als sectie 3.8 met eigen regels (`/core/transport/*`). De module v1.0 staat nog normatief vermeld in de leeswijzer van v2.1.0, maar de GitHub-repository is gearchiveerd.
+
 ## Repositories
 
-| Repository | Beschrijving | Publicatie |
-|-----------|-------------|-----------|
-| [API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules) | Hoofdspecificatie met alle ontwerp- en technische regels | [Lees online](https://logius-standaarden.github.io/API-Design-Rules/) |
-| [ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel) | Beheermodel specifiek voor de ADR standaard | [Lees online](https://logius-standaarden.github.io/ADR-Beheermodel/) |
-| [API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel) | Overkoepelend beheermodel voor alle API-standaarden | [Lees online](https://logius-standaarden.github.io/API-Standaarden-Beheermodel/) |
-| [API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security) | Module: Transport Security (TLS, certificaten) | [Lees online](https://logius-standaarden.github.io/API-mod-transport-security/) |
-| [API-mod-signing](https://github.com/logius-standaarden/API-mod-signing) | Module: HTTP Message Signing — ⚠️ draft | [Lees online](https://logius-standaarden.github.io/API-mod-signing/) |
-| [API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption) | Module: Encryption (JWE) — ⚠️ draft | [Lees online](https://logius-standaarden.github.io/API-mod-encryption/) |
-| [API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial) | Module: Geospatial (GeoJSON, CRS) — ⚠️ draft | [Lees online](https://logius-standaarden.github.io/API-mod-geospatial/) |
-| [api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse) | Python tool: test Spectral regels tegen echte OpenAPI specs uit het API-register | - |
-| [zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api) | API-specificatie voor zaakgericht werken | - |
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules) | Hoofdspecificatie (ADR) | [v2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/) | [Draft](https://logius-standaarden.github.io/API-Design-Rules/) |
+| [ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel) | Beheermodel voor de ADR standaard — **gearchiveerd**, vervangen door API-Standaarden-Beheermodel | [v1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0/) | - |
+| [API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel) | Overkoepelend beheermodel API-standaarden | - | [Draft](https://logius-standaarden.github.io/API-Standaarden-Beheermodel/) |
+| [API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial) | Module: Geospatial (GeoJSON, CRS) — normatief in ADR v2.1.0 | [v1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/) | [Draft](https://logius-standaarden.github.io/API-mod-geospatial/) |
+| [API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security) | Module: Transport Security — **gearchiveerd**; inhoud ingebed in ADR v2.1.0; normatief vermeld in leeswijzer; repo gearchiveerd | - | - |
+| [API-mod-signing](https://github.com/logius-standaarden/API-mod-signing) | Module: HTTP Message Signing — draft | - | [Draft](https://logius-standaarden.github.io/API-mod-signing/) |
+| [API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption) | Module: Encryption (JWE) — draft | - | [Draft](https://logius-standaarden.github.io/API-mod-encryption/) |
+| [api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse) | Python tool: test Spectral regels tegen echte OpenAPI specs uit het API-register | - | - |
+| [zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api) | API-specificatie voor zaakgericht werken | - | - |
 
 ## Technische Regels
 
 ### URI-ontwerp
 
-- Gebruik **kebab-case** voor padsegmenten: `/financiele-claims` (niet `/financieleClaims`)
+- Gebruik **kebab-case** voor padsegmenten: `/mijn-documenten` (niet `/mijnDocumenten`)
 - Gebruik **camelCase** voor query-parameters: `?sortOrder=desc`
 - Geen trailing slashes: `/api/v1/users` (niet `/api/v1/users/`)
 - Geen bestandsextensies (gebruik Accept-header voor content negotiation)
@@ -83,7 +92,7 @@ Geen technische details (stack traces, interne hints) in foutmeldingen.
 - Resources als **zelfstandige naamwoorden** (niet werkwoorden)
 - **Meervoud** voor collecties: `/users`, `/orders`
 - **Enkelvoud** voor individuele resources: `/users/{id}`
-- Definieer interfaces in het **Nederlands** tenzij er een officieel Engels glossary bestaat
+- Definieer interfaces in het **Nederlands** tenzij er een officieel Engelstalig begrippenkader bestaat
 - Verberg implementatiedetails (geen framework- of databasenamen)
 
 ### OpenAPI Documentatie
@@ -93,9 +102,11 @@ Geen technische details (stack traces, interne hints) in foutmeldingen.
 - Contactinformatie verplicht (name, email, url)
 - CORS ondersteunen voor documentatie-toegang
 
-## Beveiligingsmodules
+## Modules
 
 ### Transport Security (TLS)
+
+> **Let op:** De Transport Security module werd als aparte module normatief verwezen door ADR v2.0.0. Vanaf ADR v2.1.0 zijn de transport-security-eisen **ingebed in de hoofdspecificatie** (sectie 3.8, regels `/core/transport/*`) en is de [repository gearchiveerd](https://github.com/logius-standaarden/API-mod-transport-security). De module v1.0 staat nog normatief vermeld in de leeswijzer van ADR v2.1.0.
 
 Alle verbindingen MOETEN TLS gebruiken (wettelijk verplicht). Volg de laatste NCSC-richtlijnen.
 
@@ -111,23 +122,21 @@ Verplichte security headers in alle API-responses:
 | `X-Frame-Options: DENY` | Clickjacking bescherming |
 | `Access-Control-Allow-Origin` | CORS beleid |
 
-### Signing Module (JAdES) — ⚠️ DRAFT
+### Geospatial Module (v1.0.3 — vastgesteld)
+
+Normatief onderdeel van ADR v2.1.0. Verplicht bij geospatiale data. Regelt GeoJSON encodering, bounding box filtering, en coördinaatsystemen (CRS). Zie de [vastgestelde versie](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/).
+
+### Signing Module (JAdES) — draft
 
 > **Let op:** Deze module is nog in **concept** (draft) en is nog niet goedgekeurd door het Technisch Overleg. De inhoud kan nog wijzigen.
 
 Voor end-to-end berichtintegriteit en authenticiteit. Gebruikt JAdES detached signatures met RSASSA-PSS (PS256), minimaal 256 bits. Signatures in `Payload-Signature` en `Message-Signature` HTTP headers. OpenAPI representatie met `format: jws-compact-detached`.
 
-### Encryption Module (JWE) — ⚠️ DRAFT
+### Encryption Module (JWE) — draft
 
 > **Let op:** Deze module is nog in **concept** (draft) en is nog niet goedgekeurd door het Technisch Overleg. De inhoud kan nog wijzigen.
 
 Voor end-to-end versleuteling van request/response payloads wanneer transport-level encryptie niet voldoende is (bijv. bij niet-vertrouwde intermediairs).
-
-### Geospatial Module — ⚠️ DRAFT
-
-> **Let op:** Deze module is nog in **concept** (draft) en is nog niet goedgekeurd door het Technisch Overleg. De inhoud kan nog wijzigen.
-
-Verplicht bij geospatiale data. Regelt GeoJSON encodering, bounding box filtering, en coördinaatsystemen (CRS).
 
 ## Implementatievoorbeeld
 
@@ -210,7 +219,7 @@ async def problem_json_handler(request: Request, exc: HTTPException):
 
 ## Spectral Linter
 
-De Spectral linter valideert OpenAPI specs tegen 30+ ADR regels.
+De Spectral linter valideert OpenAPI specs tegen 15 ADR regels.
 
 ```bash
 # Haal spectral.yml op en lint een OpenAPI spec
@@ -227,16 +236,16 @@ gh api repos/logius-standaarden/API-Design-Rules/contents/linter/testcases --jq 
 ```
 
 Belangrijke Spectral regels:
-- `nlgov:version-in-uri` - Major versie in URI pad
+- `nlgov:include-major-version-in-uri` - Major versie in URI pad
 - `nlgov:paths-no-trailing-slash` - Geen trailing slashes
 - `nlgov:paths-kebab-case` - Kebab-case padsegmenten
-- `nlgov:query-params-camel-case` - camelCase query parameters
-- `nlgov:http-methods-only-standard` - Alleen standaard HTTP methoden
-- `nlgov:info-contact` - Contactinformatie aanwezig
-- `nlgov:api-version-header` - Version header in 2xx/3xx responses
-- `nlgov:error-response-problem-json` - Problem+json voor fouten
-- `nlgov:semver-version` - Semantic versioning formaat
+- `nlgov:query-keys-camel-case` - camelCase query parameters
+- `nlgov:http-methods` - Alleen standaard HTTP methoden
+- `nlgov:info-contact-fields-exist` - Contactinformatie aanwezig
+- `nlgov:missing-version-header` - Version header in 2xx/3xx responses
+- `nlgov:use-problem-schema` - Problem+json voor fouten
+- `nlgov:semver` - Semantic versioning formaat
 
 ## Achtergrondinfo
 
-Zie [reference.md](reference.md) voor Express.js/Go voorbeelden, impact analyse tool, en repo-exploratie commando's.
+Zie [reference.md](reference.md) voor Express.js/Go voorbeelden, impact analyse tool, en repo-exploratie commando's. Zie [conflicts.md](conflicts.md) voor bekende discrepanties tussen GitHub-tags en gepubliceerde versies.

--- a/skills/ls-api/conflicts.md
+++ b/skills/ls-api/conflicts.md
@@ -1,0 +1,69 @@
+# API Design Rules - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties tussen GitHub-repository tags en de gepubliceerde versies op [gitdocumentatie.logius.nl](https://gitdocumentatie.logius.nl). De **gepubliceerde versie op gitdocumentatie.logius.nl is leidend** voor DEF-versies.
+
+## Discrepanties
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial) | [v1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/) | `1.0.2` | Tag achter: publicatie v1.0.3 vs tag 1.0.2 |
+| [ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel) | [v1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0/) | `10r4` | Tag-formaat afwijkend: publicatie v1.0 vs tag `10r4` |
+
+### Details API-mod-geospatial
+
+- **Alle bekende tags:** `1.0.2`, `1.0.1`, `1.0.0`
+- **Geen GitHub Releases** aangemaakt
+- De tag `1.0.2` bestaat op GitHub, maar de gepubliceerde versie op gitdocumentatie is `1.0.3`
+- Er is geen tag `1.0.3` in de repository
+- Dit wijst erop dat de publicatie v1.0.3 is doorgevoerd zonder een bijbehorende Git-tag aan te maken
+
+### Details ADR-Beheermodel
+
+- **Enige tag:** `10r4` — afwijkend formaat, geen semantic versioning
+- De repository is **gearchiveerd** en vervangen door API-Standaarden-Beheermodel
+- De gepubliceerde DEF-versie op gitdocumentatie is `v1.0`
+- Het tag-formaat `10r4` komt waarschijnlijk uit een ouder versiebeheersysteem
+
+## Transport Security module: dubbelzinnige status
+
+De Transport Security module (API-mod-transport-security) heeft een dubbelzinnige status in ADR v2.1.0:
+
+| Aspect | Status | Bron |
+|--------|--------|------|
+| GitHub-repository | **Gearchiveerd** | https://github.com/logius-standaarden/API-mod-transport-security |
+| Inhoud in ADR v2.1.0 | **Ingebed** als sectie 3.8 met eigen regels (`/core/transport/*`) | https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/ |
+| Leeswijzer ADR v2.1.0 | Module v1.0 staat **normatief vermeld** | https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/ |
+
+### Analyse
+
+De module-inhoud is feitelijk in de hoofdspecificatie opgenomen, maar de leeswijzer van v2.1.0 vermeldt de module v1.0 nog steeds als normatief. De repo is gearchiveerd, wat suggereert dat het Technisch Overleg de module als afgehandeld beschouwt. De vermelding in de leeswijzer is waarschijnlijk een redactioneel overblijfsel.
+
+### Keuze in SKILL.md
+
+De SKILL.md beschrijft de feitelijke situatie: inhoud ingebed in v2.1.0, module nog normatief in leeswijzer, repo gearchiveerd. Dit voorkomt de onjuiste conclusie dat de module "vervallen" is terwijl deze nog in de leeswijzer staat. Als de leeswijzer wordt bijgewerkt, moet deze beschrijving opnieuw worden beoordeeld.
+
+## ADR werkversie-nummering op draft-pagina
+
+De draft-pagina op GitHub Pages ([logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules/)) toont in de ReSpec-configuratie nog versienummer '2.1.0', terwijl v2.1.0 ook de huidige DEF-versie is. De draft betreft echter werk-in-uitvoering richting de volgende release — het versienummer in ReSpec is simpelweg nog niet opgehoogd. Dit is een bekend patroon bij Logius-standaarden: de ReSpec `defined_in` configuratie wordt pas bijgewerkt wanneer de nieuwe versie wordt vastgesteld.
+
+### Keuze in SKILL.md
+
+De SKILL.md beschrijft de werkversie als "lopende ontwikkeling richting de volgende release" zonder een specifiek versienummer te claimen voor de draft. Dit voorkomt verwarring met de DEF-versie. Als de ReSpec-configuratie wordt bijgewerkt naar een nieuw versienummer, moet deze beschrijving opnieuw worden beoordeeld.
+
+## Keuze in SKILL.md
+
+De skill gebruikt versienummers van gitdocumentatie.logius.nl als bron van waarheid voor vastgestelde (DEF) versies. De GitHub-tag van API-mod-geospatial loopt één patchversie achter; dit is hetzelfde patroon als bij andere Logius-standaarden repos (zie ook [ls-dk/conflicts.md](../ls-dk/conflicts.md)). ADR-Beheermodel heeft een afwijkend tag-formaat (`10r4` vs DEF v1.0). Transport Security wordt beschreven met de feitelijke drieledige status (ingebed, leeswijzer, gearchiveerd). Als tags worden bijgewerkt of de leeswijzer wordt aangepast, moeten deze conflicten opnieuw worden beoordeeld.
+
+## Referenties
+
+- Publicatie API-mod-geospatial: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/
+- GitHub repo: https://github.com/logius-standaarden/API-mod-geospatial
+- GitHub tags: https://github.com/logius-standaarden/API-mod-geospatial/tags
+- Publicatie ADR-Beheermodel: https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0/
+- GitHub ADR-Beheermodel: https://github.com/logius-standaarden/ADR-Beheermodel
+- GitHub ADR-Beheermodel tags: https://github.com/logius-standaarden/ADR-Beheermodel/tags
+- GitHub API-mod-transport-security: https://github.com/logius-standaarden/API-mod-transport-security
+- Publicatie ADR v2.1.0: https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/
+- Forum Standaardisatie ADR: https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules

--- a/skills/ls-api/reference.md
+++ b/skills/ls-api/reference.md
@@ -56,7 +56,7 @@ De impact analyse tool test Spectral regels tegen echte OpenAPI specs uit het AP
 ```bash
 gh repo clone logius-standaarden/api-linter-impactanalyse /tmp/api-linter
 cd /tmp/api-linter
-uv run run-spectral-for-single-rule.py --rule nlgov:paths-no-trailing-slash
+uv run scripts/run-spectral-for-single-rule.py --rule nlgov:paths-no-trailing-slash
 ```
 
 ## Repository Exploratie Commando's

--- a/skills/ls-bomos/SKILL.md
+++ b/skills/ls-bomos/SKILL.md
@@ -7,26 +7,44 @@ allowed-tools:
   - Bash(gh issue list *)
   - Bash(gh pr list *)
   - Bash(gh search *)
+  - Bash(curl -s *)
+  - WebFetch(*)
 ---
 
 # BOMOS - Beheer- en Ontwikkelmodel voor Open Standaarden
 
 **Agent-instructie:** Deze skill helpt bij het opzetten en beoordelen van beheermodellen voor open standaarden conform BOMOS. Gebruik het template en de checklist om een beheermodel op te stellen. Gebruik gh commando's om actuele content op te halen uit de BOMOS repos.
 
+## Versiemodel
+
+Net als andere Logius-standaarden kent BOMOS twee publicatiekanalen:
+
+- **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
+
+BOMOS is geen interoperabiliteitsstandaard en staat niet op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie. Het is een raamwerk voor het beheren van open standaarden.
+
 ## Repositories
+
+### Kerndocumenten (met vastgestelde versies)
+
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament) | Kernmodel: activiteiten, rollen, structuur | [v3.0.1](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/) | [Draft](https://logius-standaarden.github.io/BOMOS-Fundament/) |
+| [BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping) | Verdiepende beschrijving van BOMOS activiteiten | [v3.1.0](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/) | [Draft](https://logius-standaarden.github.io/BOMOS-Verdieping/) |
+
+### Aanvullende modules en documenten (alleen werkversies)
 
 | Repository | Beschrijving | Publicatie |
 |-----------|-------------|-----------|
-| [BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament) | Kernmodel: activiteiten, rollen, structuur | [Lees online](https://logius-standaarden.github.io/BOMOS-Fundament/) |
-| [BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping) | Verdiepende beschrijving van BOMOS activiteiten | [Lees online](https://logius-standaarden.github.io/BOMOS-Verdieping/) |
-| [BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules) | Aanvullende modules voor specifieke aspecten | [Lees online](https://logius-standaarden.github.io/BOMOS-Aanvullende-Modules/) |
-| [BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData) | Module: beheer van Linked Data standaarden | [Lees online](https://logius-standaarden.github.io/BOMOS-LinkedData/) |
-| [BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource) | Module: open source governance | [Lees online](https://logius-standaarden.github.io/BOMOS-OpenSource/) |
-| [BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels) | Module: beheer van stelsels van standaarden | [Lees online](https://logius-standaarden.github.io/BOMOS-Stelsels/) |
-| [BOMOS-Beheermodel](https://github.com/logius-standaarden/BOMOS-Beheermodel) | Beheermodel voor BOMOS zelf | [Lees online](https://logius-standaarden.github.io/BOMOS-Beheermodel/) |
-| [BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel) | Voorbeelddocument voor een beheermodel | [Lees online](https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel/) |
-| [BOMOS-Community](https://github.com/logius-standaarden/BOMOS-Community) | Community-aspecten van standaardenbeheer | [Lees online](https://logius-standaarden.github.io/BOMOS-Community/) |
-| [Logius-Beheermodel](https://github.com/logius-standaarden/Logius-Beheermodel) | Overkoepelend beheermodel van Logius | [Lees online](https://logius-standaarden.github.io/Logius-Beheermodel/) |
+| [BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules) | Aanvullende modules voor specifieke aspecten — **gearchiveerd** | - |
+| [BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData) | Module: beheer van Linked Data standaarden | [Draft](https://logius-standaarden.github.io/BOMOS-LinkedData/) |
+| [BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource) | Module: open source governance — **gearchiveerd** | [Draft (bevroren)](https://logius-standaarden.github.io/BOMOS-OpenSource/) |
+| [BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels) | Module: beheer van stelsels van standaarden | [Draft](https://logius-standaarden.github.io/BOMOS-Stelsels/) |
+| [BOMOS-Beheermodel](https://github.com/logius-standaarden/BOMOS-Beheermodel) | Beheermodel voor BOMOS zelf | [Draft](https://logius-standaarden.github.io/BOMOS-Beheermodel/) |
+| [BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel) | Voorbeelddocument voor een beheermodel | [Draft](https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel/) |
+| [BOMOS-Community](https://github.com/logius-standaarden/BOMOS-Community) | Community-aspecten van standaardenbeheer | [Draft](https://logius-standaarden.github.io/BOMOS-Community/) |
+| [Logius-Beheermodel](https://github.com/logius-standaarden/Logius-Beheermodel) | Overkoepelend beheermodel van Logius | [Draft](https://logius-standaarden.github.io/Logius-Beheermodel/) |
 
 ## Wijzigingsbeheer Workflow
 
@@ -157,4 +175,4 @@ Een organisatie werkt conform BOMOS wanneer voor **elke** activiteit een bewuste
 
 ## Achtergrondinfo
 
-Zie [reference.md](reference.md) voor het activiteitenmodel, rollen, levensfasen, pressure cooker model, en praktijkvoorbeelden.
+Zie [reference.md](reference.md) voor het activiteitenmodel, rollen, levensfasen, pressure cooker model, en praktijkvoorbeelden. Zie [conflicts.md](conflicts.md) voor bekende discrepanties tussen GitHub-tags en gepubliceerde versies.

--- a/skills/ls-bomos/conflicts.md
+++ b/skills/ls-bomos/conflicts.md
@@ -1,0 +1,46 @@
+# BOMOS - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties tussen GitHub-repository tags en de gepubliceerde versies op [gitdocumentatie.logius.nl](https://gitdocumentatie.logius.nl). De **gepubliceerde versie op gitdocumentatie.logius.nl is leidend** voor DEF-versies.
+
+## Discrepanties
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament) | [v3.0.1](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/) | `0.2.1` | Volledig afwijkend versienummerschema |
+| [BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping) | [v3.1.0](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/) | `0.2.1` | Volledig afwijkend versienummerschema |
+
+### Details: Dubbel versienummerschema
+
+Bij BOMOS is de discrepantie **fundamenteel anders** dan bij andere Logius-standaarden. Het gaat niet om een achterlopende tag, maar om **twee volledig verschillende versienummerschema's**:
+
+- **Git-tags** (`0.2.1`, `0.2`, `0.1`): volgen het repo/tooling-versienummer. Dit nummert de technische revisies van de repository-structuur.
+- **Documentversies** (`v3.0.1`, `v3.1.0`): volgen het documentversienummer zoals opgenomen in de ReSpec-configuratie van het document zelf. Dit is het versienummer dat op de voorpagina van het document staat.
+
+De documentversie v3.0.1 resp. v3.1.0 is bevestigd via de ReSpec `localBiblio` configuratie in de repositories.
+
+### Tags per repository
+
+**BOMOS-Fundament:**
+- Tags: `0.2.1`, `0.2`, `0.1`
+- Geen GitHub Releases
+- Documentversie (ReSpec): `3.0.1`
+
+**BOMOS-Verdieping:**
+- Tags: `0.2.1`, `0.2`, `0.1`
+- Geen GitHub Releases
+- Documentversie (ReSpec): `3.1.0`
+
+## Keuze in SKILL.md
+
+De skill gebruikt de documentversies (`v3.0.1` en `v3.1.0`) van gitdocumentatie.logius.nl, niet de Git-tags die een onafhankelijk versienummerschema voor de repo-structuur hanteren. Dit is een bijzonderheid van BOMOS. Als het versienummerschema wordt geharmoniseerd, moet dit conflict opnieuw worden beoordeeld.
+
+## Referenties
+
+- Publicatie BOMOS-Fundament: https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/
+- Publicatie BOMOS-Verdieping: https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/
+- GitHub BOMOS-Fundament: https://github.com/logius-standaarden/BOMOS-Fundament
+- GitHub BOMOS-Fundament tags: https://github.com/logius-standaarden/BOMOS-Fundament/tags
+- GitHub BOMOS-Verdieping: https://github.com/logius-standaarden/BOMOS-Verdieping
+- GitHub BOMOS-Verdieping tags: https://github.com/logius-standaarden/BOMOS-Verdieping/tags

--- a/skills/ls-bomos/reference.md
+++ b/skills/ls-bomos/reference.md
@@ -43,7 +43,7 @@ De operationele laag omvat het daadwerkelijke dagelijkse werk van standaardontwi
 
 ### 4. Implementatieondersteuning
 
-Deze laag ondersteunt organisaties bij de daadwerkelijke implementatie van de standaard. Hierbij is het cruciaal om een balans te vinden tussen activiteiten van de beheerorganisatie en die van commerciele partijen.
+Deze laag ondersteunt organisaties bij de daadwerkelijke implementatie van de standaard. Hierbij is het cruciaal om een balans te vinden tussen activiteiten van de beheerorganisatie en die van commerciële partijen.
 
 - **Helpdesk** - Minimale ondersteuning voor implementatievragen (laagdrempelig, altijd nodig)
 - **Opleidingen** - Zorgvuldig aanbieden: niet concurreren met de markt, alleen waar de markt niet voorziet
@@ -55,7 +55,7 @@ Deze laag ondersteunt organisaties bij de daadwerkelijke implementatie van de st
 
 De communicatielaag zorgt voor zichtbaarheid en betrokkenheid rond de standaard.
 
-- **Promotie** - Actieve promotie van de standaard bij potentiele gebruikers en stakeholders
+- **Promotie** - Actieve promotie van de standaard bij potentiële gebruikers en stakeholders
 - **Community management** - Opbouwen en onderhouden van een actieve community van gebruikers en ontwikkelaars
 - **Events** - Organiseren van bijeenkomsten, werkgroepen, en plugfests
 - **Distributie** - Publicatie en verspreiding van de standaard en bijbehorende documentatie
@@ -84,7 +84,7 @@ Een persoon kan meerdere rollen vervullen, en een rol kan door meerdere personen
 Elke standaard doorloopt een levenscyclus waarbij per fase andere accenten in het beheer worden gelegd:
 
 1. **Creatie/Ontwikkeling** - De standaard wordt ontworpen en de eerste versie wordt opgeleverd. Focus op inhoudelijke kwaliteit, brede consultatie, en draagvlak.
-2. **Introductie** - De standaard wordt gepubliceerd en bij de doelgroep geintroduceerd. Focus op promotie, early adopters, en implementatieondersteuning.
+2. **Introductie** - De standaard wordt gepubliceerd en bij de doelgroep geïntroduceerd. Focus op promotie, early adopters, en implementatieondersteuning.
 3. **Implementatie/Groei** - Brede adoptie komt op gang. Focus op helpdesk, opleidingen, validatie, en community building.
 4. **Volwassenheid** - De standaard is breed geadopteerd en stabiel. Focus op onderhoud, wijzigingsbeheer, en interoperabiliteit met aanpalende standaarden.
 5. **Uitfasering** - De standaard wordt vervangen of buiten gebruik gesteld. Focus op migratieondersteuning, communicatie, en archivering.
@@ -118,7 +118,7 @@ TOOI (Thesaurus en Ontologie voor OverheidsInformatie) gebruikt BOMOS als basis 
 
 ## Linked Data Module
 
-De Linked Data module biedt specifieke richtlijnen voor het beheer van semantische standaarden zoals ontologieen en vocabulaires. Deze module behandelt onderwerpen als URI-strategie, versiebeheer van ontologieen, en publicatie als Linked Data.
+De Linked Data module biedt specifieke richtlijnen voor het beheer van semantische standaarden zoals ontologieën en vocabulaires. Deze module behandelt onderwerpen als URI-strategie, versiebeheer van ontologieën, en publicatie als Linked Data.
 
 **Repository:** [BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
 

--- a/skills/ls-dk/SKILL.md
+++ b/skills/ls-dk/SKILL.md
@@ -15,29 +15,43 @@ allowed-tools:
 
 **Agent-instructie:** Deze skill helpt bij het implementeren van Digikoppeling koppelvlakken. Gebruik de beslisboom om het juiste profiel te kiezen. De implementatievoorbeelden bevatten werkende code voor alle vier koppelvlakstandaarden.
 
-Digikoppeling is de Nederlandse standaard voor beveiligde elektronische gegevensuitwisseling tussen overheidsorganisaties. Het definieert de architectuur en koppelvlakspecificaties waarmee overheden op een gestandaardiseerde, veilige en betrouwbare manier berichten en gegevens uitwisselen. Digikoppeling is opgenomen op de "pas toe of leg uit"-lijst van het Forum Standaardisatie.
+Digikoppeling is de Nederlandse standaard voor beveiligde elektronische gegevensuitwisseling tussen overheidsorganisaties. Het definieert de architectuur en koppelvlakspecificaties waarmee overheden op een gestandaardiseerde, veilige en betrouwbare manier berichten en gegevens uitwisselen. Digikoppeling is opgenomen op de ["pas toe of leg uit"](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)-lijst van het Forum Standaardisatie.
+
+## Versiemodel
+
+Net als andere Logius-standaarden kent Digikoppeling twee publicatiekanalen:
+
+- **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
 
 ## Repositories
 
-| Repository | Beschrijving | Publicatie |
-|-----------|-------------|-----------|
-| [Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur) | Overkoepelende architectuurbeschrijving | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Architectuur/) |
-| [Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API) | REST-API koppelvlakspecificatie | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API/) |
-| [Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2) | ebMS2 koppelvlakspecificatie | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2/) |
-| [Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS) | WUS (WSDL/UDDI/SOAP) koppelvlakspecificatie | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS/) |
-| [Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB) | Grote Berichten koppelvlakspecificatie | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB/) |
-| [Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften) | Beveiligingsstandaarden en -voorschriften | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften/) |
-| [Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie) | Identificatie en authenticatie | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie/) |
-| [Digikoppeling-Gebruik-en-achtergrond-certificaten](https://github.com/logius-standaarden/Digikoppeling-Gebruik-en-achtergrond-certificaten) | Gebruik van PKIoverheid-certificaten | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Gebruik-en-achtergrond-certificaten/) |
-| [Digikoppeling-Handreiking-Adressering-en-Routering](https://github.com/logius-standaarden/Digikoppeling-Handreiking-Adressering-en-Routering) | Handreiking voor adressering en routering | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Handreiking-Adressering-en-Routering/) |
-| [Digikoppeling-Best-Practices-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-ebMS2) | Best practices voor ebMS2 implementatie | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Best-Practices-ebMS2/) |
-| [Digikoppeling-Best-Practices-WUS](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-WUS) | Best practices voor WUS implementatie | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Best-Practices-WUS/) |
-| [Digikoppeling-Best-Practices-GB](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-GB) | Best practices voor Grote Berichten | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Best-Practices-GB/) |
-| [Digikoppeling-Overzicht-Actuele-Documentatie-en-Compliance](https://github.com/logius-standaarden/Digikoppeling-Overzicht-Actuele-Documentatie-en-Compliance) | Overzicht documentatie en compliance | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Overzicht-Actuele-Documentatie-en-Compliance/) |
-| [Digikoppeling-Wat-is-Digikoppeling](https://github.com/logius-standaarden/Digikoppeling-Wat-is-Digikoppeling) | Introductie en uitleg | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Wat-is-Digikoppeling/) |
-| [Digikoppeling-Algemeen](https://github.com/logius-standaarden/Digikoppeling-Algemeen) | Algemene informatie en bronbestanden | - |
-| [Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel) | Beheermodel voor Digikoppeling | [Lees online](https://logius-standaarden.github.io/Digikoppeling-Beheermodel/) |
-| [OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel) | Organisatie Identificatie Nummer stelsel | [Lees online](https://logius-standaarden.github.io/OIN-Stelsel/) |
+### Kernspecificaties (met vastgestelde versies)
+
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur) | Overkoepelende architectuurbeschrijving | [v2.1.1](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Architectuur/) |
+| [Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API) | REST-API koppelvlakspecificatie | [v3.0.1](https://gitdocumentatie.logius.nl/publicatie/dk/restapi/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API/) |
+| [Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2) | ebMS2 koppelvlakspecificatie | [v3.3.2](https://gitdocumentatie.logius.nl/publicatie/dk/ebms/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2/) |
+| [Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS) | WUS (WSDL/UDDI/SOAP) koppelvlakspecificatie | [v3.8.1](https://gitdocumentatie.logius.nl/publicatie/dk/wus/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS/) |
+| [Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB) | Grote Berichten koppelvlakspecificatie | [v3.8.1](https://gitdocumentatie.logius.nl/publicatie/dk/gb/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB/) |
+| [Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften) | Beveiligingsstandaarden en -voorschriften | [v2.0.1](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften/) |
+| [Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie) | Identificatie en authenticatie | [v1.5.0](https://gitdocumentatie.logius.nl/publicatie/dk/idauth/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie/) |
+| [OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel) | Organisatie Identificatie Nummer stelsel | [v2.2.1](https://gitdocumentatie.logius.nl/publicatie/dk/oin/) | [Draft](https://logius-standaarden.github.io/OIN-Stelsel/) |
+| [Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel) | Beheermodel voor Digikoppeling | [v1.8](https://gitdocumentatie.logius.nl/publicatie/dk/beheer/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Beheermodel/) |
+
+### Aanvullende documenten
+
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [Digikoppeling-Gebruik-en-achtergrond-certificaten](https://github.com/logius-standaarden/Digikoppeling-Gebruik-en-achtergrond-certificaten) | Gebruik van PKIoverheid-certificaten | [v1.6.3](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Gebruik-en-achtergrond-certificaten/) |
+| [Digikoppeling-Handreiking-Adressering-en-Routering](https://github.com/logius-standaarden/Digikoppeling-Handreiking-Adressering-en-Routering) | Handreiking voor adressering en routering | [v1.1.0](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Handreiking-Adressering-en-Routering/) |
+| [Digikoppeling-Best-Practices-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-ebMS2) | Best practices voor ebMS2 implementatie | [v3.2.2](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Best-Practices-ebMS2/) |
+| [Digikoppeling-Best-Practices-WUS](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-WUS) | Best practices voor WUS implementatie | [v1.10.2](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Best-Practices-WUS/) |
+| [Digikoppeling-Best-Practices-GB](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-GB) | Best practices voor Grote Berichten | [v3.2.0](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Best-Practices-GB/) |
+| [Digikoppeling-Overzicht-Actuele-Documentatie-en-Compliance](https://github.com/logius-standaarden/Digikoppeling-Overzicht-Actuele-Documentatie-en-Compliance) | Overzicht documentatie en compliance | [v1.12.2](https://gitdocumentatie.logius.nl/publicatie/dk/actueel/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Overzicht-Actuele-Documentatie-en-Compliance/) |
+| [Digikoppeling-Wat-is-Digikoppeling](https://github.com/logius-standaarden/Digikoppeling-Wat-is-Digikoppeling) | Introductie en uitleg | [v1.1.2](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Wat-is-Digikoppeling/) |
+| [Digikoppeling-Algemeen](https://github.com/logius-standaarden/Digikoppeling-Algemeen) | Digikoppeling Roadmap | [v2024-2025](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap/) | [Draft](https://logius-standaarden.github.io/Digikoppeling-Algemeen/) |
 
 ## Profielkeuze
 
@@ -45,12 +59,12 @@ De keuze voor het juiste Digikoppeling-profiel hangt af van de functionele en ni
 
 ```
 Berichtgrootte > 20 MB?
-  JA  --> Grote Berichten (aanvullend op WUS of ebMS2)
+  JA  --> Grote Berichten (aanvullend op REST-API, WUS of ebMS2)
   NEE --> Ga verder
 
 Is snelheid/eenvoud belangrijk en past een synchrone request/response?
   JA  --> Is een REST-API beschikbaar/gewenst?
-            JA  --> REST-API profiel (met FSC sinds 1/1/2025)
+            JA  --> REST-API profiel (FSC verplicht, zie /ls-fsc)
             NEE --> WUS profiel (2W-be)
   NEE --> Ga verder
 
@@ -59,7 +73,7 @@ Is betrouwbare (reliable) aflevering vereist?
   NEE --> ebMS2 best-effort profiel (osb-be)
 
 Gaat het bericht via een niet-vertrouwde intermediair?
-  JA  --> Kies het signed (-S) of signed+encrypted (-SE/-E) variant van het gekozen profiel
+  JA  --> Kies de signed (-S) of signed+encrypted (-SE/-E) variant van het gekozen profiel
   NEE --> Basisprofiel volstaat
 ```
 
@@ -88,7 +102,7 @@ Gaat het bericht via een niet-vertrouwde intermediair?
 ### REST-API Koppelvlak met OIN (Python/FastAPI)
 
 ```python
-from fastapi import FastAPI, Request, Response, HTTPException
+from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 
 app = FastAPI(
@@ -138,7 +152,6 @@ async def problem_json_handler(request: Request, exc: HTTPException):
 
 ```python
 from zeep import Client
-from zeep.wsse.username import UsernameToken
 from zeep.transports import Transport
 from requests import Session
 
@@ -197,7 +210,8 @@ print(f"Naam: {response.Naam}")
 <?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-    xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd">
+    xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
   <soapenv:Header>
     <eb:MessageHeader soapenv:mustUnderstand="1" eb:version="2.0">
       <eb:From>
@@ -345,4 +359,4 @@ Bij het profiel `osb-rm` gelden de volgende retry-regels:
 
 ## Achtergrondinfo
 
-Zie [reference.md](reference.md) voor de architectuur, beveiligingsstandaarden, en gedetailleerde protocol-beschrijvingen.
+Zie [reference.md](reference.md) voor de architectuur, beveiligingsstandaarden, en gedetailleerde protocol-beschrijvingen. Zie [conflicts.md](conflicts.md) voor bekende discrepanties tussen GitHub-tags en gepubliceerde versies.

--- a/skills/ls-dk/conflicts.md
+++ b/skills/ls-dk/conflicts.md
@@ -1,0 +1,48 @@
+# Digikoppeling - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties tussen GitHub-repository tags en de gepubliceerde versies op [gitdocumentatie.logius.nl](https://gitdocumentatie.logius.nl). De **gepubliceerde versie op gitdocumentatie.logius.nl is leidend** voor DEF-versies; GitHub-tags worden niet altijd bijgewerkt na publicatie.
+
+## Patroon
+
+Bij Digikoppeling-repositories worden versie-tags in GitHub aangemaakt bij het doorlopen van het release-proces. Na vaststelling (DEF) wordt de versie gepubliceerd op gitdocumentatie.logius.nl. Echter, de Git-tags worden niet altijd bijgewerkt wanneer er na de oorspronkelijke publicatie correcties of nieuwe versies worden vastgesteld. Dit betekent dat de laatste Git-tag vaak achterloopt op de gepubliceerde versie.
+
+Daarnaast worden GitHub Releases (een apart mechanisme naast tags) niet consequent aangemaakt. Veel tags hebben geen bijbehorende GitHub Release.
+
+## Discrepanties
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur) | [v2.1.1](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur/) | `2.0.2` | Tag achter: publicatie v2.1.1 vs tag 2.0.2 |
+| [Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API) | [v3.0.1](https://gitdocumentatie.logius.nl/publicatie/dk/restapi/) | `3.0.0` | Tag achter: publicatie v3.0.1 vs tag 3.0.0 |
+| [Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2) | [v3.3.2](https://gitdocumentatie.logius.nl/publicatie/dk/ebms/) | `3.3.2` | Geen discrepantie (tag komt overeen) |
+| [Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS) | [v3.8.1](https://gitdocumentatie.logius.nl/publicatie/dk/wus/) | `3.8.1` | Geen discrepantie (tag komt overeen) |
+| [Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB) | [v3.8.1](https://gitdocumentatie.logius.nl/publicatie/dk/gb/) | `3.8.1` | Geen discrepantie (tag komt overeen, al zijn er ook sub-releases `3.8.1-2`, `3.8.1-3`) |
+| [Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften) | [v2.0.1](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig/) | `2.0.0` | Tag achter: publicatie v2.0.1 vs tag 2.0.0 |
+| [Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie) | [v1.5.0](https://gitdocumentatie.logius.nl/publicatie/dk/idauth/) | `1.4.2` | Tag achter: publicatie v1.5.0 vs tag 1.4.2 |
+| [OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel) | [v2.2.1](https://gitdocumentatie.logius.nl/publicatie/dk/oin/) | `2.2.0` | Tag achter: publicatie v2.2.1 vs tag 2.2.0 (zie ook [ls-iam conflicts.md](../ls-iam/conflicts.md)) |
+| [Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel) | [v1.8](https://gitdocumentatie.logius.nl/publicatie/dk/beheer/) | `1.6r` | Tag achter: publicatie v1.8 vs tag 1.6r |
+| [Digikoppeling-Gebruik-en-achtergrond-certificaten](https://github.com/logius-standaarden/Digikoppeling-Gebruik-en-achtergrond-certificaten) | [v1.6.3](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert/) | `1.6.2` | Tag achter: publicatie v1.6.3 vs tag 1.6.2 |
+| [Digikoppeling-Best-Practices-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-ebMS2) | [v3.2.2](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms/) | `3.2.1` | Tag achter: publicatie v3.2.2 vs tag 3.2.1 |
+| [Digikoppeling-Overzicht-Actuele-Documentatie-en-Compliance](https://github.com/logius-standaarden/Digikoppeling-Overzicht-Actuele-Documentatie-en-Compliance) | [v1.12.2](https://gitdocumentatie.logius.nl/publicatie/dk/actueel/) | `1.12.0` | Tag achter: publicatie v1.12.2 vs tag 1.12.0 |
+| [Digikoppeling-Best-Practices-GB](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-GB) | [v3.2.0](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb/) | `3.1.1` | Tag achter: publicatie v3.2.0 vs tag 3.1.1. Overige tags: `3.1`, `3.1r`–`3.1r5` |
+| [Digikoppeling-Best-Practices-WUS](https://github.com/logius-standaarden/Digikoppeling-Best-Practices-WUS) | [v1.10.2](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus/) | `1.10.1` | Tag achter: publicatie v1.10.2 vs tag 1.10.1. Overige tags: `1.10`, `1.10r`–`1.10r3`. Let op: anomale tag `3.8` (verkeerd versienummerschema) |
+| [Digikoppeling-Handreiking-Adressering-en-Routering](https://github.com/logius-standaarden/Digikoppeling-Handreiking-Adressering-en-Routering) | [v1.1.0](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres/) | `1.1.0` | Geen discrepantie (tag komt overeen). Overige tags: `1.0`, `1.0.1` |
+| [Digikoppeling-Wat-is-Digikoppeling](https://github.com/logius-standaarden/Digikoppeling-Wat-is-Digikoppeling) | [v1.1.2](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk/) | `1.1.2` | Geen discrepantie (tag komt overeen). Overige tags: `1.1.1`, `1.1.1r`–`1.1.1r4` |
+| [Digikoppeling-Algemeen](https://github.com/logius-standaarden/Digikoppeling-Algemeen) | [v2024-2025](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap/) | _(geen tags)_ | Geen tags aanwezig; publicatie v2024-2025 is niet getagd |
+
+## Overige observaties
+
+- **Malformed tag:** `Digikoppeling-Beveiligingsstandaarden-en-voorschriften` bevat een tag `1,4r` met een komma i.p.v. een punt.
+- **GitHub Releases:** Veel repos hebben een laatste GitHub Release die ouder is dan de laatste Git tag. Releases worden niet consequent aangemaakt.
+
+## Keuze in SKILL.md
+
+De skill gebruikt versienummers van gitdocumentatie.logius.nl als bron van waarheid voor vastgestelde (DEF) versies. GitHub-tags lopen achter maar dat is een beheerproces-kwestie. Als tags worden bijgewerkt, moet dit conflict opnieuw worden beoordeeld.
+
+## Referenties
+
+- Gepubliceerde versies: https://gitdocumentatie.logius.nl/publicatie/dk/
+- GitHub organisatie: https://github.com/logius-standaarden/
+- Forum Standaardisatie: https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling

--- a/skills/ls-dk/reference.md
+++ b/skills/ls-dk/reference.md
@@ -20,7 +20,7 @@ De Digikoppeling-architectuur is gebaseerd op een drielagenmodel dat inhoud, log
 - **API Gateway**: Optionele component voor het ontsluiten van REST-API's. Biedt functionaliteit als rate limiting, caching en API-management.
 - **Message Broker / ESB**: Optionele intermediaire component voor berichtroutering, transformatie en orchestratie. Kan meerdere Digikoppeling-adapters aansturen.
 - **Digikoppeling Adapter**: De kerncomponent die het Digikoppeling-protocol implementeert. Vertaalt interne berichten naar het juiste koppelvlakformaat (ebMS2, WUS, REST-API) en vice versa.
-- **PKIoverheid Certificaten**: TLS-certificaten en optioneel signing/encryptie-certificaten uitgegeven onder de PKIoverheid-hierarchie. Worden gebruikt voor authenticatie, integriteit en vertrouwelijkheid.
+- **PKIoverheid Certificaten**: TLS-certificaten en optioneel signing/encryptie-certificaten uitgegeven onder de PKIoverheid-hiërarchie. Worden gebruikt voor authenticatie, integriteit en vertrouwelijkheid.
 - **Service Contract**: De formele beschrijving van de dienst. Bij WUS is dit een WSDL, bij ebMS2 een CPA (Collaboration Protocol Agreement), bij REST-API een OpenAPI-specificatie.
 
 ### Ontkoppelingsprincipe
@@ -42,7 +42,7 @@ De REST-API koppelvlakstandaard is de nieuwste toevoeging aan Digikoppeling en b
 - **HTTP-methoden**: GET (ophalen), POST (aanmaken), PUT (vervangen), PATCH (wijzigen), DELETE (verwijderen)
 - **Adressering**: RESTful URL-structuur met OIN in het endpoint of header
 - **Beveiliging**: TLS (transport), optioneel OAuth 2.0 voor autorisatie, PKIoverheid-certificaten voor authenticatie
-- **FSC-integratie**: Sinds 1 januari 2025 is het gebruik van Federated Service Connectivity (FSC) verplicht bij Digikoppeling REST-API. FSC verzorgt de federatieve autorisatie en logging van API-aanroepen tussen organisaties.
+- **FSC-integratie**: Het gebruik van Federated Service Connectivity (FSC) is verplicht bij Digikoppeling REST-API (vanaf v3.0.1). FSC verzorgt de federatieve autorisatie en logging van API-aanroepen tussen organisaties.
 
 REST-API is geschikt voor synchrone bevragingen, CRUD-operaties en scenario's waar snelheid en eenvoud belangrijk zijn.
 
@@ -96,7 +96,7 @@ De koppelvlakstandaard Grote Berichten biedt een oplossing voor het uitwisselen 
 #### PULL-variant (ontvanger haalt op bij verzender)
 
 1. Verzender plaatst het grote bestand op een beveiligde HTTP-server
-2. Verzender stuurt een regulier Digikoppeling-bericht (via WUS of ebMS2) met daarin de URL naar het bestand
+2. Verzender stuurt een regulier Digikoppeling-bericht (via REST-API, WUS of ebMS2) met daarin de URL naar het bestand
 3. Ontvanger ontvangt het bericht met de URL (de claim-check)
 4. Ontvanger downloadt het bestand via HTTPS van de opgegeven URL
 5. Bij onderbreking kan de download hervat worden dankzij BYTE-RANGE ondersteuning
@@ -112,7 +112,7 @@ De koppelvlakstandaard Grote Berichten biedt een oplossing voor het uitwisselen 
 
 - **Hervatbaarheid**: HTTP 1.1 BYTE-RANGE ondersteuning maakt het mogelijk om onderbroken transfers te hervatten zonder opnieuw te beginnen
 - **Beveiliging**: TLS voor transport, PKIoverheid-certificaten voor authenticatie, optioneel payload-encryptie
-- **Combinatie**: Grote Berichten is altijd een aanvulling op WUS of ebMS2 -- het reguliere bericht dat de claim-check bevat wordt via een van deze twee protocollen verstuurd
+- **Combinatie**: Grote Berichten is altijd een aanvulling op een ander koppelvlak (REST-API, WUS of ebMS2) -- het reguliere bericht dat de claim-check bevat wordt via een van deze protocollen verstuurd
 - **Geen maximum**: Er is geen bovengrens gedefinieerd voor de bestandsgrootte
 
 ## Beveiliging
@@ -177,7 +177,7 @@ gh api repos/logius-standaarden/Digikoppeling-Architectuur/commits --jq '.[:5] |
 gh api orgs/logius-standaarden/repos --paginate --jq '[.[] | select(.name | startswith("Digikoppeling"))] | sort_by(.name) | .[].name'
 
 # Inhoud van een document
-gh api repos/logius-standaarden/Digikoppeling-Architectuur/contents/ch01_Inleiding.md -H "Accept: application/vnd.github.raw"
+gh api repos/logius-standaarden/Digikoppeling-Architectuur/contents/1_dk_doel_document.md -H "Accept: application/vnd.github.raw"
 
 # Open issues over alle DK repos
 for repo in Digikoppeling-Architectuur Digikoppeling-Koppelvlakstandaard-REST-API Digikoppeling-Koppelvlakstandaard-ebMS2; do
@@ -187,3 +187,13 @@ done
 # OIN stelsel documentatie
 gh api repos/logius-standaarden/OIN-Stelsel/contents --jq '.[].name'
 ```
+
+## Gerelateerde Skills
+
+| Skill | Relatie |
+|-------|---------|
+| `/ls-fsc` | FSC is verplicht bij Digikoppeling REST-API (v3.0.1+) |
+| `/ls-iam` | OIN-Stelsel wordt gedeeld met IAM; OAuth/OIDC voor REST-API autorisatie |
+| `/ls-api` | REST-API koppelvlak is gebaseerd op de API Design Rules |
+| `/ls-pub` | ReSpec tooling voor Digikoppeling documentatie |
+| `/ls` | Overzicht alle standaarden |

--- a/skills/ls-egov/SKILL.md
+++ b/skills/ls-egov/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-egov
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'Terugmelding', 'Terugmelden', 'Digimelding', 'basisfactuur', 'basisorder', 'e-procurement', 'inkoopstandaarden overheid', 'factuurstandaard', 'PEPPOLBIS', 'elektronisch bestellen'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'Terugmelding', 'Terugmelden', 'Digimelding', 'basisfactuur', 'basisorder', 'e-procurement', 'inkoopstandaarden overheid', 'factuurstandaard', 'NLCIUS', 'Peppol BIS', 'PEPPOLBIS', 'elektronisch bestellen'."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -13,33 +13,37 @@ allowed-tools:
 
 # E-Government Services
 
-**Agent-instructie:** Deze skill helpt bij het implementeren van terugmeldingen op basisregistraties en e-facturatie voor de Rijksoverheid. Gebruik de Terugmelden-API (OpenAPI 3.1.0) voor meldingen. Basisfactuur Rijk volgt Peppol BIS 3 / NLCIUS.
+**Agent-instructie:** Deze skill helpt bij het implementeren van terugmeldingen op basisregistraties en e-facturatie voor de Rijksoverheid. Gebruik de Digimelding-Koppelvlakspecificatie voor meldingen. Basisfactuur Rijk volgt Peppol BIS 3 / NLCIUS.
 
 De E-Government standaarden omvatten diensten voor terugmelding op basisregistraties, Digimelding, en e-procurement (elektronisch bestellen en factureren) voor de Nederlandse overheid. Deze standaarden worden beheerd door Logius en vormen een essentieel onderdeel van de digitale overheidsdienstverlening.
 
+## Versiemodel
+
+Net als andere Logius-standaarden kennen deze standaarden twee publicatiekanalen (vergelijkbaar met W3C):
+
+- **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
+
+De E-Government standaarden hebben momenteel **alleen werkversies**. Er zijn nog geen vastgestelde versies gepubliceerd.
+
 ## Repositories
 
-| Repository | Beschrijving | Publicatie |
-|-----------|-------------|-----------|
-| [Terugmelding](https://github.com/logius-standaarden/Terugmelding) | Standaard voor terugmelden op basisregistraties | [Lees online](https://logius-standaarden.github.io/Terugmelding/) |
-| [Terugmelden-API](https://github.com/logius-standaarden/Terugmelden-API) | REST API specificatie (OpenAPI 3.1.0) voor terugmelden | [Lees online](https://logius-standaarden.github.io/Terugmelden-API/) |
-| [Digimelding-Koppelvlakspecificatie](https://github.com/logius-standaarden/Digimelding-Koppelvlakspecificatie) | Koppelvlakspecificatie voor Digimelding | [Lees online](https://logius-standaarden.github.io/Digimelding-Koppelvlakspecificatie/) |
-| [basisfactuur-rijk](https://github.com/logius-standaarden/basisfactuur-rijk) | Standaard basisfactuur voor de Rijksoverheid | [Lees online](https://logius-standaarden.github.io/basisfactuur-rijk/) |
-| [basisorder-rijk](https://github.com/logius-standaarden/basisorder-rijk) | Standaard basisorder voor de Rijksoverheid | [Lees online](https://logius-standaarden.github.io/basisorder-rijk/) |
-| [e-procurement](https://github.com/logius-standaarden/e-procurement) | Overkoepelende e-procurement standaarden | [Lees online](https://logius-standaarden.github.io/e-procurement/) |
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [Terugmelding](https://github.com/logius-standaarden/Terugmelding) | Standaard voor terugmelden op basisregistraties | - | [Draft](https://logius-standaarden.github.io/Terugmelding/) |
+| [Terugmelden-API](https://github.com/logius-standaarden/Terugmelden-API) | Werkrepository voor een toekomstige REST API koppelvlakspecificatie voor terugmelden (nog geen specificatie beschikbaar) | - | - |
+| [Digimelding-Koppelvlakspecificatie](https://github.com/logius-standaarden/Digimelding-Koppelvlakspecificatie) | Koppelvlakspecificatie voor Digimelding | - | [Draft](https://logius-standaarden.github.io/Digimelding-Koppelvlakspecificatie/) |
+| [basisfactuur-rijk](https://github.com/logius-standaarden/basisfactuur-rijk) | Handreiking basisfactuur voor de Rijksoverheid | - | [Draft](https://logius-standaarden.github.io/basisfactuur-rijk/) |
+| [basisorder-rijk](https://github.com/logius-standaarden/basisorder-rijk) | Handreiking basisorder voor de Rijksoverheid | - | [Draft](https://logius-standaarden.github.io/basisorder-rijk/) |
+| [e-procurement](https://github.com/logius-standaarden/e-procurement) | Overkoepelende e-procurement standaarden | - | [Draft](https://logius-standaarden.github.io/e-procurement/) |
 
 ---
 
-## Terugmelden-API
+## Terugmelden-API (in ontwikkeling)
 
-De Terugmelden-API is een REST API gespecificeerd in **OpenAPI 3.1.0**. Deze API is gebaseerd op de Digimelding-functionaliteit en biedt een moderne interface voor het indienen en opvragen van terugmeldingen.
+De Terugmelden-API is een **beoogde** REST API voor het indienen en opvragen van terugmeldingen. De repository bevat nog geen uitgewerkte specificatie; de API is in conceptfase. De bestaande koppelvlakspecificatie voor terugmelden is de Digimelding-Koppelvlakspecificatie (SOAP/WUS).
 
-Kenmerken van de API:
-
-- RESTful architectuur conform de API Design Rules (ADR)
-- JSON-gebaseerde request/response berichten
-- OpenAPI 3.1.0 specificatie voor machineleesbare documentatie
-- Ondersteuning voor het aanmaken, opvragen en bijwerken van terugmeldingen
+> **Let op:** De onderstaande implementatievoorbeelden voor de REST API zijn **conceptueel/illustratief** en tonen hoe een toekomstige REST API eruit zou kunnen zien. Ze zijn niet gebaseerd op een gepubliceerde OpenAPI-specificatie.
 
 ---
 
@@ -101,6 +105,8 @@ E-Procurement (overkoepelend)
     └── UBL 2.1 Order
 ```
 
+**Forum Standaardisatie status:** NLCIUS is **verplicht** (['pas-toe-of-leg-uit'](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)). Peppol BIS is [**aanbevolen**](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis), niet verplicht. De overige e-government standaarden (Digimelding, Terugmelding, e-procurement) staan niet op de lijst.
+
 ---
 
 ## Implementatievoorbeelden
@@ -159,7 +165,7 @@ curl -X GET https://digimelding.example.com/api/v1/terugmeldingen/550e8400-e29b-
 import requests
 
 class DigimeldingClient:
-    """Client voor de Terugmelden-API (OpenAPI 3.1.0)."""
+    """Client voor de Terugmelden-API (conceptueel)."""
 
     def __init__(self, base_url: str, token: str):
         self.base_url = base_url
@@ -360,3 +366,4 @@ Bij afwijzing ontvangt de leverancier een e-mail met de specifieke ontbrekende v
 ## Achtergrondinfo
 
 Zie [reference.md](reference.md) voor kernbegrippen, annotatie-framework, best practices leveranciers, en e-procurement details.
+Zie [conflicts.md](conflicts.md) voor bronconflicten en gemaakte keuzes.

--- a/skills/ls-egov/conflicts.md
+++ b/skills/ls-egov/conflicts.md
@@ -1,0 +1,43 @@
+# E-Government - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties en bewuste keuzes voor de E-Government-skill.
+
+## GitHub-tags vs. gepubliceerde versies
+
+Alle E-Government repositories beheerd door Logius hebben alleen werkversies. Er zijn geen vastgestelde (DEF) versies en geen GitHub-tags.
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [Terugmelding](https://github.com/logius-standaarden/Terugmelding) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [Terugmelden-API](https://github.com/logius-standaarden/Terugmelden-API) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [Digimelding-Koppelvlakspecificatie](https://github.com/logius-standaarden/Digimelding-Koppelvlakspecificatie) | _(geen DEF)_ | `1.3` | N.v.t. — alleen werkversies |
+| [basisfactuur-rijk](https://github.com/logius-standaarden/basisfactuur-rijk) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [basisorder-rijk](https://github.com/logius-standaarden/basisorder-rijk) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [e-procurement](https://github.com/logius-standaarden/e-procurement) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+
+## Forum Standaardisatie: externe standaarden
+
+De volgende standaarden worden op het Forum Standaardisatie vermeld in de context van e-government, maar worden **niet door Logius beheerd**. Ze verschijnen daarom niet als Logius-repositories in de SKILL.md repo-tabel:
+
+| Standaard | Forum-versie | Beheerder |
+|-----------|-------------|-----------|
+| [NLCIUS](https://www.forumstandaardisatie.nl/open-standaarden/nlcius) | v1.03 | SIMPLERINVOICING (extern) |
+| [Peppol BIS](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis) | v3.08 | OpenPeppol (extern) |
+
+### Analyse
+
+De SKILL.md vermeldt NLCIUS en Peppol BIS als Forum-standaarden met hun status (verplicht), maar neemt ze niet op als Logius-repositories. Dit is correct: Logius beheert de Terugmeld- en Digimelding-standaarden, niet de e-procurement standaarden.
+
+## Keuze in SKILL.md
+
+De skill vermeldt correct dat Logius-repositories alleen werkversies hebben. NLCIUS en Peppol BIS worden vermeld vanwege hun Forum Standaardisatie-status, maar niet als Logius-repositories. Als er DEF-versies worden vastgesteld voor de Terugmeld-repositories, moet dit document worden bijgewerkt.
+
+## Referenties
+
+- GitHub Terugmelding: https://github.com/logius-standaarden/Terugmelding
+- GitHub Terugmelden-API: https://github.com/logius-standaarden/Terugmelden-API
+- Forum Standaardisatie Digikoppeling (Digimelding valt hieronder): https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling
+- Forum Standaardisatie NLCIUS: https://www.forumstandaardisatie.nl/open-standaarden/nlcius
+- Forum Standaardisatie Peppol BIS: https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis

--- a/skills/ls-fsc/SKILL.md
+++ b/skills/ls-fsc/SKILL.md
@@ -13,19 +13,30 @@ allowed-tools:
 
 # Federated Service Connectivity (FSC)
 
-**Agent-instructie:** Deze skill helpt bij het implementeren van FSC (Federated Service Connectivity) voor federatieve dienstverlening. FSC gebruikt mTLS, OAuth 2.0 client_credentials en cryptografisch ondertekende contracten. Sinds 1/1/2025 verplicht bij Digikoppeling REST-API.
+**Agent-instructie:** Deze skill helpt bij het implementeren van FSC (Federated Service Connectivity) voor federatieve dienstverlening. FSC gebruikt mTLS, OAuth 2.0 client_credentials en cryptografisch ondertekende contracten. Vereist bij Digikoppeling REST-API (v3.0.1+); geen afzonderlijke vermelding op het Forum Standaardisatie.
+
+## Versiemodel
+
+Net als andere Logius-standaarden kent FSC twee publicatiekanalen (vergelijkbaar met W3C):
+
+- **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
+
+FSC heeft **vastgestelde versies** voor fsc-core en fsc-logging. De overige modules hebben alleen werkversies; fsc-external-contract heeft een consultatieversie (CV). Modulestatus hangt samen met de core-specificatie maar wordt apart vastgesteld.
 
 ## Repositories
 
-| Repository | Beschrijving | Publicatie |
-|-----------|-------------|-----------|
-| [fsc-core](https://github.com/logius-standaarden/fsc-core) | Core specificatie: architectuur, protocol, componenten | [Lees online](https://logius-standaarden.github.io/fsc-core/) |
-| [fsc-logging](https://github.com/logius-standaarden/fsc-logging) | Logging specificatie voor FSC transacties | [Lees online](https://logius-standaarden.github.io/fsc-logging/) |
-| [fsc-properties](https://github.com/logius-standaarden/fsc-properties) | Metadata-properties voor FSC services | [Lees online](https://logius-standaarden.github.io/fsc-properties/) |
-| [fsc-regulated-area](https://github.com/logius-standaarden/fsc-regulated-area) | Regulated Area specificatie (governance zones) | [Lees online](https://logius-standaarden.github.io/fsc-regulated-area/) |
-| [fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract) | External Contract specificatie (afspraken tussen partijen) | [Lees online](https://logius-standaarden.github.io/fsc-external-contract/) |
-| [fsc-extensie-template](https://github.com/logius-standaarden/fsc-extensie-template) | Template voor FSC extensies | [Lees online](https://logius-standaarden.github.io/fsc-extensie-template/) |
-| [fsc-test-suite](https://github.com/logius-standaarden/fsc-test-suite) | Integratietests en componenttests | - |
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [fsc-core](https://github.com/logius-standaarden/fsc-core) | Core specificatie: architectuur, protocol, componenten | [v1.1.2](https://gitdocumentatie.logius.nl/publicatie/fsc/core/) | [Draft](https://logius-standaarden.github.io/fsc-core/) |
+| [fsc-logging](https://github.com/logius-standaarden/fsc-logging) | Module: logging specificatie voor FSC transacties | [v1.0.0](https://gitdocumentatie.logius.nl/publicatie/fsc/logging/) | [Draft](https://logius-standaarden.github.io/fsc-logging/) |
+| [fsc-properties](https://github.com/logius-standaarden/fsc-properties) | Module: metadata-properties voor FSC services | - | [Draft](https://logius-standaarden.github.io/fsc-properties/) |
+| [fsc-regulated-area](https://github.com/logius-standaarden/fsc-regulated-area) | Module: Regulated Area specificatie (governance zones) | - | [Draft](https://logius-standaarden.github.io/fsc-regulated-area/) |
+| [fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract) | Module: External Contract specificatie (afspraken tussen partijen) | [CV v1.0.0](https://gitdocumentatie.logius.nl/publicatie/fsc/ext/)¹ | [Draft](https://logius-standaarden.github.io/fsc-external-contract/) |
+| [fsc-extensie-template](https://github.com/logius-standaarden/fsc-extensie-template) | Richtlijn voor nieuwe FSC extensies | - | [Draft](https://logius-standaarden.github.io/fsc-extensie-template/) |
+| [fsc-test-suite](https://github.com/logius-standaarden/fsc-test-suite) | Integratietests en componenttests | - | - |
+
+¹ CV = consultatieversie, nog niet definitief vastgesteld.
 
 ## Service Connectivity Flow
 
@@ -82,7 +93,7 @@ De Inway van de provider:
 
 1. Extraheert het JWT uit de `Fsc-Authorization` header
 2. Valideert de handtekening van het token
-3. Controleert de claims (`aud`, `svc`, `gth`, `cnf`)
+3. Controleert de claims (`aud`, `svc`, `gth`, `gid`, `cnf`)
 4. Verifieert dat het certificaat van de verbinding overeenkomt met de `cnf` thumbprint
 5. Stuurt het verzoek door naar de achterliggende service
 6. Retourneert de response aan de Outway
@@ -139,12 +150,12 @@ Het access token is een JSON Web Token (JWT) dat wordt uitgegeven door de Manage
 | `sub` | Subject: het PeerID van de consumer die de service afneemt |
 | `iss` | Issuer: het PeerID van de provider die het token uitgeeft |
 | `svc` | Service: de naam van de service waarvoor het token geldig is |
-| `aud` | Audience: het PeerID van de provider (ontvanger van het token) |
+| `aud` | Audience: de URL van de Inway van de provider |
 | `gth` | Grant Hash: de hash van het specifieke grant in het contract |
-| `gid` | Grant ID: identifier van het grant binnen het contract |
+| `gid` | Group ID: identifier van de Group waarbinnen het token geldig is |
 | `cnf` | Confirmation: object met `x5t#S256` (SHA-256 thumbprint van het client-certificaat) |
 | `exp` | Expiration: verloopdatum van het token |
-| `iat` | Issued At: tijdstip van uitgifte |
+| `nbf` | Not Before: tijdstip vanaf wanneer het token geldig is |
 
 De `cnf` claim bindt het token aan het specifieke certificaat van de consumer, waardoor token-diefstal wordt voorkomen (certificate-bound tokens).
 
@@ -153,14 +164,14 @@ De `cnf` claim bindt het token aan het specifieke certificaat van de consumer, w
   "sub": "PeerID-consumer",
   "iss": "PeerID-provider",
   "svc": "mijn-service",
-  "aud": "PeerID-provider",
+  "aud": "https://inway.provider.example.nl",
   "gth": "sha256-hash-van-grant",
-  "gid": "grant-identifier",
+  "gid": "nl-overheid-productie",
   "cnf": {
     "x5t#S256": "sha256-thumbprint-van-client-certificaat"
   },
   "exp": 1735689600,
-  "iat": 1735686000
+  "nbf": 1735686000
 }
 ```
 
@@ -305,7 +316,7 @@ async def proxy_request(service_name: str, path: str, request: Request):
         url=f"{inway_url}/{service_name}/{path}",
         headers={
             "Fsc-Authorization": f"Bearer {access_token}",
-            "Fsc-Transaction-Id": str(uuid.uuid4()),  # UUID V7 per request
+            "Fsc-Transaction-Id": str(uuid.uuid4()),  # Uniek per request
             **{k: v for k, v in request.headers.items()
                if k.lower() not in ("host", "fsc-authorization")},
         },
@@ -430,21 +441,21 @@ curl -s "https://directory.example.com:8443/services?name=brp-bevraging" \
 
 | HTTP Status | Fsc-Error-Code | Beschrijving | Actie |
 |------------|---------------|-------------|-------|
-| 401 | `ACCESS_TOKEN_MISSING` | Geen Fsc-Authorization header | Voeg token toe via Outway |
-| 401 | `ACCESS_TOKEN_INVALID` | Token handtekening ongeldig | Nieuw token ophalen |
-| 401 | `ACCESS_TOKEN_EXPIRED` | Token verlopen | Nieuw token ophalen |
-| 403 | `WRONG_GROUP_ID_IN_TOKEN` | Group ID in token matcht niet | Controleer groepsconfiguratie |
-| 404 | `SERVICE_NOT_FOUND` | Service niet geregistreerd | Controleer servicenaam in contract |
-| 500 | `TRANSACTION_LOG_WRITE_ERROR` | Transactielog schrijven mislukt | Probeer later opnieuw |
-| 502 | `SERVICE_UNREACHABLE` | Achterliggende service onbereikbaar | Probeer later opnieuw |
+| 401 | `ERROR_CODE_ACCESS_TOKEN_MISSING` | Geen Fsc-Authorization header | Voeg token toe via Outway |
+| 401 | `ERROR_CODE_ACCESS_TOKEN_INVALID` | Token handtekening ongeldig | Nieuw token ophalen |
+| 401 | `ERROR_CODE_ACCESS_TOKEN_EXPIRED` | Token verlopen | Nieuw token ophalen |
+| 403 | `ERROR_CODE_WRONG_GROUP_ID_IN_TOKEN` | Group ID in token matcht niet | Controleer groepsconfiguratie |
+| 404 | `ERROR_CODE_SERVICE_NOT_FOUND` | Service niet geregistreerd | Controleer servicenaam in contract |
+| 500 | `ERROR_CODE_TRANSACTION_LOG_WRITE_ERROR` | Transactielog schrijven mislukt | Probeer later opnieuw |
+| 502 | `ERROR_CODE_SERVICE_UNREACHABLE` | Achterliggende service onbereikbaar | Probeer later opnieuw |
 
 ### Error Response Formaat
 
 ```json
 {
-  "code": "ACCESS_TOKEN_EXPIRED",
-  "domain": "inway",
-  "details": "Token expired at 2024-01-15T10:30:00Z"
+  "code": "ERROR_CODE_ACCESS_TOKEN_EXPIRED",
+  "domain": "ERROR_DOMAIN_INWAY",
+  "message": "Token expired at 2024-01-15T10:30:00Z"
 }
 ```
 
@@ -454,38 +465,12 @@ De `Fsc-Error-Code` header wordt altijd meegegeven bij foutresponses, naast de H
 
 | HTTP Status | Fsc-Error-Code | Beschrijving |
 |------------|---------------|-------------|
-| 405 | `METHOD_UNSUPPORTED` | CONNECT methode niet ondersteund |
+| 405 | `ERROR_CODE_METHOD_UNSUPPORTED` | CONNECT methode niet ondersteund |
 
 ### Retry Strategie
 
-```python
-import time
-
-def call_service_via_fsc(service_name: str, path: str, max_retries: int = 3):
-    """Roep een FSC service aan met retry bij tijdelijke fouten."""
-    for attempt in range(max_retries):
-        response = outway.proxy_request(service_name, path)
-
-        error_code = response.headers.get("Fsc-Error-Code")
-        if not error_code:
-            return response  # Succes of applicatie-error
-
-        if error_code in ("ACCESS_TOKEN_EXPIRED", "ACCESS_TOKEN_INVALID"):
-            # Token vernieuwen en opnieuw proberen
-            token_cache.pop(service_name, None)
-            continue
-
-        if error_code in ("SERVICE_UNREACHABLE", "TRANSACTION_LOG_WRITE_ERROR"):
-            # Tijdelijke fout - exponential backoff
-            time.sleep(min(2 ** attempt * 5, 60))
-            continue
-
-        # Permanente fouten niet opnieuw proberen
-        break
-
-    return response
-```
+Zie [reference.md](reference.md) voor een Python implementatie van een retry-strategie met exponential backoff die onderscheid maakt tussen token-fouten (vernieuwen en opnieuw proberen), tijdelijke fouten (backoff) en permanente fouten (direct stoppen).
 
 ## Achtergrondinfo
 
-Zie [reference.md](reference.md) voor de componentarchitectuur, trust model, en gedetailleerde protocoldocumentatie.
+Zie [reference.md](reference.md) voor componentarchitectuur, trust model, retry-strategie code, en protocoldocumentatie. Zie [conflicts.md](conflicts.md) voor bekende discrepanties tussen GitHub-tags en gepubliceerde versies.

--- a/skills/ls-fsc/conflicts.md
+++ b/skills/ls-fsc/conflicts.md
@@ -1,0 +1,49 @@
+# FSC - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties tussen GitHub-repository tags en de gepubliceerde versies op [gitdocumentatie.logius.nl](https://gitdocumentatie.logius.nl). De **gepubliceerde versie op gitdocumentatie.logius.nl is leidend** voor DEF-versies.
+
+## Discrepanties
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [fsc-core](https://github.com/logius-standaarden/fsc-core) | [v1.1.2](https://gitdocumentatie.logius.nl/publicatie/fsc/core/) | `1.1.0-rc` | Tag ver achter: publicatie v1.1.2 vs tag 1.1.0-rc (release candidate) |
+| [fsc-logging](https://github.com/logius-standaarden/fsc-logging) | [v1.0.0](https://gitdocumentatie.logius.nl/publicatie/fsc/logging/) | _(geen tags)_ | Geen tags: publicatie v1.0.0 bestaat maar de repo heeft nul Git-tags |
+| [fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract) | [CV v1.0.0](https://gitdocumentatie.logius.nl/publicatie/fsc/ext/) | _(geen tags)_ | Geen tags: publicatie CV v1.0.0 bestaat maar de repo heeft nul Git-tags |
+
+### Details fsc-core
+
+- **Enige tag:** `1.1.0-rc` (gepubliceerd als GitHub Release op 2025-08-07)
+- De tag is een **release candidate** (`-rc`), terwijl de gepubliceerde versie `v1.1.2` al twee patchversies verder is
+- Er zijn geen tags voor `1.1.0`, `1.1.1` of `1.1.2`
+- Dit wijst erop dat het volledige release-proces (v1.1.0 -> v1.1.1 -> v1.1.2) heeft plaatsgevonden zonder nieuwe Git-tags
+
+### Details fsc-logging
+
+- De repository heeft **nul Git-tags** en **nul GitHub Releases**
+- Desondanks bestaat er een gepubliceerde versie [v1.0.0 op gitdocumentatie](https://gitdocumentatie.logius.nl/publicatie/fsc/logging/)
+- Het publicatieproces heeft hier volledig buiten Git-tagging om plaatsgevonden
+
+### Details fsc-external-contract
+
+- De repository heeft **nul Git-tags** en **nul GitHub Releases**
+- Op gitdocumentatie bestaat een gepubliceerde versie [CV v1.0.0](https://gitdocumentatie.logius.nl/publicatie/fsc/ext/)
+- **Let op:** Dit is een **CV** (Consultatieversie), geen DEF-versie — het document is nog niet definitief vastgesteld
+- Het publicatieproces heeft hier volledig buiten Git-tagging om plaatsgevonden
+
+## Keuze in SKILL.md
+
+De skill gebruikt versienummers van gitdocumentatie.logius.nl als bron van waarheid voor vastgestelde (DEF) versies. De GitHub-tags lopen significant achter (fsc-core) of ontbreken geheel (fsc-logging, fsc-external-contract). Als tags worden bijgewerkt of aangemaakt, moet dit conflict opnieuw worden beoordeeld.
+
+## Referenties
+
+- Publicatie fsc-core: https://gitdocumentatie.logius.nl/publicatie/fsc/core/
+- Publicatie fsc-logging: https://gitdocumentatie.logius.nl/publicatie/fsc/logging/
+- GitHub fsc-core: https://github.com/logius-standaarden/fsc-core
+- GitHub fsc-core tags: https://github.com/logius-standaarden/fsc-core/tags
+- GitHub fsc-logging: https://github.com/logius-standaarden/fsc-logging
+- GitHub fsc-logging tags: https://github.com/logius-standaarden/fsc-logging/tags
+- Publicatie fsc-external-contract: https://gitdocumentatie.logius.nl/publicatie/fsc/ext/
+- GitHub fsc-external-contract: https://github.com/logius-standaarden/fsc-external-contract
+- GitHub fsc-external-contract tags: https://github.com/logius-standaarden/fsc-external-contract/tags

--- a/skills/ls-fsc/reference.md
+++ b/skills/ls-fsc/reference.md
@@ -8,7 +8,7 @@ FSC kent een componentmodel waarin organisaties (Peers) via proxies en managers 
 
 ### Peer
 
-Een **Peer** is een actor (organisatie) die deelneemt aan het FSC-netwerk. Een Peer kan services aanbieden (provider) en/of afnemen (consumer). Elke Peer wordt uniek geidentificeerd door een **PeerID**, afgeleid uit het subject van het X.509-certificaat dat de Peer gebruikt voor mTLS-verbindingen.
+Een **Peer** is een actor (organisatie) die deelneemt aan het FSC-netwerk. Een Peer kan services aanbieden (provider) en/of afnemen (consumer). Elke Peer wordt uniek geïdentificeerd door een **PeerID**, afgeleid uit het subject van het X.509-certificaat dat de Peer gebruikt voor mTLS-verbindingen.
 
 ### Group
 
@@ -121,6 +121,36 @@ curl -s --cert client.pem --key client-key.pem --cacert ca.pem \
 # Services opvragen bij Directory
 curl -s --cert client.pem --key client-key.pem --cacert ca.pem \
   https://directory.example.nl:8443/services | jq .
+```
+
+## Retry Strategie
+
+```python
+import time
+
+def call_service_via_fsc(service_name: str, path: str, max_retries: int = 3):
+    """Roep een FSC service aan met retry bij tijdelijke fouten."""
+    for attempt in range(max_retries):
+        response = outway.proxy_request(service_name, path)
+
+        error_code = response.headers.get("Fsc-Error-Code")
+        if not error_code:
+            return response  # Succes of applicatie-error
+
+        if error_code in ("ERROR_CODE_ACCESS_TOKEN_EXPIRED", "ERROR_CODE_ACCESS_TOKEN_INVALID"):
+            # Token vernieuwen en opnieuw proberen
+            token_cache.pop(service_name, None)
+            continue
+
+        if error_code in ("ERROR_CODE_SERVICE_UNREACHABLE", "ERROR_CODE_TRANSACTION_LOG_WRITE_ERROR"):
+            # Tijdelijke fout - exponential backoff
+            time.sleep(min(2 ** attempt * 5, 60))
+            continue
+
+        # Permanente fouten niet opnieuw proberen
+        break
+
+    return response
 ```
 
 ## Gerelateerde Skills

--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -13,22 +13,35 @@ allowed-tools:
 
 # Identity & Access Management (IAM)
 
-**Agent-instructie:** Deze skill helpt bij het implementeren van authenticatie en autorisatie voor overheids-APIs. Gebruik de OAuth 2.0 NL en OIDC NL GOV profielen voor nieuwe implementaties. AuthZEN voor geexternaliseerde autorisatie.
+**Agent-instructie:** Deze skill helpt bij het implementeren van authenticatie en autorisatie voor overheids-APIs. Gebruik de OAuth 2.0 NL en OIDC NL GOV profielen voor nieuwe implementaties. AuthZEN voor geëxternaliseerde autorisatie.
 
 De IAM-standaarden van Logius definiëren profielen voor authenticatie en autorisatie bij Nederlandse overheids-APIs. Dit omvat OAuth 2.0, OpenID Connect, AuthZEN en aanvullende profielen specifiek voor de Nederlandse overheid. Deze standaarden waarborgen een consistent en veilig identiteits- en toegangsbeheer binnen het publieke domein.
 
+## Versiemodel
+
+Net als andere Logius-standaarden kennen deze standaarden twee publicatiekanalen (vergelijkbaar met W3C):
+
+- **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
+
+De IAM-standaarden OAuth-NL-profiel, OIDC-NLGOV en OIN-Stelsel hebben **vastgestelde versies** op gitdocumentatie.logius.nl. OAuth-Beheermodel heeft eveneens een vastgestelde versie maar is **gearchiveerd**. De overige standaarden (AuthZEN, Authorization Decision Log, OAuth-Inleiding) hebben momenteel alleen werkversies.
+
+OpenID.NLGov (v1.0.1) en SAML zijn beide **verplicht** als onderdeel van de gecombineerde vermelding ["Authenticatie-standaarden (OpenID.NLGov en SAML)"](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden) op het Forum Standaardisatie (sinds 21-09-2023). Voor **nieuwe implementaties** wordt OIDC NL GOV aanbevolen; bestaande SAML-koppelingen blijven ondersteund.
+
+Op het Forum Standaardisatie staat het OAuth-NL-profiel **v1.0** als verplicht (['pas-toe-of-leg-uit'](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)). Versie v1.1.0 is vastgesteld door Logius (DEF) maar is op het Forum [in procedure genomen](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11) (intake goedgekeurd 24-09-2025, verkort expertonderzoek loopt).
+
 ## Repositories
 
-| Repository | Beschrijving | Publicatie |
-|-----------|-------------|-----------|
-| [OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel) | Nederlands profiel voor OAuth 2.0 | [Lees online](https://logius-standaarden.github.io/OAuth-NL-profiel/) |
-| [OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV) | OpenID Connect profiel voor NL overheid | [Lees online](https://logius-standaarden.github.io/OIDC-NLGOV/) |
-| [OAuth-Inleiding](https://github.com/logius-standaarden/OAuth-Inleiding) | Introductie en achtergrond OAuth | [Lees online](https://logius-standaarden.github.io/OAuth-Inleiding/) |
-| [OAuth-Beheermodel](https://github.com/logius-standaarden/OAuth-Beheermodel) | Beheermodel voor OAuth standaarden | [Lees online](https://logius-standaarden.github.io/OAuth-Beheermodel/) |
-| [authzen-nlgov](https://github.com/logius-standaarden/authzen-nlgov) | AuthZEN NL GOV profiel (autorisatiebeslissingen) | [Lees online](https://logius-standaarden.github.io/authzen-nlgov/) |
-| [authorization-decision-log](https://github.com/logius-standaarden/authorization-decision-log) | Logging van autorisatiebeslissingen | [Lees online](https://logius-standaarden.github.io/authorization-decision-log/) |
-| [st-saml-spec](https://github.com/logius-standaarden/st-saml-spec) | SAML specificatie voor NL overheid | [Lees online](https://logius-standaarden.github.io/st-saml-spec/) |
-| [OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel) | Organisatie Identificatie Nummer (ook in `/ls-dk`) | [Lees online](https://logius-standaarden.github.io/OIN-Stelsel/) |
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel) | Nederlands profiel voor OAuth 2.0 | [v1.1.0](https://gitdocumentatie.logius.nl/publicatie/api/oauth/) | [Draft](https://logius-standaarden.github.io/OAuth-NL-profiel/) |
+| [OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV) | OpenID Connect profiel voor NL overheid | [v1.0.1](https://gitdocumentatie.logius.nl/publicatie/api/oidc/) | [Draft](https://logius-standaarden.github.io/OIDC-NLGOV/) |
+| [OAuth-Inleiding](https://github.com/logius-standaarden/OAuth-Inleiding) | Introductie en achtergrond OAuth | - | [Draft](https://logius-standaarden.github.io/OAuth-Inleiding/) |
+| [OAuth-Beheermodel](https://github.com/logius-standaarden/OAuth-Beheermodel) | Beheermodel voor OAuth standaarden — **gearchiveerd** | [v1.0](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer/) | - |
+| [authzen-nlgov](https://github.com/logius-standaarden/authzen-nlgov) | AuthZEN NL GOV profiel (autorisatiebeslissingen) | - | [Draft](https://logius-standaarden.github.io/authzen-nlgov/) |
+| [authorization-decision-log](https://github.com/logius-standaarden/authorization-decision-log) | Logging van autorisatiebeslissingen | - | [Draft](https://logius-standaarden.github.io/authorization-decision-log/) |
+| [st-saml-spec](https://github.com/logius-standaarden/st-saml-spec) | SAML specificatie — onderdeel van verplichte "Authenticatie-standaarden"; voor nieuwe implementaties wordt OIDC aanbevolen | - | [Draft](https://logius-standaarden.github.io/st-saml-spec/) |
+| [OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel) | Organisatie Identificatie Nummer (ook in `/ls-dk`) | [v2.2.1](https://gitdocumentatie.logius.nl/publicatie/dk/oin/) | [Draft](https://logius-standaarden.github.io/OIN-Stelsel/) |
 
 ---
 
@@ -434,4 +447,4 @@ curl -X POST https://auth.example.com/introspect \
 
 ## Achtergrondinfo
 
-Zie [reference.md](reference.md) voor SAML legacy info, OIN-stelsel, en gedetailleerde protocoldocumentatie.
+Zie [reference.md](reference.md) voor SAML-details, OIN-stelsel, en gedetailleerde protocoldocumentatie. Zie [conflicts.md](conflicts.md) voor bekende bronconflicten (GitHub-tags vs. publicatie, Forum Standaardisatie tegenstrijdigheden).

--- a/skills/ls-iam/conflicts.md
+++ b/skills/ls-iam/conflicts.md
@@ -1,0 +1,82 @@
+# IAM - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties in bronnen die relevant zijn voor de IAM-skill.
+
+---
+
+## 1. GitHub-tag vs. gepubliceerde versie: OIN-Stelsel
+
+De **gepubliceerde versie op gitdocumentatie.logius.nl is leidend** voor DEF-versies.
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel) | [v2.2.1](https://gitdocumentatie.logius.nl/publicatie/dk/oin/) | `2.2.0` | Tag achter: publicatie v2.2.1 vs tag 2.2.0 |
+
+### Details OIN-Stelsel
+
+- **Bekende tags:** `2.2.0`, `2.0.3`, `2.0.2`, `2.0.2r`, `2.0.1`
+- **Laatste GitHub Release:** `2.0.3` (gepubliceerd 2022-11-29) — ver achter op de laatste tag `2.2.0`
+- De tag `2.2.0` bestaat, maar de gepubliceerde versie op gitdocumentatie is `v2.2.1` — één patchversie verder
+- Er is geen tag `2.2.1` in de repository
+
+**Let op:** OIN-Stelsel wordt ook gerefereerd vanuit `/ls-dk` (Digikoppeling). Dezelfde discrepantie is gedocumenteerd in [ls-dk/conflicts.md](../ls-dk/conflicts.md).
+
+---
+
+## 1b. GitHub-tags vs. gepubliceerde versies: OAuth-NL, OIDC-NLGOV en OAuth-Beheermodel
+
+Voor compleetheid worden hier ook de IAM-repositories vermeld waar tags en publicatieversies wél overeenkomen, en het gearchiveerde OAuth-Beheermodel.
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel) | [v1.1.0](https://gitdocumentatie.logius.nl/publicatie/api/oauth/) | `v1.1.0` | Geen discrepantie (tag komt overeen). Alle tags: `v1.1.0`, `v1.1.0-rc.2`, `v1.1.0-rc.1`, `v1.0`, `1.0r`, `1.0r2` |
+| [OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV) | [v1.0.1](https://gitdocumentatie.logius.nl/publicatie/api/oidc/) | `v1.0.1` | Geen discrepantie (tag komt overeen) |
+| [OAuth-Beheermodel](https://github.com/logius-standaarden/OAuth-Beheermodel) | [v1.0](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer/) | `0.2` | Tag-formaat afwijkend: publicatie v1.0 vs tag `0.2` |
+
+### Details OAuth-Beheermodel
+
+- **Enige tag:** `0.2`
+- De repository is **gearchiveerd**
+- De gepubliceerde DEF-versie op gitdocumentatie is `v1.0`
+- De tag `0.2` is een conceptversie; de definitieve versie v1.0 is gepubliceerd zonder bijbehorende Git-tag
+
+---
+
+## 2. Forum Standaardisatie bronconflict: OAuth v1.1 expertonderzoek type
+
+Het Forum Standaardisatie bevat **tegenstrijdige informatie** over het type expertonderzoek voor OAuth NL profiel v1.1:
+
+| Bron | URL | Vermelding |
+|------|-----|-----------|
+| **Hoofdpagina** OAuth 2.0 NL | [forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20) | "Een **volledig** expertonderzoek is aangewezen" |
+| **Intakeadvies** OAuth v1.1 | [forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11) | "Een **verkort** expertonderzoek is aangewezen om de nieuwe versie van de standaard te toetsen aan de criteria voor opname op de lijst." |
+
+### Analyse
+
+- Het intakeadvies-document is het **meer specifieke en autoritatieve** bron: het is de daadwerkelijke aanbeveling van de stuurgroep op basis van de intake op 14-08-2025
+- De stuurgroep adviseert "verkort" omdat het een beperkte/incrementele versie-update betreft die backward compatible is met v1.0
+- De hoofdpagina is waarschijnlijk niet bijgewerkt na het intakeadvies
+
+### Keuze in SKILL.md
+
+De skill gebruikt **"verkort expertonderzoek"**, conform het intakeadvies-document. Als de hoofdpagina van het Forum wordt bijgewerkt, moet dit conflict opnieuw worden beoordeeld.
+
+---
+
+## Keuze in SKILL.md
+
+De skill gebruikt versienummers van gitdocumentatie.logius.nl als bron van waarheid voor vastgestelde (DEF) versies (OIN-Stelsel v2.2.1, OAuth-Beheermodel v1.0). Voor het expertonderzoek-type van OAuth v1.1 volgt de skill het intakeadvies-document ("verkort"). OAuth-Beheermodel heeft een afwijkende tag (`0.2` vs DEF v1.0) maar is gearchiveerd. Als de GitHub-tags of de Forum-hoofdpagina worden bijgewerkt, moet dit conflict opnieuw worden beoordeeld.
+
+## Referenties
+
+- Publicatie OIN-Stelsel: https://gitdocumentatie.logius.nl/publicatie/dk/oin/
+- GitHub OIN-Stelsel: https://github.com/logius-standaarden/OIN-Stelsel
+- GitHub OIN-Stelsel tags: https://github.com/logius-standaarden/OIN-Stelsel/tags
+- Forum Standaardisatie OAuth 2.0 NL: https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20
+- Intakeadvies OAuth v1.1: https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11
+- Publicatie OAuth-Beheermodel: https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer/
+- GitHub OAuth-Beheermodel: https://github.com/logius-standaarden/OAuth-Beheermodel
+- GitHub OAuth-Beheermodel tags: https://github.com/logius-standaarden/OAuth-Beheermodel/tags
+- Forum Standaardisatie Authenticatie-standaarden: https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden

--- a/skills/ls-iam/reference.md
+++ b/skills/ls-iam/reference.md
@@ -1,12 +1,12 @@
 # Identity & Access Management - Achtergrondinfo
 
-Deze referentiedocumentatie bevat aanvullende informatie over SAML legacy implementaties, het OIN-stelsel, en uitgebreide protocoldocumentatie voor OAuth en OpenID Connect. Voor praktische implementatie-informatie, zie [SKILL.md](SKILL.md).
+Deze referentiedocumentatie bevat aanvullende informatie over SAML-implementaties, het OIN-stelsel, en uitgebreide protocoldocumentatie voor OAuth en OpenID Connect. Voor praktische implementatie-informatie, zie [SKILL.md](SKILL.md).
 
 ---
 
 ## SAML
 
-Security Assertion Markup Language (SAML) is een legacy standaard voor federatieve authenticatie en autorisatie. Hoewel nieuwere implementaties de voorkeur geven aan OAuth 2.0 en OpenID Connect, is SAML nog steeds in gebruik bij:
+Security Assertion Markup Language (SAML) is samen met OpenID.NLGov (v1.0.1) **verplicht** als onderdeel van de gecombineerde vermelding ["Authenticatie-standaarden (OpenID.NLGov en SAML)"](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden) op het Forum Standaardisatie (sinds 21-09-2023). Hoewel voor nieuwe implementaties OIDC NL GOV wordt aanbevolen, is SAML actief in gebruik bij:
 
 - **DigiD**: het authenticatiesysteem voor burgers
 - **eHerkenning**: het authenticatiesysteem voor bedrijven

--- a/skills/ls-logboek/SKILL.md
+++ b/skills/ls-logboek/SKILL.md
@@ -20,19 +20,27 @@ overheidsorganisaties. Het biedt een gestandaardiseerde manier om verwerkingsact
 en raadplegen, in lijn met de AVG/GDPR verantwoordingsplicht. De standaard is gebaseerd op
 OpenTelemetry en W3C Trace Context, waardoor verwerkingen over organisatiegrenzen heen traceerbaar zijn.
 
+## Versiemodel
+
+Net als andere Logius-standaarden kent Logboek Dataverwerkingen twee publicatiekanalen (vergelijkbaar met W3C):
+
+- **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
+
+Logboek Dataverwerkingen heeft momenteel **alleen werkversies**. Er zijn nog geen vastgestelde versies gepubliceerd. Extensies ontlenen hun status aan de hoofdspecificatie. Logboek Dataverwerkingen is nog niet opgenomen op de lijst van het Forum Standaardisatie; de standaard is in ontwikkeling.
+
 ## Repositories
 
-| Repository                                                                                                                               | Beschrijving                               | Publicatie                                                                                           |
-|------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|------------------------------------------------------------------------------------------------------|
-| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen)                                               | Hoofdspecificatie met REST API definitie   | [Lees online](https://logius-standaarden.github.io/logboek-dataverwerkingen/)                        |
-| [logboek-dataverwerkingen-inleiding](https://github.com/logius-standaarden/logboek-dataverwerkingen-inleiding)                           | Introductie en achtergrond                 | [Lees online](https://logius-standaarden.github.io/logboek-dataverwerkingen-inleiding/)              |
-| [logboek-dataverwerkingen-juridisch-beleidskader](https://github.com/logius-standaarden/logboek-dataverwerkingen-juridisch-beleidskader) | Juridisch en beleidskader                  | [Lees online](https://logius-standaarden.github.io/logboek-dataverwerkingen-juridisch-beleidskader/) |
-| [logboek-dataverwerkingen-demo](https://github.com/logius-standaarden/logboek-dataverwerkingen-demo)                                     | Docker demo-omgeving met meerdere services | -                                                                                                    |
-| [logboek-extensie-lezen](https://github.com/logius-standaarden/logboek-extensie-lezen)                                                   | Extensie: leesoperaties op het logboek     | [Lees online](https://logius-standaarden.github.io/logboek-extensie-lezen/)                          |
-| [logboek-extensie-nen7513](https://github.com/logius-standaarden/logboek-extensie-nen7513)                                               | Extensie: NEN 7513 (logging in de zorg)    | [Lees online](https://logius-standaarden.github.io/logboek-extensie-nen7513/)                        |
-| [logboek-extensie-object](https://github.com/logius-standaarden/logboek-extensie-object)                                                 | Extensie: objectgegevens bij verwerkingen  | [Lees online](https://logius-standaarden.github.io/logboek-extensie-object/)                         |
-| [logboek-extensie-template](https://github.com/logius-standaarden/logboek-extensie-template)                                             | Template voor nieuwe extensies             | [Lees online](https://logius-standaarden.github.io/logboek-extensie-template/)                       |
-| [logboek-dataverwerkingen_Juridisch-beleidskader](https://github.com/logius-standaarden/logboek-dataverwerkingen_Juridisch-beleidskader) | Alternatieve juridisch beleidskader repo   | -                                                                                                    |
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen) | Hoofdspecificatie met REST API definitie | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen/) |
+| [logboek-dataverwerkingen-inleiding](https://github.com/logius-standaarden/logboek-dataverwerkingen-inleiding) | Introductie en achtergrond | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen-inleiding/) |
+| [logboek-dataverwerkingen-juridisch-beleidskader](https://github.com/logius-standaarden/logboek-dataverwerkingen-juridisch-beleidskader) | Juridisch en beleidskader | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen-juridisch-beleidskader/) |
+| [logboek-dataverwerkingen-demo](https://github.com/logius-standaarden/logboek-dataverwerkingen-demo) | Docker demo-omgeving met meerdere services | - | - |
+| [logboek-extensie-lezen](https://github.com/logius-standaarden/logboek-extensie-lezen) | Extensie: leesoperaties op het logboek | - | [Draft](https://logius-standaarden.github.io/logboek-extensie-lezen/) |
+| [logboek-extensie-nen7513](https://github.com/logius-standaarden/logboek-extensie-nen7513) | Extensie: NEN 7513 (logging in de zorg) | - | [Draft](https://logius-standaarden.github.io/logboek-extensie-nen7513/) |
+| [logboek-extensie-object](https://github.com/logius-standaarden/logboek-extensie-object) | Extensie: objectgegevens bij verwerkingen | - | [Draft](https://logius-standaarden.github.io/logboek-extensie-object/) |
+| [logboek-extensie-template](https://github.com/logius-standaarden/logboek-extensie-template) | Template voor nieuwe extensies | - | [Draft](https://logius-standaarden.github.io/logboek-extensie-template/) |
 
 ## Architectuur
 
@@ -127,11 +135,11 @@ Resultaat:
 
 ## Protocol
 
-De standaard beveelt **OpenTelemetry Protocol (OTLP)** aan als transportprotocol voor het aanleveren van logregels aan het Logboek.
+De standaard schrijft geen specifiek transportprotocol voor, maar beveelt **OpenTelemetry Protocol (OTLP)** aan als transportprotocol voor het aanleveren van logregels aan het Logboek.
 
 **Vereisten:**
 
-- **TLS** is verplicht ondersteund voor alle communicatie met het Logboek.
+- Het Logboek **MOET** TLS kunnen afdwingen voor alle communicatie.
 - Het Logboek **MOET** elke schrijfactie bevestigen met een bevestigingsbericht (acknowledgement). De applicatie weet hierdoor zeker dat de logregel is opgeslagen.
 - OTLP ondersteunt zowel gRPC als HTTP/protobuf als transportlaag.
 - Bij gebruik van gRPC wordt bidirectionele streaming ondersteund voor hoge volumes.
@@ -186,7 +194,7 @@ resource = Resource.create({
 
 provider = TracerProvider(resource=resource)
 provider.add_span_processor(
-    BatchSpanProcessor(OTLPSpanExporter(endpoint="grpc://logboek:4317"))
+    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://logboek:4317", insecure=True))
 )
 trace.set_tracer_provider(provider)
 tracer = trace.get_tracer("mijn-applicatie")
@@ -315,6 +323,8 @@ def verwerk_batch(bsn_lijst: list[str], verwerking_id: str):
 ### Error Logging met Exception Details
 
 ```python
+import traceback
+
 with tracer.start_as_current_span("verwerk-gegevens") as span:
     span.set_attribute("dpl.core.processing_activity_id", verwerking_url)
     span.set_attribute("dpl.core.data_subject_id", bsn)
@@ -346,3 +356,4 @@ Als een verplicht veld ontbreekt, MOET de software een standaardwaarde invullen 
 ## Achtergrondinfo
 
 Zie [reference.md](reference.md) voor de architectuurbeschrijving, W3C Trace Context details, Docker demo-omgeving, en extensie-details.
+Zie [conflicts.md](conflicts.md) voor bronconflicten en gemaakte keuzes.

--- a/skills/ls-logboek/conflicts.md
+++ b/skills/ls-logboek/conflicts.md
@@ -1,0 +1,30 @@
+# Logboek Dataverwerkingen - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties en bewuste keuzes voor de Logboek-skill.
+
+## GitHub-tags vs. gepubliceerde versies
+
+Er zijn geen vastgestelde (DEF) versies voor Logboek Dataverwerkingen. De publicatie-URL `gitdocumentatie.logius.nl/publicatie/logboek/logging/` geeft een 404. De GitHub-repositories hebben geen tags.
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [logboek-extensie-lezen](https://github.com/logius-standaarden/logboek-extensie-lezen) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [logboek-extensie-nen7513](https://github.com/logius-standaarden/logboek-extensie-nen7513) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [logboek-extensie-object](https://github.com/logius-standaarden/logboek-extensie-object) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [logboek-extensie-template](https://github.com/logius-standaarden/logboek-extensie-template) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [logboek-dataverwerkingen-inleiding](https://github.com/logius-standaarden/logboek-dataverwerkingen-inleiding) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [logboek-dataverwerkingen-juridisch-beleidskader](https://github.com/logius-standaarden/logboek-dataverwerkingen-juridisch-beleidskader) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [logboek-dataverwerkingen-demo](https://github.com/logius-standaarden/logboek-dataverwerkingen-demo) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — demo/referentie-implementatie |
+
+## Keuze in SKILL.md
+
+De skill vermeldt correct dat er alleen werkversies zijn. Er zijn geen bronconflicten geconstateerd. Als er een DEF-versie wordt vastgesteld, moet dit document worden bijgewerkt met de versie-informatie.
+
+## Referenties
+
+- GitHub repo: https://github.com/logius-standaarden/logboek-dataverwerkingen
+- GitHub extensies: https://github.com/logius-standaarden?q=logboek-extensie
+- Werkversie: https://logius-standaarden.github.io/logboek-dataverwerkingen/

--- a/skills/ls-logboek/reference.md
+++ b/skills/ls-logboek/reference.md
@@ -51,10 +51,10 @@ De demo-omgeving simuleert een multi-organisatie opstelling met meerdere microse
 
 | Service | Beschrijving |
 |---------|--------------|
-| `currus` | Applicatieservice die verwerkingen uitvoert en logregels genereert |
+| `munera` | Fictieve "Mijn Gemeente"-omgeving waar burgers gemeentezaken kunnen regelen |
+| `currus` | API voor het beheren van parkeervergunningen |
+| `lamina` | API voor het beschikbaar stellen van registratiegegevens van voertuigen |
 | `grafana` | Visualisatie en dashboard voor het inzien van logregels |
-| `lamina` | Logboek-implementatie die logregels opslaat en beheert |
-| `munera` | Register-service met verwerkingsactiviteiten (Art. 30) |
 
 ### Demo starten
 
@@ -64,14 +64,14 @@ gh repo clone logius-standaarden/logboek-dataverwerkingen-demo /tmp/logboek-demo
 gh api repos/logius-standaarden/logboek-dataverwerkingen-demo/contents --jq '.[].name'
 
 # Docker compose configuratie ophalen
-gh api repos/logius-standaarden/logboek-dataverwerkingen-demo/contents/docker-compose.yml \
+gh api repos/logius-standaarden/logboek-dataverwerkingen-demo/contents/docker-compose.yaml \
   -H "Accept: application/vnd.github.raw"
 
 # Demo starten
 cd /tmp/logboek-demo && docker compose up -d
 
 # Of via Makefile
-make build && make run
+make build && make start
 ```
 
 ### Demo gebruiken
@@ -81,7 +81,7 @@ make build && make run
 gh repo clone logius-standaarden/logboek-dataverwerkingen-demo /tmp/logboek-demo
 cd /tmp/logboek-demo
 
-# Services starten (currus=logboek, grafana=dashboard, lamina=register, munera=applicatie)
+# Services starten (munera=Mijn Gemeente app, currus=parkeervergunningen, lamina=voertuigregistratie, grafana=dashboard)
 docker compose up -d
 
 # Status controleren

--- a/skills/ls-notif/SKILL.md
+++ b/skills/ls-notif/SKILL.md
@@ -15,16 +15,29 @@ allowed-tools:
 
 **Agent-instructie:** Deze skill helpt bij het implementeren van event-driven communicatie met CloudEvents NL GOV profiel. Gebruik de `cloudevents` SDK voor Python/JavaScript. Source moet URN nld-notatie gebruiken: `urn:nld:oin:<OIN>:systeem:<naam>`.
 
-De notificatiestandaarden definieren hoe overheidsorganisaties gebeurtenissen (events) kunnen publiceren en daarop kunnen abonneren. Gebaseerd op de internationale CNCF CloudEvents specificatie (v1.0) met een NL GOV profiel dat specifieke eisen stelt aan naamgeving, identificatie en het gebruik van context-attributen binnen de Nederlandse overheid.
+De notificatiestandaarden definiëren hoe overheidsorganisaties gebeurtenissen (events) kunnen publiceren en daarop kunnen abonneren. Gebaseerd op de internationale CNCF CloudEvents specificatie (v1.0.1) met een NL GOV profiel dat specifieke eisen stelt aan naamgeving, identificatie en het gebruik van context-attributen binnen de Nederlandse overheid.
+
+## Versiemodel
+
+Net als andere Logius-standaarden kennen de notificatiestandaarden twee publicatiekanalen (vergelijkbaar met W3C):
+
+- **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
+
+Het NL GOV profiel voor CloudEvents heeft een **vastgestelde versie** (v1.1 DEF). De Guidelines zijn een toelichting zonder eigen publicatie. Notificatieservices is een werkrepository zonder publicatie. Abonneren heeft een **werkversie** (v0.0.1 WV) op gitdocumentatie maar is nog niet vastgesteld.
+
+Op het Forum Standaardisatie staat CloudEvents **v1.0** als verplicht (['pas-toe-of-leg-uit'](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents), goedgekeurd OBDO 25-11-2025). Versie v1.1 is de meest recente DEF van Logius.
 
 ## Repositories
 
-| Repository | Beschrijving | Publicatie |
-|-----------|-------------|-----------|
-| [NL-GOV-profile-for-CloudEvents](https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents) | Nederlands overheidsprofiel voor CloudEvents | [Lees online](https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents/) |
-| [CloudEvents-NL-Guidelines](https://github.com/logius-standaarden/CloudEvents-NL-Guidelines) | Richtlijnen voor gebruik van CloudEvents in NL | [Lees online](https://logius-standaarden.github.io/CloudEvents-NL-Guidelines/) |
-| [Notificatieservices](https://github.com/logius-standaarden/Notificatieservices) | Specificatie voor notificatieservices | [Lees online](https://logius-standaarden.github.io/Notificatieservices/) |
-| [Abonneren](https://github.com/logius-standaarden/Abonneren) | Specificatie voor het abonneren op notificaties | [Lees online](https://logius-standaarden.github.io/Abonneren/) |
+| Repository | Beschrijving | Vastgesteld | Draft |
+|-----------|-------------|------------|-------|
+| [NL-GOV-profile-for-CloudEvents](https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents) | Nederlands overheidsprofiel voor CloudEvents (kernstandaard) | [v1.1](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl/) | [Draft](https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents/) |
+| [CloudEvents-NL-Guidelines](https://github.com/logius-standaarden/CloudEvents-NL-Guidelines) | Richtlijnen en toelichting bij het NL GOV profiel | - | [Draft](https://logius-standaarden.github.io/CloudEvents-NL-Guidelines/) |
+| [Notificatieservices](https://github.com/logius-standaarden/Notificatieservices) | API-specificatie voor notificatieservices (werkrepository, geen publicatie) | - | - |
+| [Abonneren](https://github.com/logius-standaarden/Abonneren) | API-specificatie voor het abonneren op notificaties | - | [WV v0.0.1](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren/)¹ |
+
+¹ Abonneren WV v0.0.1 is gepubliceerd op gitdocumentatie.logius.nl, wat normaal voor vastgestelde versies (DEF/VV) is. Dit is een uitzondering; de standaard is nog in ontwikkeling.
 
 ## CloudEvents NL GOV Profiel
 
@@ -80,7 +93,7 @@ Content-Type: application/json
 
 Het Abonneren-component beschrijft hoe afnemers zich kunnen registreren om specifieke events te ontvangen. Twee hoofdmodellen worden onderscheiden:
 
-**Push-model (aanbevolen):** Event-driven aflevering via webhooks. De notificatieservice stuurt events actief naar een door de afnemer opgegeven endpoint. Dit is het voorkeursmodel vanwege lage latency en efficienter resourcegebruik.
+**Push-model (aanbevolen):** Event-driven aflevering via webhooks. De notificatieservice stuurt events actief naar een door de afnemer opgegeven endpoint. Dit is het voorkeursmodel vanwege lage latency en efficiënter resourcegebruik.
 
 **Pull-model:** Polling-gebaseerde aflevering. De afnemer bevraagt periodiek de notificatieservice op nieuwe events. Geschikt voor situaties waar de afnemer geen inkomend endpoint kan aanbieden (bijv. vanwege firewallrestricties).
 
@@ -88,7 +101,7 @@ Het Abonneren-component beschrijft hoe afnemers zich kunnen registreren om speci
 
 Bij het werken met notificaties gelden strikte eisen op het gebied van beveiliging en privacy:
 
-- **Geen gevoelige data in context-attributen**: Context-attributen (zoals `source`, `type`, `subject`) zijn introspectable en worden gelogd door tussenliggende systemen. Plaats nooit persoonsgegevens of gevoelige informatie in deze velden. Gebruik hiervoor de versleutelde `data`-payload.
+- **Geen gevoelige data in context-attributen**: Context-attributen (zoals `source`, `type`, `subject`) zijn inspecteerbaar en worden gelogd door tussenliggende systemen. Plaats nooit persoonsgegevens of gevoelige informatie in deze velden. Gebruik hiervoor de versleutelde `data`-payload.
 - **Versleuteling van event data**: Wanneer de payload gevoelige gegevens bevat, moet deze versleuteld worden (end-to-end encryptie). De context-attributen blijven leesbaar voor routering.
 - **TLS verplicht**: Alle communicatie tussen bronnen, notificatieservices en afnemers moet plaatsvinden over TLS (minimaal versie 1.2).
 - **Claim Check Pattern**: Bij grote of gevoelige payloads kan het `dataref`-attribuut verwijzen naar een beveiligd endpoint. De afnemer haalt de payload separaat op met eigen autorisatie.
@@ -309,4 +322,5 @@ def deliver_event(webhook_url: str, event: dict, max_retries: int = 5):
 
 ## Achtergrondinfo
 
-Zie [reference.md](reference.md) voor het type systeem, kernconcepten, en aanbevolen technologieen.
+Zie [reference.md](reference.md) voor het type systeem, kernconcepten, en aanbevolen technologieën.
+Zie [conflicts.md](conflicts.md) voor bronconflicten en gemaakte keuzes.

--- a/skills/ls-notif/conflicts.md
+++ b/skills/ls-notif/conflicts.md
@@ -1,0 +1,38 @@
+# Notificaties (CloudEvents) - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties en bewuste keuzes voor de Notificaties-skill.
+
+## GitHub-tags vs. gepubliceerde versies
+
+| Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
+|-----------|---------------------------|-------------------|-------------|
+| [NL-GOV-profile-for-CloudEvents](https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents) | [v1.1](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl/) | `1.1` | Geen discrepantie (tag komt overeen). Alle tags: `1.1`, `1.0`, `0.3`, `v0.1` |
+| [Abonneren](https://github.com/logius-standaarden/Abonneren) | _(geen DEF)_ — [WV v0.0.1](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren/) | _(geen tags)_ | Werkversie op gitdocumentatie; nog geen vastgestelde versie |
+
+### Observatie: reponaam
+
+De juiste GitHub-reponaam is `NL-GOV-profile-for-CloudEvents`. De naam `CloudEvents-NL-profiel` (die soms in verwijzingen voorkomt) bestaat niet en geeft een 404.
+
+## Forum Standaardisatie vs. Logius DEF-versie
+
+| Bron | Versie | Status |
+|------|--------|--------|
+| [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents) | v1.0 | Verplicht (pas-toe-of-leg-uit) |
+| [gitdocumentatie.logius.nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl/) | v1.1 | Meest recente DEF bij Logius |
+
+### Analyse
+
+Het Forum Standaardisatie vermeldt v1.0 als de verplichte versie op de pas-toe-of-leg-uit lijst. Logius heeft inmiddels v1.1 als DEF vastgesteld. Dit is geen fout: het Forum werkt met vastgestelde lijstversies die periodiek worden bijgewerkt, terwijl Logius doorontwikkelt.
+
+## Keuze in SKILL.md
+
+De skill noemt beide versies correct: v1.0 als de Forum Standaardisatie-versie (verplicht) en v1.1 als de meest recente Logius DEF. Als het Forum de lijstversie bijwerkt naar v1.1, moet dit conflict opnieuw worden beoordeeld.
+
+## Referenties
+
+- Publicatie CloudEvents NL GOV profiel: https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl/
+- GitHub repo: https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents
+- GitHub tags: https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents/tags
+- Forum Standaardisatie: https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents

--- a/skills/ls-notif/reference.md
+++ b/skills/ls-notif/reference.md
@@ -22,13 +22,13 @@ CloudEvents definieert de volgende datatypes voor attributen:
 - **NL GOV profiel** - Nederlandse aanscherping met verplichte attributen en URN-naamgeving
 - **Notificatieservice** - Dienst die events ontvangt van bronnen en doorstuurt naar abonnees
 - **Abonnement** - Registratie van een afnemer om specifieke events te ontvangen
-- **Event source** - De bron die een gebeurtenis genereert (geidentificeerd via OIN in URN-notatie)
+- **Event source** - De bron die een gebeurtenis genereert (geïdentificeerd via OIN in URN-notatie)
 - **Event subject** - Het onderwerp waarop de event betrekking heeft (bijv. BSN, zaak-ID)
 - **Pub/Sub** - Publish/Subscribe patroon voor losse koppeling tussen bron en afnemer
 - **Webhook** - HTTP callback voor het afleveren van events bij abonnees (push-model)
 - **Claim Check Pattern** - Patroon waarbij de payload extern wordt opgeslagen en het event alleen een referentie bevat
 
-## Aanbevolen technologieen
+## Aanbevolen technologieën
 
 | Technologie | Type | Toelichting |
 |-------------|------|-------------|
@@ -37,7 +37,7 @@ CloudEvents definieert de volgende datatypes voor attributen:
 | Apache Kafka | Event streaming | Geschikt voor hoge volumes en event replay |
 | NATS JetStream | Lightweight messaging | Lichtgewicht alternatief met persistence |
 
-## Niet aanbevolen technologieen
+## Niet aanbevolen technologieën
 
 | Technologie | Reden |
 |-------------|-------|
@@ -90,4 +90,5 @@ gh api repos/logius-standaarden/Notificatieservices/contents/openapi.yaml --jq '
 | `/ls-api` | Notificatie-APIs volgen de API Design Rules |
 | `/ls-fsc` | FSC kan CloudEvents transporteren |
 | `/ls-logboek` | Events kunnen verwerkingen triggeren die gelogd worden |
+| `/ls-pub` | ReSpec tooling voor notificatiedocumentatie |
 | `/ls` | Overzicht alle standaarden |

--- a/skills/ls-pub/SKILL.md
+++ b/skills/ls-pub/SKILL.md
@@ -20,17 +20,29 @@ allowed-tools:
 
 **Agent-instructie:** Deze skill is de centrale plek voor publicatie-tooling en kwaliteitschecks van alle Logius standaarden. Gebruik deze skill wanneer de gebruiker een document wil bouwen, valideren (WCAG, markdown lint, link check), publiceren, of een nieuw ReSpec-document wil opzetten. Dit is de ENIGE skill met markdownlint, axe-core en muffet tools.
 
+## Versiemodel van standaarden
+
+De publicatie-tooling ondersteunt het versiemodel van Logius-standaarden via de `specStatus` configuratiewaarde in ReSpec:
+
+| specStatus | Betekenis | Publicatiekanaal |
+|-----------|-----------|-----------------|
+| `WV` | Werkversie (draft) | `logius-standaarden.github.io` |
+| `CV` | Consultatieversie | `logius-standaarden.github.io/Openbare-Consultaties/` (automatisch op `consultatie/*` branches) |
+| `VV` | Versie ter vaststelling | `gitdocumentatie.logius.nl` |
+| `DEF` | Vastgestelde versie | `gitdocumentatie.logius.nl` |
+
 ## Repositories
 
 | Repository | Beschrijving | Publicatie |
 |-----------|-------------|-----------|
-| [publicatie](https://github.com/logius-standaarden/publicatie) | Centrale publicatie-repo: alle gepubliceerde standaarden | [Lees online](https://logius-standaarden.github.io/publicatie/) |
+| [publicatie](https://github.com/logius-standaarden/publicatie) | Centrale publicatie-repo: alle vastgestelde standaarden | gitdocumentatie.logius.nl (geen directory listing) |
 | [Publicatie-Preview](https://github.com/logius-standaarden/Publicatie-Preview) | Preview-omgeving voor documenten in ontwikkeling | [Lees online](https://logius-standaarden.github.io/Publicatie-Preview/) |
 | [respec](https://github.com/logius-standaarden/respec) | Logius fork van W3C ReSpec documentatie-tool | - |
 | [ReSpec-template](https://github.com/logius-standaarden/ReSpec-template) | Basis template voor nieuwe ReSpec documenten | [Lees online](https://logius-standaarden.github.io/ReSpec-template/) |
 | [ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius) | Logius-specifiek ReSpec template met huisstijl | [Lees online](https://logius-standaarden.github.io/ReSpec-template-Logius/) |
+| [Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties) | Gepubliceerde consultatieversies (CV) | [Lees online](https://logius-standaarden.github.io/Openbare-Consultaties/) |
 | [Automatisering](https://github.com/logius-standaarden/Automatisering) | Herbruikbare GitHub Actions workflows | - |
-| [automatisering-test](https://github.com/logius-standaarden/automatisering-test) | Testomgeving voor de automatiseringworkflows | - |
+| [automatisering-test](https://github.com/logius-standaarden/automatisering-test) | Testomgeving voor de automatiseringsworkflows | - |
 | [tech-radar](https://github.com/logius-standaarden/tech-radar) | Technologie radar voor Logius standaarden | [Lees online](https://logius-standaarden.github.io/tech-radar/) |
 
 ## ReSpec Documentatie-systeem
@@ -46,30 +58,38 @@ Het hoofdbestand `index.html` laadt de ReSpec-engine en verwijst via `data-inclu
 <section data-include-format="markdown" data-include="ch02.md"></section>
 ```
 
-### ReSpec Configuratie (`js/config.js`)
+### ReSpec Configuratie (`js/config.mjs`)
+
+Nieuwe documenten gebruiken ES-module formaat (`config.mjs`); oudere repos kunnen nog `config.js` bevatten.
 
 ```javascript
-{
+// js/config.mjs (nieuw, aanbevolen formaat)
+import { loadRespecWithConfiguration } from
+  "https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs";
+
+loadRespecWithConfiguration({
   useLogo: true,
   useLabel: true,
-  license: "cc0",
-  specStatus: "WV",        // WV=Working Version, CV=Consultation, VV=Vastgesteld, DEF=Definitief
+  license: "cc-by",
+  specStatus: "WV",        // WV=Werkversie, CV=Consultatieversie, VV=Versie ter vaststelling, DEF=Vastgestelde versie
   specType: "HR",           // HR=Handreiking, ST=Standaard, PR=Praktijkrichtlijn, IM=Informatiemodel
   pubDomain: "dk",
   shortName: "template",
-  publishDate: "2023-01-31",
-  publishVersion: "0.0.1",
-  title: "Template",
-  content: { "ch01": "informative", "ch02": "" },
-  alternateFormats: [{ label: "pdf", uri: "template.pdf" }]
-}
+  publishDate: "2023-06-21",
+  publishVersion: "0.0.3",
+  editors: [{ name: "Logius Standaarden", company: "Logius", companyURL: "https://logius.nl" }],
+  authors: [{ name: "Logius Standaarden", company: "Logius", companyURL: "https://logius.nl" }],
+  github: "https://github.com/logius-standaarden/ReSpec-template",
+});
 ```
+
+> **Let op:** Oudere repos gebruiken `config.js` met `var respecConfig = { ... }` syntax. Die bevat soms extra velden zoals `content`, `alternateFormats` en `postProcess` die niet in de `config.mjs`-variant voorkomen.
 
 ### Directory Structuur
 
 ```
 .github/workflows/    # CI/CD workflows (verwijzen naar Automatisering repo)
-js/config.js          # ReSpec configuratie
+js/config.mjs         # ReSpec configuratie (of config.js bij oudere repos)
 media/                # Afbeeldingen, diagrammen
 ch01.md, ch02.md      # Hoofdstukken
 abstract.md           # Samenvatting
@@ -82,9 +102,9 @@ Alle standaarden-repos roepen centrale workflows aan uit de `Automatisering` rep
 
 ### build.yml - Document Generatie
 
-1. Branch-detectie: `consultatie/*` branches krijgen automatisch `specStatus: "cv"`
-2. HTML generatie: `npx respec --localhost --src index.html --out static/index.html`
-3. PDF generatie via Puppeteer/headless Chrome
+1. Branch-detectie: `consultatie/*` branches krijgen automatisch `specStatus: "cv"` (via sed op `config.mjs`)
+2. HTML generatie: `npx respec --localhost --src index.html --out ~/static/index.html --haltonwarn`
+3. PDF generatie via Puppeteer/headless Chrome (met `scripts/pdf.js`)
 4. Cache opslag als GitHub Actions cache
 
 ### check.yml - Kwaliteitschecks (3 parallelle checks)
@@ -95,7 +115,15 @@ Alle standaarden-repos roepen centrale workflows aan uit de `Automatisering` rep
 
 ### publish.yml - Publicatie
 
-Publiceert definitieve versies naar de centrale `publicatie` repo.
+Bevat meerdere jobs afhankelijk van de context:
+- **Release** (push naar `main`/`master`): publiceert naar de centrale `publicatie` repo (gitdocumentatie.logius.nl)
+- **Deploy develop** (push naar `develop`): publiceert naar GitHub Pages van de standaarden-repo zelf
+- **Preview** (pull request): publiceert een preview naar de `Publicatie-Preview` repo
+- **Consultatie** (`consultatie/*` branches): publiceert naar de `Openbare-Consultaties` repo
+
+### link-checker.yml - Gepubliceerde Links Controleren
+
+Controleert periodiek of de gepubliceerde versie op gitdocumentatie.logius.nl geen dode links bevat. Stuurt een e-mail bij gevonden fouten.
 
 ### Calling Workflow Voorbeeld
 
@@ -104,7 +132,7 @@ Publiceert definitieve versies naar de centrale `publicatie` repo.
 name: Build document
 on:
   push:
-    branches: [main, 'consultatie/**']
+    branches: [main, 'consultatie/*']
   pull_request:
     branches: [main]
 
@@ -112,13 +140,13 @@ jobs:
   build:
     uses: logius-standaarden/Automatisering/.github/workflows/build.yml@main
     with:
-      source-files: index.html
+      workflow_input_file_names: '["index.html"]'
 ```
 
 ## Nieuw Document Starten
 
 1. **Fork het template**: Gebruik [ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius) als basis
-2. **Configureer `js/config.js`**: Pas `specStatus`, `specType`, `pubDomain`, `shortName`, `title` aan
+2. **Configureer `js/config.mjs`**: Pas `specStatus`, `specType`, `pubDomain`, `shortName`, `title` aan
 3. **Schrijf content**: Maak hoofdstukken als losse Markdown-bestanden
 4. **Push naar GitHub**: CI/CD bouwt automatisch HTML en PDF
 
@@ -151,8 +179,9 @@ muffet http://localhost:8080/index.html
 
 ### Consultatie Branch Gedrag
 
-Op `consultatie/*` branches wordt `specStatus` automatisch overschreven naar `"cv"`. Na merge naar `main` wordt `specStatus` uit `js/config.js` gebruikt.
+Op `consultatie/*` branches wordt `specStatus` automatisch overschreven naar `"cv"`. Na merge naar `main` wordt `specStatus` uit `js/config.mjs` gebruikt.
 
 ## Achtergrondinfo
 
 Zie [reference.md](reference.md) voor gedetailleerde info over tech radar, label-updates workflow, en workflow-configuratie.
+Zie [conflicts.md](conflicts.md) voor bronconflicten en gemaakte keuzes.

--- a/skills/ls-pub/conflicts.md
+++ b/skills/ls-pub/conflicts.md
@@ -1,0 +1,21 @@
+# Publicatie & Tooling - Bronconflicten
+
+Geconstateerd: 2026-02-21
+
+Dit document beschrijft bekende discrepanties en bewuste keuzes voor de Publicatie-skill.
+
+## GitHub-tags vs. gepubliceerde versies
+
+De publicatie-tooling repositories (respec, respec-tools, build-push-action, etc.) zijn tooling-repos, geen standaard-documenten. Ze hebben geen vastgestelde (DEF) versies op gitdocumentatie.logius.nl.
+
+Er zijn geen bronconflicten geconstateerd. Tooling-versies worden via GitHub Releases beheerd, niet via gitdocumentatie.logius.nl.
+
+## Keuze in SKILL.md
+
+De skill beschrijft de publicatie-tooling en workflows zonder versieclaims voor de tooling zelf. Er zijn geen discrepanties tussen bronnen. Als er in de toekomst versiegebonden tooling-releases komen, moet dit document worden bijgewerkt.
+
+## Referenties
+
+- GitHub publicatie-tools: https://github.com/logius-standaarden/respec
+- GitHub Automatisering: https://github.com/logius-standaarden/Automatisering
+- Publicatie-overzicht: https://gitdocumentatie.logius.nl/publicatie/

--- a/skills/ls-pub/reference.md
+++ b/skills/ls-pub/reference.md
@@ -8,7 +8,7 @@ De [Tech Radar](https://logius-standaarden.github.io/tech-radar/) is een visuali
 |------|-----------|
 | **Adopt** | Bewezen technologie, actief aanbevolen voor gebruik |
 | **Trial** | Veelbelovend, wordt actief getest in projecten |
-| **Assess** | Interessant, wordt onderzocht en geevalueerd |
+| **Assess** | Interessant, wordt onderzocht en geëvalueerd |
 | **Hold** | Niet aanbevolen voor nieuw gebruik, wordt uitgefaseerd |
 
 ```bash
@@ -53,6 +53,7 @@ jobs:
   publish:
     needs: [build, check]
     uses: logius-standaarden/Automatisering/.github/workflows/publish.yml@main
+    secrets: inherit
 ```
 
 ## Handige Commando's
@@ -75,3 +76,13 @@ gh api repos/logius-standaarden/Automatisering/commits \
 # Welke repos gebruiken de centrale workflows
 gh search code "logius-standaarden/Automatisering" --owner logius-standaarden --filename "*.yml"
 ```
+
+## Gerelateerde Skills
+
+| Skill | Relatie |
+|-------|---------|
+| `/ls-api` | API Design Rules documentatie gebruikt ReSpec en de centrale workflows |
+| `/ls-dk` | Digikoppeling documentatie gebruikt ReSpec en de centrale workflows |
+| `/ls-fsc` | FSC documentatie gebruikt ReSpec en de centrale workflows |
+| `/ls-bomos` | BOMOS documentatie gebruikt ReSpec en de centrale workflows |
+| `/ls` | Overzicht alle standaarden |

--- a/skills/ls/SKILL.md
+++ b/skills/ls/SKILL.md
@@ -15,19 +15,40 @@ allowed-tools:
 
 **Agent-instructie:** Gebruik deze skill om de gebruiker naar het juiste domein te routeren. Bij een domein-specifieke vraag, verwijs naar de juiste `/ls-*` skill. Bij organisatie-brede vragen, gebruik de gh commando's hieronder.
 
-Logius beheert 88 GitHub repositories onder [github.com/logius-standaarden](https://github.com/logius-standaarden), verdeeld over 9 domeinen:
+Logius beheert 88 GitHub repositories onder [github.com/logius-standaarden](https://github.com/logius-standaarden). Deze plugin bevat skills voor 77 daarvan, verdeeld over 9 domeinen (de overige repos zijn gearchiveerd, meta/test-repos of duplicaten).
+
+## Versiemodel
+
+Logius-standaarden kennen twee publicatiekanalen (vergelijkbaar met W3C):
+
+- **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
+- **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
+
+Niet alle standaarden hebben al een vastgestelde versie. De domeinen ADR, Digikoppeling, BOMOS, IAM (OAuth-NL-profiel v1.1.0, OIDC-NLGOV v1.0.1), FSC (fsc-core v1.1.2, fsc-logging v1.0.0) en Notificaties (CloudEvents NL GOV v1.1) hebben vastgestelde publicaties; de overige domeinen (Logboek, E-Gov) publiceren vooralsnog alleen werkversies. Een standaard kan tegelijkertijd een vastgestelde versie en een werkversie (draft voor de volgende release) hebben. Modules en subcomponenten ontlenen hun status aan de standaard die ernaar verwijst.
+
+## Forum Standaardisatie Status
+
+Niet alle Logius-standaarden staan op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie:
+
+- **Verplicht**: [API Design Rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules), [Digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling), [Authenticatie-standaarden (OIDC+SAML)](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden), [OAuth-NL-profiel v1.0](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20), [CloudEvents v1.0](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents), [NLCIUS](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+- **Aanbevolen**: Peppol BIS
+- **Niet op de lijst**: BOMOS (raamwerk, geen interoperabiliteitsstandaard), FSC (onderdeel Digikoppeling), Logboek (in ontwikkeling), Digimelding/Terugmelding, e-procurement
+
+> OAuth-NL-profiel v1.1 is vastgesteld door Logius (DEF), maar op het Forum Standaardisatie nog ["in behandeling"](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11); v1.0 is de verplichte versie.
+
+## Domeinen
 
 | Skill | Domein | Repos | Beschrijving |
 |-------|--------|-------|-------------|
 | `/ls-dk` | Digikoppeling | 17 | Beveiligde gegevensuitwisseling (REST, ebMS2, WUS, GB), OIN |
-| `/ls-api` | API Design Rules | 10 | NL GOV API-standaard, Spectral linter, referentie-implementaties |
+| `/ls-api` | API Design Rules | 9 | NL GOV API-standaard, Spectral linter, referentie-implementaties |
 | `/ls-iam` | Identity & Access Management | 8 | OAuth 2.0 NL, OpenID Connect, AuthZEN, SAML |
 | `/ls-fsc` | Federated Service Connectivity | 7 | Federatief netwerk: inway/outway, contracten, service directory |
-| `/ls-logboek` | Logboek Dataverwerkingen | 9 | AVG-logging, OpenTelemetry, W3C Trace Context |
+| `/ls-logboek` | Logboek Dataverwerkingen | 8 | AVG-logging, OpenTelemetry, W3C Trace Context |
 | `/ls-notif` | CloudEvents & Notificaties | 4 | NL GOV CloudEvents profiel, pub/sub |
 | `/ls-bomos` | BOMOS Governance | 10 | Beheer- en Ontwikkelmodel voor Open Standaarden |
 | `/ls-egov` | E-Government Services | 6 | Terugmelding, Digimelding, e-procurement |
-| `/ls-pub` | Publicatie & Tooling | 8 | ReSpec, GitHub Actions, WCAG checks, markdown lint |
+| `/ls-pub` | Publicatie & Tooling | 9 | ReSpec, GitHub Actions, WCAG checks, markdown lint |
 
 ## Organisatie-brede Commando's
 


### PR DESCRIPTION
## Samenvatting

Naar aanleiding van [waardevolle feedback op #7](https://github.com/MinBZK/logius-standaarden-plugin/pull/7#issuecomment-3937078192) over de complexiteit van het ADR-versiemodel is de hele plugin doorgelicht op correctheid van versienummers, URLs en interne consistentie.

**Belangrijkste wijzigingen:**

- **Versiemodel verduidelijkt** — ADR Transport Security beschrijving gecorrigeerd (inhoud ingebed in v2.1.0, module gearchiveerd), werkversies beter beschreven
- **`conflicts.md` per domein** — alle 9 domeinen hebben nu een bronconflicten-bestand dat discrepanties tussen GitHub-tags en gepubliceerde versies documenteert
- **Consistentie-audit** — alle 76 repo-URLs gevalideerd, 13 versienummers bevestigd op gitdocumentatie.logius.nl, 3 broken URLs gefixt

## Details

### Nieuwe bestanden (9x `conflicts.md`)
Elk domein documenteert nu expliciet waar GitHub-tags achterlopen op gepubliceerde versies, met een "Keuze in SKILL.md" sectie die de gemaakte keuze motiveert.

### Gefixt
- Broken URL `fsc/external-contract/` → `fsc/ext/` in ls-fsc/conflicts.md
- Broken URL Abonneren GitHub Pages → gitdocumentatie in ls-notif/conflicts.md
- Hoofdletter `Logius-standaarden` → `logius-standaarden` in ls-pub/SKILL.md

### Overig
- Markdownlint: MD034 en MD060 uitgeschakeld (false positives in referentielijsten)
- CLAUDE.md: conventies voor conflicts.md patroon toegevoegd
- CHANGELOG en README bijgewerkt

## Verificatie
- [x] Alle 76 GitHub repo-URLs bestaan (0 broken)
- [x] Alle 13 geclaimde versienummers bevestigd op gitdocumentatie.logius.nl
- [x] Alle SKILL.md onder 500 regels
- [x] Alle frontmatter compleet (name, description, model)
- [x] Geen broken URLs meer in conflicts.md bestanden