### PR TITLE
fix: markdownlint regels compatibel met release-please CHANGELOG

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,6 @@
 {
+  "MD004": false,
+  "MD012": false,
   "MD013": false,
   "MD022": false,
   "MD024": false,


### PR DESCRIPTION
## Beschrijving

MD004 (ul-style) en MD012 (no-multiple-blanks) uitgezet in `.markdownlint.json` omdat release-please dashes en dubbele blanco regels genereert in CHANGELOG.md die niet overeenkomen met de eerder geconfigureerde asterisk-stijl.

Dit fixt de falende `lint-markdown` check op de release PR (#20).