### PR TITLE
Fix forum monitoring: body hashing en JS nonce normalisatie

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -4,8 +4,7 @@
 Vergelijkt de huidige staat van URLs met een opgeslagen checksums.json.
 Verschillende detectiemethoden per URL-type:
 - github_repo: GitHub API (commit SHA, laatste tag, archived status)
-- published_doc/draft_doc: HTTP ETag/Last-Modified + SHA256 van body
-- forum: Alleen HTTP ETag/Last-Modified (body te dynamisch)
+- published_doc/draft_doc/forum: HTTP ETag/Last-Modified + SHA256 van genormaliseerde body
 
 Maakt GitHub Issues aan bij gedetecteerde wijzigingen.
 """
@@ -71,8 +70,9 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s\"'<]*", "", html)
     # Verwijder generator meta-tags
     html = re.sub(r'<meta\s+name="generator"[^>]*>', "", html)
-    # Verwijder nonces
+    # Verwijder nonces (HTML-attributen en JS-assignments)
     html = re.sub(r'nonce="[^"]*"', "", html)
+    html = re.sub(r'\.nonce\s*=\s*"[^"]*"', '.nonce = ""', html)
     # Verwijder ReSpec-specifieke build timestamps
     html = re.sub(r"respecVersion\s*=\s*['\"][^'\"]*['\"]", "", html)
     # Verwijder HTML comments (build hashes, timestamps, etc.)
@@ -161,7 +161,7 @@ def check_url(entry: dict) -> dict:
     elif url_type in ("published_doc", "draft_doc"):
         return check_http_resource(url, hash_body=True)
     elif url_type == "forum":
-        return check_http_resource(url, hash_body=False)
+        return check_http_resource(url, hash_body=True)
     else:
         return {"error": f"Onbekend type: {url_type}"}
 


### PR DESCRIPTION
## Summary

- Forum URLs (forumstandaardisatie.nl) hadden lege `state: {}` in checksums.json — content wijzigingen werden niet gedetecteerd
- Oorzaak: `hash_body=False` voor forum type, en de server stuurt geen ETag/Last-Modified headers
- De body-dynamiek bleek alleen nonces te zijn (CSP security tokens die per request roteren)
- Fix: schakel body hashing in voor forum URLs en voeg JS nonce normalisatie toe (`tags.nonce = "..."`)

## Test plan

- [x] Twee opeenvolgende fetches van forumstandaardisatie.nl produceren identieke hashes na normalisatie
- [ ] CI checks slagen
- [ ] Na merge: volgende monitoring run vult forum state in checksums.json