### PR TITLE
fix: versie-badge in README automatisch bijwerken bij release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Logius Standaarden - Claude Code Plugin
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![versie](https://img.shields.io/badge/versie-1.2.0-green.svg)](CHANGELOG.md)
+[![versie](https://img.shields.io/badge/versie-1.2.0-green.svg)](CHANGELOG.md) <!-- x-release-please-version -->
 
 Claude Code plugin voor het werken met 77 van de 88 GitHub repositories van [Logius standaarden](https://github.com/logius-standaarden) voor Nederlandse overheidsinteroperabiliteit.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,10 @@
           "type": "yaml",
           "path": "publiccode.yml",
           "jsonpath": "$.softwareVersion"
+        },
+        {
+          "type": "generic",
+          "path": "README.md"
         }
       ]
     }


### PR DESCRIPTION
## Beschrijving

De versie-badge in README.md was hardcoded op `1.2.0`. Nu wordt deze automatisch bijgewerkt door release-please via een `x-release-please-version` marker.

## Wijzigingen

- `README.md` — `x-release-please-version` comment toegevoegd aan badge
- `release-please-config.json` — README.md als generic extra-file toegevoegd