### PR TITLE
fix: gebruik dynamische shields.io badge voor versienummer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Logius Standaarden - Claude Code Plugin
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![versie](https://img.shields.io/badge/versie-1.3.0)](CHANGELOG.md) <!-- x-release-please-version -->
+[![versie](https://img.shields.io/github/v/tag/MinBZK/logius-standaarden-plugin?label=versie&color=green)](CHANGELOG.md)
 
 Claude Code plugin voor het werken met 77 van de 88 GitHub repositories van [Logius standaarden](https://github.com/logius-standaarden) voor Nederlandse overheidsinteroperabiliteit.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,10 +28,6 @@
           "type": "yaml",
           "path": "publiccode.yml",
           "jsonpath": "$.softwareVersion"
-        },
-        {
-          "type": "generic",
-          "path": "README.md"
         }
       ]
     }


### PR DESCRIPTION
## Beschrijving

De vorige aanpak (release-please generic updater) stripte `-green.svg` van de shields.io URL, waardoor de badge 404 gaf.

Nu wordt een dynamische shields.io badge gebruikt die automatisch de laatste GitHub tag toont. Geen release-please config meer nodig voor README.md.