### PR TITLE
fix: elimineer monitoring false positives

### DIFF
--- a/scripts/extract_urls.py
+++ b/scripts/extract_urls.py
@@ -38,6 +38,8 @@ EXCLUDE_PATTERNS = [
     re.compile(r"https?://manager\.example"),
     re.compile(r"https?://directory\.example"),
     re.compile(r"https?://provider-manager\.example"),
+    # Publicatie-Preview verandert by design meerdere keren per dag (preview builds)
+    re.compile(r"https?://github\.com/logius-standaarden/Publicatie-Preview"),
 ]
 
 # Markdown-extractie regex: vindt alle URLs in tekst

--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -78,6 +78,21 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"<!--.*?-->", "", html, flags=re.DOTALL)
     # Verwijder cache-busting query params in script/link/img tags
     html = re.sub(r'(\.(js|css|png|svg|ico))\?[^"\'>\s]+', r"\1", html)
+    # Drupal CMS: aggregatie filenames met content-hashes (veranderen bij cache rebuild)
+    html = re.sub(
+        r"/sites/default/files/css/css_[A-Za-z0-9_-]+\.css",
+        "/sites/default/files/css/css_HASH.css",
+        html,
+    )
+    html = re.sub(
+        r"/sites/default/files/js/js_[A-Za-z0-9_-]+\.js",
+        "/sites/default/files/js/js_HASH.js",
+        html,
+    )
+    # Drupal CMS: view DOM IDs (veranderen bij cache rebuild)
+    html = re.sub(r"js-view-dom-id-[a-f0-9]+", "js-view-dom-id-HASH", html)
+    # Drupal CMS: permissionsHash (verandert bij module/permissie updates)
+    html = re.sub(r'"permissionsHash":"[a-f0-9]+"', '"permissionsHash":"HASH"', html)
     return html
 
 

--- a/tests/test_monitor_content.py
+++ b/tests/test_monitor_content.py
@@ -68,6 +68,30 @@ class TestNormalizeHtml:
         result = normalize_html(html)
         assert "35.0.2" not in result
 
+    def test_drupal_css_aggregatie(self):
+        html = '<link href="/sites/default/files/css/css_US753fRZjubynpaAuOsRw3D.css">'
+        result = normalize_html(html)
+        assert "US753fRZ" not in result
+        assert "css_HASH.css" in result
+
+    def test_drupal_js_aggregatie(self):
+        html = '<script src="/sites/default/files/js/js_Abc123XYZ_def456.js"></script>'
+        result = normalize_html(html)
+        assert "Abc123XYZ" not in result
+        assert "js_HASH.js" in result
+
+    def test_drupal_view_dom_id(self):
+        html = '<div class="js-view-dom-id-56cf8948b068a635455604d548fcf9d2039b62fd">'
+        result = normalize_html(html)
+        assert "56cf8948" not in result
+        assert "js-view-dom-id-HASH" in result
+
+    def test_drupal_permissions_hash(self):
+        html = '{"user":{"uid":0,"permissionsHash":"c838df03955022ed860389a1310a7a71"}}'
+        result = normalize_html(html)
+        assert "c838df03" not in result
+        assert '"permissionsHash":"HASH"' in result
+
     def test_gewone_content_behouden(self):
         html = "<h1>Digikoppeling Architectuur</h1><p>Standaard tekst.</p>"
         assert normalize_html(html) == html


### PR DESCRIPTION
## Beschrijving

Monitoring genereerde false positive issues door:
1. **Drupal CMS dynamische content** op forumstandaardisatie.nl — CSS/JS aggregatie filenames, view DOM IDs en permissionsHash veranderen bij elke Drupal cache rebuild
2. **Publicatie-Preview repo** — ontvangt meerdere "new preview build" commits per dag by design

## Wijzigingen

- `normalize_html()`: 4 nieuwe Drupal-specifieke normalisatieregels
- `EXCLUDE_PATTERNS`: Publicatie-Preview repo uitgesloten
- 4 nieuwe tests voor Drupal normalisatie

## Issues gesloten

False positives: #30, #31, #32, #33 (forum), #42 (Publicatie-Preview)
Duplicaten: #34, #35, #36, #37, #38, #39

Enige echte issue: #43 (dk URL geeft 403) blijft open.