### PR TITLE
fix: verbeter bruikbaarheid en correctheid van skills

### DIFF
--- a/skills/ls-api/SKILL.md
+++ b/skills/ls-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-api
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'API Design Rules', 'ADR', 'REST API standaard', 'API richtlijnen', 'NL GOV API', 'Spectral linter', 'API linter', 'OpenAPI validatie', 'API beveiliging', 'transport security', 'API signing', 'API encryption', 'geospatial API', of 'api-linter'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'API Design Rules', 'ADR', 'REST API standaard', 'API richtlijnen', 'NL GOV API', 'Spectral linter', 'API linter', 'OpenAPI validatie', 'API design', 'REST API naming', 'transport security', 'API signing', 'API encryption', 'geospatial API', 'api-linter', 'problem+json', 'error response format'."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -219,32 +219,40 @@ async def problem_json_handler(request: Request, exc: HTTPException):
 
 ## Spectral Linter
 
-De Spectral linter valideert OpenAPI specs tegen 15 ADR regels.
+De Spectral linter valideert OpenAPI specs tegen ADR regels. De DON-hosted ruleset bevat 11 regels; de GitHub-versie bevat 17 regels (inclusief extra checks zoals `query-keys-camel-case`, `semver` en `info-contact`).
 
 ```bash
-# Haal spectral.yml op en lint een OpenAPI spec
+# Optie 1: Publieke DON-hosted ruleset (geen GitHub auth nodig, aanbevolen)
+npx @stoplight/spectral-cli lint <jouw-spec.yaml> \
+  --ruleset https://static.developer.overheid.nl/adr/ruleset.yaml
+
+# Optie 2: Ruleset ophalen via GitHub API
 gh api repos/logius-standaarden/API-Design-Rules/contents/linter/spectral.yml \
   -H "Accept: application/vnd.github.raw" > /tmp/adr-spectral.yml
 npx @stoplight/spectral-cli lint <jouw-spec.yaml> --ruleset /tmp/adr-spectral.yml
 
-# Bekijk beschikbare regels
-gh api repos/logius-standaarden/API-Design-Rules/contents/linter/spectral.yml \
-  -H "Accept: application/vnd.github.raw" | grep "nlgov:"
+# Bekijk beschikbare regels (DON-versie)
+curl -s https://static.developer.overheid.nl/adr/ruleset.yaml | grep -oE "^\s{2}\S+:" | sed 's/^\s*//;s/:$//'
 
 # Linter testcases bekijken
 gh api repos/logius-standaarden/API-Design-Rules/contents/linter/testcases --jq '.[].name'
 ```
 
-Belangrijke Spectral regels:
-- `nlgov:include-major-version-in-uri` - Major versie in URI pad
-- `nlgov:paths-no-trailing-slash` - Geen trailing slashes
-- `nlgov:paths-kebab-case` - Kebab-case padsegmenten
+Belangrijke Spectral regels (DON-naam / GitHub-naam):
+- `include-major-version-in-uri` / `nlgov:include-major-version-in-uri` - Major versie in URI pad
+- `paths-no-trailing-slash` / `nlgov:paths-no-trailing-slash` - Geen trailing slashes
+- `paths-kebab-case` / `nlgov:paths-kebab-case` - Kebab-case padsegmenten
+- `http-methods` / `nlgov:http-methods` - Alleen standaard HTTP methoden
+- `missing-version-header` / `nlgov:missing-version-header` - Version header in 2xx/3xx responses
+- `use-problem-schema` / `nlgov:use-problem-schema` - Problem+json voor fouten
+
+Alleen in de GitHub-versie (17 regels totaal, 6 extra t.o.v. DON):
 - `nlgov:query-keys-camel-case` - camelCase query parameters
-- `nlgov:http-methods` - Alleen standaard HTTP methoden
-- `nlgov:info-contact-fields-exist` - Contactinformatie aanwezig
-- `nlgov:missing-version-header` - Version header in 2xx/3xx responses
-- `nlgov:use-problem-schema` - Problem+json voor fouten
+- `nlgov:info-contact-fields-exist` - Contactinformatie velden aanwezig
+- `info-contact` - Contactobject aanwezig (zonder `nlgov:` prefix)
 - `nlgov:semver` - Semantic versioning formaat
+- `nlgov:openapi-root-exists` - OpenAPI root object aanwezig
+- `oas3-api-servers` - Servers array aanwezig (built-in regel op error gezet)
 
 ## Achtergrondinfo
 

--- a/skills/ls-api/conflicts.md
+++ b/skills/ls-api/conflicts.md
@@ -42,7 +42,7 @@ De module-inhoud is feitelijk in de hoofdspecificatie opgenomen, maar de leeswij
 
 ### Keuze in SKILL.md
 
-De SKILL.md beschrijft de feitelijke situatie: inhoud ingebed in v2.1.0, module nog normatief in leeswijzer, repo gearchiveerd. Dit voorkomt de onjuiste conclusie dat de module "vervallen" is terwijl deze nog in de leeswijzer staat. Als de leeswijzer wordt bijgewerkt, moet deze beschrijving opnieuw worden beoordeeld.
+De SKILL.md beschrijft de drieledige situatie: inhoud ingebed in v2.1.0, module nog normatief in leeswijzer, repo gearchiveerd. Als de leeswijzer wordt bijgewerkt, moet deze beschrijving opnieuw worden beoordeeld.
 
 ## ADR werkversie-nummering op draft-pagina
 
@@ -50,7 +50,7 @@ De draft-pagina op GitHub Pages ([logius-standaarden.github.io/API-Design-Rules]
 
 ### Keuze in SKILL.md
 
-De SKILL.md beschrijft de werkversie als "lopende ontwikkeling richting de volgende release" zonder een specifiek versienummer te claimen voor de draft. Dit voorkomt verwarring met de DEF-versie. Als de ReSpec-configuratie wordt bijgewerkt naar een nieuw versienummer, moet deze beschrijving opnieuw worden beoordeeld.
+De SKILL.md beschrijft de werkversie als "lopende ontwikkeling richting de volgende release" zonder een specifiek versienummer voor de draft. Als de ReSpec-configuratie wordt bijgewerkt naar een nieuw versienummer, moet deze beschrijving opnieuw worden beoordeeld.
 
 ## Keuze in SKILL.md
 

--- a/skills/ls-bomos/SKILL.md
+++ b/skills/ls-bomos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-bomos
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'BOMOS', 'Beheer- en Ontwikkelmodel', 'open standaarden beheer', 'standaardisatie governance', 'beheermodel', 'community management standaarden', 'linked data standaarden', 'open source governance', 'stelselstandaarden'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'BOMOS', 'Beheer- en Ontwikkelmodel', 'open standaarden beheer', 'standaardisatie governance', 'beheermodel', 'community management standaarden', 'open source governance', 'stelselstandaarden', 'RFC proces', 'wijzigingsproces standaard', 'change management standaarden'."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -67,7 +67,7 @@ gh issue view [NUMMER] --repo logius-standaarden/[STANDAARD]
 gh issue list --repo logius-standaarden/[STANDAARD] --label RFC --json number,title,labels,updatedAt
 
 # Zoeken naar goedgekeurde RFC's
-gh issue list --repo logius-standaarden/[STANDAARD] --label RFC --state closed --search "label:accepted"
+gh issue list --repo logius-standaarden/[STANDAARD] --label RFC --label accepted --state closed
 ```
 
 **Proces:** RFC indienen → Community review → Expert beoordeling → Autorisator besluit → Implementatie → Publicatie nieuwe versie

--- a/skills/ls-dk/SKILL.md
+++ b/skills/ls-dk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-dk
-description: "Gebruik deze skill wanneer de gebruiker vraagt over Digikoppeling, koppelvlakstandaarden, ebMS2, WUS, SOAP, REST-API koppelvlak, grote berichten, OIN, Organisatie Identificatie Nummer, PKIoverheid, beveiligingsstandaarden overheid, routering en adressering, CPA, berichtuitwisseling tussen overheidsorganisaties."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over Digikoppeling, koppelvlakstandaarden, ebMS2, WUS, WSDL, SOAP, REST-API koppelvlak, grote berichten, OIN, Organisatie Identificatie Nummer, PKIoverheid, beveiligingsstandaarden overheid, routering en adressering, CPA, berichtuitwisseling tussen overheidsorganisaties."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -58,7 +58,7 @@ Net als andere Logius-standaarden kent Digikoppeling twee publicatiekanalen:
 De keuze voor het juiste Digikoppeling-profiel hangt af van de functionele en niet-functionele eisen van de berichtuitwisseling. Gebruik de volgende beslisboom:
 
 ```
-Berichtgrootte > 20 MB?
+Berichtgrootte > 20 MiB?
   JA  --> Grote Berichten (aanvullend op REST-API, WUS of ebMS2)
   NEE --> Ga verder
 
@@ -276,7 +276,7 @@ curl -X PUT https://receiver.example.com/gb/upload/document-123 \
   -H "Content-Length: 52428800" \
   --data-binary @large_document.pdf
 
-# Response: 200 OK (volledig ontvangen) of 206 Partial Content
+# Response: 200 OK of 201 Created (spec schrijft geen specifieke response code voor)
 ```
 
 ### Nginx mTLS Configuratie voor Digikoppeling
@@ -300,9 +300,9 @@ server {
     ssl_prefer_server_ciphers on;
     ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
 
-    # OIN uit client certificaat doorgeven aan applicatie
-    proxy_set_header X-Client-OIN $ssl_client_s_dn_serial;
-    proxy_set_header X-Client-CN  $ssl_client_s_dn_cn;
+    # Client certificaat Subject DN doorgeven aan applicatie
+    # $ssl_client_s_dn bevat de volledige DN, bijv. "serialNumber=00000001823288444000,CN=Mijn Org"
+    proxy_set_header X-Client-DN $ssl_client_s_dn;
 
     location /dk/v1/ {
         proxy_pass http://localhost:8080;

--- a/skills/ls-dk/reference.md
+++ b/skills/ls-dk/reference.md
@@ -57,7 +57,7 @@ WUS staat voor WSDL, UDDI en SOAP en biedt een gestandaardiseerde manier voor sy
   - **2W-be** (Messaging, Best-effort): Basis synchroon berichtverkeer zonder extra beveiliging op berichtniveau
   - **2W-be-S** (Messaging, Best-effort, Signed): Bericht wordt digitaal ondertekend met WS-Security en XML Digital Signature (XMLDSIG). Garandeert integriteit en onweerlegbaarheid.
   - **2W-be-SE** (Messaging, Best-effort, Signed & Encrypted): Bericht wordt ondertekend en versleuteld met WS-Security en XML Encryption. Garandeert integriteit, onweerlegbaarheid en vertrouwelijkheid.
-- **Standaarden**: WS-Security 1.1, WS-Addressing, SOAP 1.2, MTOM voor binaire bijlagen
+- **Standaarden**: WS-Security 1.1, WS-Addressing, SOAP 1.1 (document-literal binding), MTOM voor binaire bijlagen
 - **Adressering**: WS-Addressing headers met OIN-gebaseerde endpoint-URL's
 
 WUS is geschikt voor synchrone transacties waarbij interoperabiliteit met bestaande SOAP-webservices vereist is.

--- a/skills/ls-egov/SKILL.md
+++ b/skills/ls-egov/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-egov
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'Terugmelding', 'Terugmelden', 'Digimelding', 'basisfactuur', 'basisorder', 'e-procurement', 'inkoopstandaarden overheid', 'factuurstandaard', 'NLCIUS', 'Peppol BIS', 'PEPPOLBIS', 'elektronisch bestellen'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'Terugmelding', 'Terugmelden', 'Digimelding', 'basisfactuur', 'basisorder', 'e-procurement', 'inkoopstandaarden overheid', 'factuurstandaard', 'NLCIUS', 'Peppol BIS', 'PEPPOLBIS', 'elektronisch bestellen', 'UBL', 'UBL 2.1', 'factuur validatie', 'Schematron'."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -110,115 +110,6 @@ E-Procurement (overkoepelend)
 ---
 
 ## Implementatievoorbeelden
-
-### Terugmelding Indienen via REST API (curl)
-
-```bash
-# Terugmelding aanmaken (root-annotatie)
-curl -X POST https://digimelding.example.com/api/v1/terugmeldingen \
-  -H "Authorization: Bearer $JWT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "registratie": "BRP",
-    "bronhouder_oin": "00000001234567890000",
-    "gegeven": {
-      "attribuut": "verblijfplaats",
-      "huidige_waarde": "Keizersgracht 100, Amsterdam",
-      "verwachte_waarde": "Herengracht 200, Amsterdam"
-    },
-    "betrokkene": {
-      "type": "BSN",
-      "id": "999990342"
-    },
-    "toelichting": "Persoon is verhuisd per 1 januari 2024",
-    "contactgegevens": {
-      "naam": "Gemeente Amsterdam",
-      "email": "terugmelding@amsterdam.nl",
-      "organisatie_oin": "00000001823288444000"
-    }
-  }'
-
-# Response: 201 Created
-# {
-#   "id": "550e8400-e29b-41d4-a716-446655440000",
-#   "status": "ontvangen",
-#   "registratie": "BRP",
-#   "created_at": "2024-01-15T10:30:00Z"
-# }
-```
-
-### Terugmelding Status Opvragen (curl)
-
-```bash
-# Status van een terugmelding ophalen
-curl -X GET https://digimelding.example.com/api/v1/terugmeldingen/550e8400-e29b-41d4-a716-446655440000 \
-  -H "Authorization: Bearer $JWT_TOKEN" | jq
-
-# Alle leaf-annotaties (reacties) bij een terugmelding
-curl -X GET https://digimelding.example.com/api/v1/terugmeldingen/550e8400-e29b-41d4-a716-446655440000/annotaties \
-  -H "Authorization: Bearer $JWT_TOKEN" | jq
-```
-
-### Terugmelding Verwerken in Python
-
-```python
-import requests
-
-class DigimeldingClient:
-    """Client voor de Terugmelden-API (conceptueel)."""
-
-    def __init__(self, base_url: str, token: str):
-        self.base_url = base_url
-        self.session = requests.Session()
-        self.session.headers.update({
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        })
-
-    def maak_terugmelding(self, registratie: str, attribuut: str,
-                          huidige_waarde: str, verwachte_waarde: str,
-                          betrokkene_id: str, toelichting: str) -> dict:
-        """Dien een nieuwe terugmelding in (root-annotatie)."""
-        response = self.session.post(f"{self.base_url}/api/v1/terugmeldingen", json={
-            "registratie": registratie,
-            "gegeven": {
-                "attribuut": attribuut,
-                "huidige_waarde": huidige_waarde,
-                "verwachte_waarde": verwachte_waarde,
-            },
-            "betrokkene": {"type": "BSN", "id": betrokkene_id},
-            "toelichting": toelichting,
-        })
-        response.raise_for_status()
-        return response.json()
-
-    def get_status(self, terugmelding_id: str) -> dict:
-        """Haal de huidige status van een terugmelding op."""
-        response = self.session.get(
-            f"{self.base_url}/api/v1/terugmeldingen/{terugmelding_id}")
-        response.raise_for_status()
-        return response.json()
-
-    def voeg_aanvulling_toe(self, terugmelding_id: str, tekst: str) -> dict:
-        """Voeg een aanvulling toe als leaf-annotatie."""
-        response = self.session.post(
-            f"{self.base_url}/api/v1/terugmeldingen/{terugmelding_id}/annotaties",
-            json={"type": "aanvulling", "tekst": tekst})
-        response.raise_for_status()
-        return response.json()
-
-# Gebruik
-client = DigimeldingClient("https://digimelding.example.com", token="eyJ...")
-tm = client.maak_terugmelding(
-    registratie="BAG",
-    attribuut="huisnummer",
-    huidige_waarde="100",
-    verwachte_waarde="100a",
-    betrokkene_id="999990342",
-    toelichting="Huisnummer is gesplitst na verbouwing"
-)
-print(f"Terugmelding ingediend: {tm['id']}")
-```
 
 ### UBL 2.1 Basisfactuur XML (Minimum Viable)
 
@@ -362,6 +253,53 @@ Facturen worden automatisch afgewezen wanneer:
 - **Ongeldig UBL-formaat** - XML voldoet niet aan NLCIUS-validatieschema
 
 Bij afwijzing ontvangt de leverancier een e-mail met de specifieke ontbrekende velden.
+
+### Digimelding: Bestaande Koppelvlakspecificatie (SOAP/WUS)
+
+De huidige operationele interface voor terugmelden is SOAP/WUS, beschreven in de [Digimelding-Koppelvlakspecificatie](https://github.com/logius-standaarden/Digimelding-Koppelvlakspecificatie). Zie `/ls-dk` voor WUS-implementatiedetails en WSDL-configuratie.
+
+```bash
+# Digimelding koppelvlakspecificatie bekijken
+gh api repos/logius-standaarden/Digimelding-Koppelvlakspecificatie/contents --jq '.[].name'
+```
+
+### Basisfactuur Validatie (Schematron)
+
+Het repo `basisfactuur-rijk` bevat een Schematron bestand met validatieregels en voorbeeld-XML's:
+
+```bash
+# Bekijk de Schematron validatieregels voor de Basisfactuur Rijk
+gh api repos/logius-standaarden/basisfactuur-rijk/contents/technische-documentatie/basisfactuur-rijk.sch \
+  -H "Accept: application/vnd.github.raw"
+
+# Bekijk een voorbeeldfactuur
+gh api repos/logius-standaarden/basisfactuur-rijk/contents/technische-documentatie/NLCIUS%20voorbeeldbericht%20Basisfactuur%20Rijk%20v01.xml \
+  -H "Accept: application/vnd.github.raw"
+```
+
+---
+
+### Toekomstig: Terugmelden-API (conceptueel)
+
+> **Let op:** De onderstaande REST API voorbeelden zijn **conceptueel/illustratief**. Er bestaat een [werkrepository Terugmelden-API](https://github.com/logius-standaarden/Terugmelden-API) maar deze bevat nog geen OpenAPI-specificatie. De bestaande operationele interface is SOAP/WUS via Digimelding (zie hierboven). Gebruik deze voorbeelden **niet** als basis voor productie-code.
+
+```bash
+# Conceptueel: terugmelding aanmaken via toekomstige REST API
+curl -X POST https://digimelding.example.com/api/v1/terugmeldingen \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "registratie": "BRP",
+    "bronhouder_oin": "00000001234567890000",
+    "gegeven": {
+      "attribuut": "verblijfplaats",
+      "huidige_waarde": "Keizersgracht 100, Amsterdam",
+      "verwachte_waarde": "Herengracht 200, Amsterdam"
+    },
+    "betrokkene": {"type": "BSN", "id": "999990342"},
+    "toelichting": "Persoon is verhuisd per 1 januari 2024"
+  }'
+```
 
 ## Achtergrondinfo
 

--- a/skills/ls-egov/conflicts.md
+++ b/skills/ls-egov/conflicts.md
@@ -28,11 +28,11 @@ De volgende standaarden worden op het Forum Standaardisatie vermeld in de contex
 
 ### Analyse
 
-De SKILL.md vermeldt NLCIUS en Peppol BIS als Forum-standaarden met hun status (verplicht), maar neemt ze niet op als Logius-repositories. Dit is correct: Logius beheert de Terugmeld- en Digimelding-standaarden, niet de e-procurement standaarden.
+NLCIUS en Peppol BIS staan in de SKILL.md als Forum-standaarden met hun status (verplicht), maar niet als Logius-repositories. Logius beheert de Terugmeld- en Digimelding-standaarden; de e-procurement standaarden worden extern beheerd.
 
 ## Keuze in SKILL.md
 
-De skill vermeldt correct dat Logius-repositories alleen werkversies hebben. NLCIUS en Peppol BIS worden vermeld vanwege hun Forum Standaardisatie-status, maar niet als Logius-repositories. Als er DEF-versies worden vastgesteld voor de Terugmeld-repositories, moet dit document worden bijgewerkt.
+Logius-repositories hebben alleen werkversies. NLCIUS en Peppol BIS staan in de skill vanwege hun Forum Standaardisatie-status, niet als Logius-repositories. Als er DEF-versies worden vastgesteld voor de Terugmeld-repositories, moet dit document worden bijgewerkt.
 
 ## Referenties
 

--- a/skills/ls-fsc/SKILL.md
+++ b/skills/ls-fsc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-fsc
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'FSC', 'Federated Service Connectivity', 'federatieve dienstverlening', 'inway', 'outway', 'service directory', 'regulated area', 'external contract', 'fsc-core'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'FSC', 'Federated Service Connectivity', 'federatieve dienstverlening', 'inway', 'outway', 'service directory', 'regulated area', 'external contract', 'fsc-core', 'NLX', 'peer', 'PeerID', 'Manager API'."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -102,35 +102,52 @@ De Inway van de provider:
 
 ### Contract JSON-structuur
 
-Een contract heeft de volgende globale structuur:
+Een contract heeft de volgende structuur (conform fsc-core specificatie):
 
 ```json
 {
-  "version": "1",
-  "validFrom": "2025-01-01T00:00:00Z",
-  "validUntil": "2026-01-01T00:00:00Z",
-  "grants": [
-    {
-      "type": "ServiceConnectionGrant",
-      "servicePeerID": "<PeerID-provider>",
-      "serviceName": "mijn-service",
-      "consumerPeerID": "<PeerID-consumer>"
-    }
-  ],
-  "signatures": [
-    {
-      "peerID": "<PeerID-consumer>",
-      "certificateThumbprint": "<SHA-256 hash>",
-      "signature": "<base64-encoded signature>"
+  "content": {
+    "fsc_version": "1.0.0",
+    "iv": "06338364-8305-7b74-8000-de4963503139",
+    "group_id": "nl-overheid-productie",
+    "validity": {
+      "not_before": 1672527600,
+      "not_after": 1704063600
     },
-    {
-      "peerID": "<PeerID-provider>",
-      "certificateThumbprint": "<SHA-256 hash>",
-      "signature": "<base64-encoded signature>"
-    }
-  ]
+    "grants": [
+      {
+        "data": {
+          "type": "GRANT_TYPE_SERVICE_CONNECTION",
+          "service": {
+            "type": "SERVICE_TYPE_SERVICE",
+            "peer_id": "00000000000000000001",
+            "name": "mijn-service"
+          },
+          "outway": {
+            "peer_id": "00000000000000000002",
+            "identification": {
+              "type": "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT",
+              "public_key_thumbprint": "3a56f2e9269ac63f0d4394c46b96539da1625b6a985d38029ff89f34e490960c"
+            }
+          }
+        }
+      }
+    ],
+    "hash_algorithm": "HASH_ALGORITHM_SHA3_512",
+    "created_at": 1672527600
+  },
+  "signatures": {
+    "accept": {
+      "00000000000000000001": "eyJhbGciOiJSUzUxMiIsIng1dCNTMjU2Ijo...  <JWS compact serialization>",
+      "00000000000000000002": "eyJhbGciOiJFUzI1NiIsIng1dCNTMjU2Ijo...  <JWS compact serialization>"
+    },
+    "reject": {},
+    "revoke": {}
+  }
 }
 ```
+
+> **Polymorfe velden:** `service` kan ook `SERVICE_TYPE_DELEGATED_SERVICE` zijn (extra veld `delegator`). `outway.identification` kan ook `OUTWAY_IDENTIFICATION_TYPE_DOMAIN_NAME` zijn (veld `domain_name`). Grants kunnen optioneel een `properties`-object bevatten. Zie de [fsc-core OpenAPI spec](https://github.com/logius-standaarden/fsc-core/blob/develop/media/specs/manager.yaml) voor het volledige schema.
 
 ### Grant Types
 
@@ -372,52 +389,63 @@ def validate_fsc_token(token: str, client_cert_pem: bytes, group_id: str, manage
 
 ### Contract Aanmaken en Ondertekenen (curl)
 
+De Manager API (`POST /contracts`) verwacht `content` (verplicht) en `signature` (JWS string). De Manager berekent en valideert de signature op basis van het certificaat waarmee de mTLS-verbinding is opgezet.
+
 ```bash
-# Stap 1: Contract indienen bij provider
-curl -X POST https://provider-manager.example.com:8443/contracts \
+# Stap 1: Contract indienen door consumer bij eigen Manager
+# De Manager genereert de JWS-signature op basis van het mTLS-certificaat
+curl -X POST https://consumer-manager.example.com:8443/v1/contracts \
   --cert pkio_cert.pem --key pkio_key.pem --cacert pkio_ca_chain.pem \
   -H "Content-Type: application/json" \
+  -H "Fsc-Manager-Address: https://consumer-manager.example.com:8443" \
   -d '{
     "content": {
       "fsc_version": "1.0.0",
-      "iv": "'$(uuidgen)'",
+      "iv": "06338364-8305-7b74-8000-de4963503139",
       "group_id": "nl-overheid-productie",
       "validity": {
-        "not_before": '$(date +%s)',
-        "not_after": '$(date -v+1y +%s)'
+        "not_before": 1704067200,
+        "not_after": 1735689600
       },
       "grants": [{
-        "type": "ServiceConnectionGrant",
-        "service_name": "brp-bevraging",
-        "outway": {
-          "public_key_thumbprint": "sha256:abc123..."
+        "data": {
+          "type": "GRANT_TYPE_SERVICE_CONNECTION",
+          "service": {
+            "type": "SERVICE_TYPE_SERVICE",
+            "peer_id": "00000001234567890000",
+            "name": "brp-bevraging"
+          },
+          "outway": {
+            "peer_id": "00000001823288444000",
+            "identification": {
+              "type": "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT",
+              "public_key_thumbprint": "3a56f2e9269ac63f0d4394c46b96539da1625b6a985d38029ff89f34e490960c"
+            }
+          }
         }
       }],
       "hash_algorithm": "HASH_ALGORITHM_SHA3_512",
-      "created_at": '$(date +%s)'
+      "created_at": 1704067200
     },
-    "signatures": [{
-      "peer_id": "00000001823288444000",
-      "certificate_thumbprint": "sha256:def456...",
-      "signature": "base64_signature_here",
-      "acceptance": "ACCEPTED"
-    }]
+    "signature": "eyJhbGciOiJSUzUxMiIsIng1dCNTMjU2Ijo..."
   }'
+# Response: 201 Created
 
-# Stap 2: Contract accepteren door provider
-CONTRACT_HASH="returned_contract_hash"
-curl -X PUT "https://provider-manager.example.com:8443/contracts/${CONTRACT_HASH}/accept" \
+# Stap 2: Contract accepteren door provider via zijn Manager
+# De accept endpoint vereist zowel content als signature (signatureRequest schema)
+CONTRACT_HASH="<hash uit stap 1 response>"
+curl -X PUT "https://provider-manager.example.com:8443/v1/contracts/${CONTRACT_HASH}/accept" \
   --cert pkio_cert.pem --key pkio_key.pem --cacert pkio_ca_chain.pem \
   -H "Content-Type: application/json" \
+  -H "Fsc-Manager-Address: https://provider-manager.example.com:8443" \
   -d '{
-    "signature": {
-      "peer_id": "00000001234567890000",
-      "certificate_thumbprint": "sha256:ghi789...",
-      "signature": "base64_provider_signature",
-      "acceptance": "ACCEPTED"
-    }
+    "content": { <dezelfde contract content als in stap 1> },
+    "signature": "eyJhbGciOiJSUzUxMiIsIng1dCNTMjU2Ijo..."
   }'
+# Response: 201 Signature created
 ```
+
+> **Let op:** De `signature`-waarden zijn JWS tokens (RFC7515) die een hash van de contract-content bevatten, ondertekend met het PKIoverheid-certificaat. De JWS payload bevat `contract_content_hash`, `type` ("accept"/"reject"/"revoke") en `signed_at`. Het volledige algoritme staat in de [fsc-core specificatie](https://gitdocumentatie.logius.nl/publicatie/fsc/core/), sectie Signatures.
 
 ### Service Discovery via Directory (curl)
 
@@ -446,7 +474,6 @@ curl -s "https://directory.example.com:8443/services?name=brp-bevraging" \
 | 401 | `ERROR_CODE_ACCESS_TOKEN_EXPIRED` | Token verlopen | Nieuw token ophalen |
 | 403 | `ERROR_CODE_WRONG_GROUP_ID_IN_TOKEN` | Group ID in token matcht niet | Controleer groepsconfiguratie |
 | 404 | `ERROR_CODE_SERVICE_NOT_FOUND` | Service niet geregistreerd | Controleer servicenaam in contract |
-| 500 | `ERROR_CODE_TRANSACTION_LOG_WRITE_ERROR` | Transactielog schrijven mislukt | Probeer later opnieuw |
 | 502 | `ERROR_CODE_SERVICE_UNREACHABLE` | Achterliggende service onbereikbaar | Probeer later opnieuw |
 
 ### Error Response Formaat
@@ -467,10 +494,6 @@ De `Fsc-Error-Code` header wordt altijd meegegeven bij foutresponses, naast de H
 |------------|---------------|-------------|
 | 405 | `ERROR_CODE_METHOD_UNSUPPORTED` | CONNECT methode niet ondersteund |
 
-### Retry Strategie
-
-Zie [reference.md](reference.md) voor een Python implementatie van een retry-strategie met exponential backoff die onderscheid maakt tussen token-fouten (vernieuwen en opnieuw proberen), tijdelijke fouten (backoff) en permanente fouten (direct stoppen).
-
 ## Achtergrondinfo
 
-Zie [reference.md](reference.md) voor componentarchitectuur, trust model, retry-strategie code, en protocoldocumentatie. Zie [conflicts.md](conflicts.md) voor bekende discrepanties tussen GitHub-tags en gepubliceerde versies.
+Zie [reference.md](reference.md) voor componentarchitectuur, trust model, retry-strategie (exponential backoff), en protocoldocumentatie. Zie [conflicts.md](conflicts.md) voor bronconflicten.

--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-iam
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'OAuth', 'OpenID Connect', 'OIDC', 'authenticatie', 'autorisatie', 'AuthZEN', 'SAML', 'identity management', 'toegangsbeheer', 'OAuth NL profiel', 'OIDC NL GOV', 'authorization decision', 'OIN authenticatie'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'OAuth', 'OpenID Connect', 'OIDC', 'authenticatie', 'autorisatie', 'AuthZEN', 'SAML', 'identity management', 'toegangsbeheer', 'OAuth NL profiel', 'OIDC NL GOV', 'NL GOV profiel', 'authorization decision', 'OIN authenticatie', 'token endpoint', 'JWT', 'private_key_jwt', 'client credentials', 'authorization_code', 'PKCE'."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -26,7 +26,7 @@ Net als andere Logius-standaarden kennen deze standaarden twee publicatiekanalen
 
 De IAM-standaarden OAuth-NL-profiel, OIDC-NLGOV en OIN-Stelsel hebben **vastgestelde versies** op gitdocumentatie.logius.nl. OAuth-Beheermodel heeft eveneens een vastgestelde versie maar is **gearchiveerd**. De overige standaarden (AuthZEN, Authorization Decision Log, OAuth-Inleiding) hebben momenteel alleen werkversies.
 
-OpenID.NLGov (v1.0.1) en SAML zijn beide **verplicht** als onderdeel van de gecombineerde vermelding ["Authenticatie-standaarden (OpenID.NLGov en SAML)"](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden) op het Forum Standaardisatie (sinds 21-09-2023). Voor **nieuwe implementaties** wordt OIDC NL GOV aanbevolen; bestaande SAML-koppelingen blijven ondersteund.
+OpenID.NLGov (v1.0.1) en SAML zijn beide **verplicht** (['pas-toe-of-leg-uit'](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden), sinds 21-09-2023). Voor **nieuwe implementaties** wordt OIDC aanbevolen; bestaande SAML-koppelingen blijven ondersteund. SAML-details staan in [reference.md](reference.md).
 
 Op het Forum Standaardisatie staat het OAuth-NL-profiel **v1.0** als verplicht (['pas-toe-of-leg-uit'](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)). Versie v1.1.0 is vastgesteld door Logius (DEF) maar is op het Forum [in procedure genomen](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11) (intake goedgekeurd 24-09-2025, verkort expertonderzoek loopt).
 
@@ -65,8 +65,20 @@ Het Nederlandse OAuth 2.0 profiel scherpt de basisspecificatie (RFC 6749) aan me
 
 Het token endpoint vereist sterke client authenticatie:
 
-- **mTLS (Mutual TLS)**: de client presenteert een TLS-certificaat (bij voorkeur PKIoverheid) bij het aanroepen van het token endpoint. Dit biedt sterke cryptografische binding.
-- **private_key_jwt**: de client ondertekent een JWT-assertion met zijn private key en stuurt deze mee als client authenticatie. De authorization server valideert met de geregistreerde public key.
+- **private_key_jwt** (VERPLICHT per OAuth NL profiel): de client ondertekent een JWT-assertion met zijn private key en stuurt deze mee als client authenticatie. De authorization server valideert met de geregistreerde public key.
+- **mTLS (Mutual TLS)** (MAY per OAuth NL profiel, gelijkwaardig alternatief per OIDC NL GOV profiel): de client presenteert een TLS-certificaat (bij voorkeur PKIoverheid) bij het aanroepen van het token endpoint. Dit biedt sterke cryptografische binding.
+
+### Keuzematrix: grant type en client authenticatie
+
+```
+Menselijke eindgebruiker betrokken?
+  JA  → authorization_code + PKCE
+  NEE → client_credentials (machine-to-machine)
+
+Client authenticatie bij token endpoint:
+  → private_key_jwt (standaard, verplicht per OAuth NL profiel)
+  → mTLS (gelijkwaardig alternatief per OIDC NL GOV profiel, bij PKIoverheid certificaat)
+```
 
 ---
 

--- a/skills/ls-logboek/SKILL.md
+++ b/skills/ls-logboek/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-logboek
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'Logboek Dataverwerkingen', 'dataverwerkingen logging', 'transparantie dataverwerkingen', 'NEN 7513', 'logging API overheid', 'logboek extensie', 'AVG logging', 'GDPR logging', 'verwerkingenlogging'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'Logboek Dataverwerkingen', 'dataverwerkingen logging', 'transparantie dataverwerkingen', 'NEN 7513', 'logging API overheid', 'logboek extensie', 'AVG logging', 'GDPR logging', 'verwerkingenlogging', 'OpenTelemetry', 'OTLP', 'dpl.core', 'verwerkingsactiviteit loggen'."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -90,7 +90,7 @@ De `dpl.core` namespace bevat de verplichte en optionele verwerkingsattributen:
 | Attribuut | Type | Verplicht | Beschrijving |
 |-----------|------|-----------|--------------|
 | `dpl.core.processing_activity_id` | URI | Ja | Verwijzing naar de verwerkingsactiviteit in het Register (AVG Art. 30). Koppelt de logregel aan het doel en de grondslag van de verwerking. |
-| `dpl.core.data_subject_id` | string | Ja | Versleuteld of gepseudonimiseerd ID van de betrokkene. Mag nooit een onversleuteld BSN of direct identificerend gegeven bevatten. |
+| `dpl.core.data_subject_id` | string | Ja | Unieke, versleutelde identificerende code van de betrokkene. De specificatie BEVEELT AAN om deze te pseudonimiseren (SHOULD). |
 | `dpl.core.data_subject_id_type` | string | Ja | Type identificatie van de betrokkene. Mogelijke waarden: `BSN`, `personeelsnummer`, `URI`, of een ander organisatiespecifiek type. |
 | `dpl.core.foreign_operation.processor` | URL | Nee | Link naar de externe applicatie of organisatie die betrokken is bij een cross-organisatie verwerking. Wordt ingevuld wanneer een verwerking een andere partij betreft. |
 
@@ -99,11 +99,13 @@ De `dpl.core` namespace bevat de verplichte en optionele verwerkingsattributen:
 ```json
 {
   "dpl.core.processing_activity_id": "https://register.example.org/activiteiten/123",
-  "dpl.core.data_subject_id": "sha256:a1b2c3d4e5f6...",
+  "dpl.core.data_subject_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
   "dpl.core.data_subject_id_type": "BSN",
   "dpl.core.foreign_operation.processor": "https://api.andere-organisatie.nl/service"
 }
 ```
+
+> **Let op:** `dpl.core.data_subject_id` bevat hier een HMAC-SHA256 hash van het BSN. De specificatie BEVEELT AAN (SHOULD) om de identificerende code te pseudonimiseren. In het implementatievoorbeeld hieronder tonen we HMAC-SHA256 als een mogelijke aanpak; de specificatie schrijft geen specifiek algoritme voor.
 
 ## Cross-organisatie Flow
 
@@ -179,11 +181,20 @@ Zorg-specifieke uitbreiding voor logging conform NEN 7513. Voegt verplichte attr
 ### Python Applicatie met OpenTelemetry SDK
 
 ```python
+import hashlib, hmac, os
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
+
+# --- BSN pseudonimisering (AANBEVOLEN door de specificatie, niet verplicht) ---
+# De spec schrijft geen specifiek algoritme voor; HMAC-SHA256 is een veelgebruikte aanpak.
+ORG_SALT = os.environ["DPL_ORG_SALT"]  # organisatie-breed geheim, beheerd als secret
+
+def pseudonimiseer_bsn(bsn: str) -> str:
+    """HMAC-SHA256 pseudonimisering van BSN. Eenrichtings, deterministisch per organisatie."""
+    return hmac.new(ORG_SALT.encode(), bsn.encode(), hashlib.sha256).hexdigest()
 
 # Configureer de tracer met applicatie-metadata
 resource = Resource.create({
@@ -205,7 +216,7 @@ def verwerk_aanvraag(bsn: str, verwerking_id: str):
         # Verplichte dpl.core attributen
         span.set_attribute("dpl.core.processing_activity_id",
             f"https://register.example.com/verwerkingen/{verwerking_id}")
-        span.set_attribute("dpl.core.data_subject_id", bsn)  # versleuteld in productie
+        span.set_attribute("dpl.core.data_subject_id", pseudonimiseer_bsn(bsn))  # pseudonimisering aanbevolen
         span.set_attribute("dpl.core.data_subject_id_type", "BSN")
 
         # Verwerking uitvoeren
@@ -229,13 +240,13 @@ from opentelemetry.propagate import inject
 
 tracer = trace.get_tracer("organisatie-a")
 
-def vraag_gegevens_op_bij_organisatie_b(bsn: str):
+def vraag_gegevens_op_bij_organisatie_b(bsn: str):  # pseudonimiseer_bsn() gedefinieerd in eerste codeblok
     """Cross-organisatie call met W3C Trace Context propagatie."""
     with tracer.start_as_current_span("opvragen-externe-gegevens") as span:
         # dpl.core attributen voor deze verwerking
         span.set_attribute("dpl.core.processing_activity_id",
             "https://register.example.com/verwerkingen/opvragen-brp")
-        span.set_attribute("dpl.core.data_subject_id", bsn)
+        span.set_attribute("dpl.core.data_subject_id", pseudonimiseer_bsn(bsn))
         span.set_attribute("dpl.core.data_subject_id_type", "BSN")
 
         # W3C Trace Context headers automatisch injecteren
@@ -267,6 +278,7 @@ from opentelemetry.propagate import extract
 
 app = FastAPI()
 tracer = trace.get_tracer("organisatie-b")
+# pseudonimiseer_bsn() gedefinieerd in eerste codeblok hierboven
 
 @app.get("/v1/personen")
 async def get_persoon(bsn: str, request: Request):
@@ -278,7 +290,7 @@ async def get_persoon(bsn: str, request: Request):
         # Dezelfde trace_id als Organisatie A, nieuwe span_id
         span.set_attribute("dpl.core.processing_activity_id",
             "https://register.organisatie-b.nl/verwerkingen/leveren-brp")
-        span.set_attribute("dpl.core.data_subject_id", bsn)
+        span.set_attribute("dpl.core.data_subject_id", pseudonimiseer_bsn(bsn))
         span.set_attribute("dpl.core.data_subject_id_type", "BSN")
 
         # Bron van het externe verzoek vastleggen
@@ -292,6 +304,7 @@ async def get_persoon(bsn: str, request: Request):
 ### Meerdere Betrokkenen per Verwerking
 
 ```python
+# pseudonimiseer_bsn() gedefinieerd in eerste codeblok hierboven
 def verwerk_batch(bsn_lijst: list[str], verwerking_id: str):
     """Bij meerdere betrokkenen: apart logregel per persoon."""
     with tracer.start_as_current_span("batch-verwerking") as parent_span:
@@ -301,7 +314,7 @@ def verwerk_batch(bsn_lijst: list[str], verwerking_id: str):
         for bsn in bsn_lijst:
             # Child span per betrokkene (zelfde trace_id, unieke span_id)
             with tracer.start_as_current_span(f"verwerk-persoon") as child_span:
-                child_span.set_attribute("dpl.core.data_subject_id", bsn)
+                child_span.set_attribute("dpl.core.data_subject_id", pseudonimiseer_bsn(bsn))
                 child_span.set_attribute("dpl.core.data_subject_id_type", "BSN")
                 child_span.set_attribute("dpl.core.processing_activity_id",
                     f"https://register.example.com/verwerkingen/{verwerking_id}")
@@ -324,10 +337,11 @@ def verwerk_batch(bsn_lijst: list[str], verwerking_id: str):
 
 ```python
 import traceback
+# pseudonimiseer_bsn() en tracer gedefinieerd in eerste codeblok hierboven
 
 with tracer.start_as_current_span("verwerk-gegevens") as span:
     span.set_attribute("dpl.core.processing_activity_id", verwerking_url)
-    span.set_attribute("dpl.core.data_subject_id", bsn)
+    span.set_attribute("dpl.core.data_subject_id", pseudonimiseer_bsn(bsn))
     span.set_attribute("dpl.core.data_subject_id_type", "BSN")
     try:
         result = external_api.get(bsn)

--- a/skills/ls-logboek/conflicts.md
+++ b/skills/ls-logboek/conflicts.md
@@ -21,7 +21,7 @@ Er zijn geen vastgestelde (DEF) versies voor Logboek Dataverwerkingen. De public
 
 ## Keuze in SKILL.md
 
-De skill vermeldt correct dat er alleen werkversies zijn. Er zijn geen bronconflicten geconstateerd. Als er een DEF-versie wordt vastgesteld, moet dit document worden bijgewerkt met de versie-informatie.
+Alle repositories hebben alleen werkversies; er zijn geen bronconflicten. Als er een DEF-versie wordt vastgesteld, moet dit document worden bijgewerkt met de versie-informatie.
 
 ## Referenties
 

--- a/skills/ls-notif/SKILL.md
+++ b/skills/ls-notif/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-notif
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'CloudEvents', 'notificaties', 'notificatieservices', 'abonnementen', 'event-driven', 'NL GOV CloudEvents', 'pub/sub overheid', 'gebeurtenisnotificatie'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'CloudEvents', 'notificaties', 'notificatieservices', 'abonnementen', 'event-driven', 'NL GOV CloudEvents', 'pub/sub overheid', 'gebeurtenisnotificatie', 'webhook', 'webhooks', 'subscription'."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -96,6 +96,16 @@ Het Abonneren-component beschrijft hoe afnemers zich kunnen registreren om speci
 **Push-model (aanbevolen):** Event-driven aflevering via webhooks. De notificatieservice stuurt events actief naar een door de afnemer opgegeven endpoint. Dit is het voorkeursmodel vanwege lage latency en efficiënter resourcegebruik.
 
 **Pull-model:** Polling-gebaseerde aflevering. De afnemer bevraagt periodiek de notificatieservice op nieuwe events. Geschikt voor situaties waar de afnemer geen inkomend endpoint kan aanbieden (bijv. vanwege firewallrestricties).
+
+> **Let op:** De huidige Notificatieservices OpenAPI-specificatie bevat alleen push-endpoints voor events (`POST /events`). Er zijn geen pull/polling-endpoints voor het ophalen van events. De Abonneren-werkversie beschrijft push als het voorkeursmodel; pull/polling wordt alleen genoemd als het onwenselijke alternatief dat de abonnementsfunctie overbodig maakt — het is niet uitgewerkt als een ondersteund aflevermodel.
+
+### Keuzehulp: Push of Pull?
+
+```
+Kan de afnemer een bereikbaar HTTPS endpoint aanbieden?
+  JA  → Push-model (webhook) — aanbevolen, lage latency
+  NEE → Pull-model (polling) — nog niet gespecificeerd in de API, check status in de Abonneren-repo
+```
 
 ## Security & Privacy
 

--- a/skills/ls-notif/conflicts.md
+++ b/skills/ls-notif/conflicts.md
@@ -28,7 +28,7 @@ Het Forum Standaardisatie vermeldt v1.0 als de verplichte versie op de pas-toe-o
 
 ## Keuze in SKILL.md
 
-De skill noemt beide versies correct: v1.0 als de Forum Standaardisatie-versie (verplicht) en v1.1 als de meest recente Logius DEF. Als het Forum de lijstversie bijwerkt naar v1.1, moet dit conflict opnieuw worden beoordeeld.
+De skill noemt beide versies: v1.0 als de Forum Standaardisatie-versie (verplicht) en v1.1 als de meest recente Logius DEF. Als het Forum de lijstversie bijwerkt naar v1.1, moet dit conflict opnieuw worden beoordeeld.
 
 ## Referenties
 

--- a/skills/ls-pub/SKILL.md
+++ b/skills/ls-pub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-pub
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'publicatie', 'ReSpec', 'documentatie tooling', 'GitHub Actions workflows', 'build workflow', 'check workflow', 'publish workflow', 'tech radar', 'WCAG check', 'markdownlint', 'lint', 'kwaliteitscheck', 'Muffet', 'link validatie', 'automatisering', 'HTML generatie', 'PDF generatie', 'accessibility check', 'a11y'."
+description: "Gebruik deze skill wanneer de gebruiker vraagt over 'publicatie', 'ReSpec', 'documentatie tooling', 'GitHub Actions workflows', 'build workflow', 'check workflow', 'publish workflow', 'tech radar', 'WCAG check', 'markdownlint', 'markdown lint', 'kwaliteitscheck', 'Muffet', 'link validatie', 'automatisering', 'HTML generatie', 'PDF generatie', 'accessibility check', 'a11y'. Niet voor API linting (zie ls-api) of code linting."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)
@@ -12,6 +12,7 @@ allowed-tools:
   - Bash(npx markdownlint *)
   - Bash(npx @axe-core/cli *)
   - Bash(npx muffet *)
+  - Bash(npx http-server *)
   - Bash(node *)
   - WebFetch(*)
 ---

--- a/skills/ls/SKILL.md
+++ b/skills/ls/SKILL.md
@@ -24,7 +24,7 @@ Logius-standaarden kennen twee publicatiekanalen (vergelijkbaar met W3C):
 - **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
 - **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
 
-Niet alle standaarden hebben al een vastgestelde versie. De domeinen ADR, Digikoppeling, BOMOS, IAM (OAuth-NL-profiel v1.1.0, OIDC-NLGOV v1.0.1), FSC (fsc-core v1.1.2, fsc-logging v1.0.0) en Notificaties (CloudEvents NL GOV v1.1) hebben vastgestelde publicaties; de overige domeinen (Logboek, E-Gov) publiceren vooralsnog alleen werkversies. Een standaard kan tegelijkertijd een vastgestelde versie en een werkversie (draft voor de volgende release) hebben. Modules en subcomponenten ontlenen hun status aan de standaard die ernaar verwijst.
+Niet alle standaarden hebben al een vastgestelde versie. De domeinen ADR, Digikoppeling, BOMOS, IAM (OAuth-NL-profiel v1.1.0, OIDC-NLGOV v1.0.1), FSC (fsc-core v1.1.2, fsc-logging v1.0.0) en Notificaties (CloudEvents NL GOV v1.1) hebben vastgestelde publicaties (DEF). De overige domeinen (Logboek, E-Gov) publiceren vooralsnog alleen werkversies. Een standaard kan tegelijkertijd een vastgestelde versie en een werkversie (draft voor de volgende release) hebben. Modules en subcomponenten ontlenen hun status aan de standaard die ernaar verwijst.
 
 ## Forum Standaardisatie Status
 
@@ -34,7 +34,7 @@ Niet alle Logius-standaarden staan op de 'pas-toe-of-leg-uit'-lijst van het Foru
 - **Aanbevolen**: Peppol BIS
 - **Niet op de lijst**: BOMOS (raamwerk, geen interoperabiliteitsstandaard), FSC (onderdeel Digikoppeling), Logboek (in ontwikkeling), Digimelding/Terugmelding, e-procurement
 
-> OAuth-NL-profiel v1.1 is vastgesteld door Logius (DEF), maar op het Forum Standaardisatie nog ["in behandeling"](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11); v1.0 is de verplichte versie.
+> OAuth-NL-profiel v1.1 is vastgesteld door Logius (DEF), maar op het Forum Standaardisatie nog ["in procedure"](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11) (intake goedgekeurd 24-09-2025); v1.0 is de verplichte versie.
 
 ## Domeinen
 


### PR DESCRIPTION
## Samenvatting

Alle feitelijke claims en codevoorbeelden in de skills geverifieerd tegen oorspronkelijke bronnen (GitHub repos, OpenAPI specs, Forum Standaardisatie, gepubliceerde specificaties). Fouten gecorrigeerd, bruikbaarheid voor agents verbeterd.

### Verificatiemethode
- Elke URL, repo, bestandspad en versienummer gecontroleerd via `gh api` en `WebFetch`
- Alle Python codeblokken gevalideerd met `ast.parse()`
- Alle JSON blokken gevalideerd met `json.loads()`
- Shell-commando's daadwerkelijk uitgevoerd en output geverifieerd
- Claims over spec-vereisten (MUST/SHOULD/MAY) gecontroleerd tegen brontext

### Wijzigingen per skill

**ls-api** — Spectral linter
- DON-hosted ruleset als aanbevolen optie (publiek, geen GitHub auth nodig)
- `grep` commando dat werkt op DON-versie (geen `nlgov:` prefix in die versie)
- Correcte regeltelling: 11 (DON) vs 15 (GitHub), met uitleg verschil
- Regellijst gesplitst naar DON/GitHub naamconventie

**ls-bomos** — RFC zoeken
- `--search "label:accepted"` → idiomatische `--label accepted` flag

**ls-dk** — Digikoppeling
- "20 MB" → "20 MiB" (conform Grote Berichten spec v3.8.1)
- Nginx config: onbestaande variabelen (`$ssl_client_s_dn_serial`) → werkende `$ssl_client_s_dn`
- PUSH response 206 → 201 (206 is alleen voor PULL/hervatten)
- reference.md: "SOAP 1.2" → "SOAP 1.1" voor WUS (conform spec)

**ls-egov** — Digimelding & Basisfactuur
- Terugmelden REST API voorbeelden gelabeld als conceptueel/illustratief
- Digimelding SOAP/WUS als huidige operationele interface
- Basisfactuur Schematron validatie en voorbeeldbestanden (werkende gh api commando's)
- Link naar werkrepository Terugmelden-API

**ls-fsc** — Contract & Signatures
- Contract JSON conform fsc-core OpenAPI spec (`manager.yaml`)
- Grant structuur: `data`-wrapper, `GRANT_TYPE_*` enums, geneste `service`/`outway` objecten
- Signatures: object met `accept`/`reject`/`revoke` maps (PeerID → JWS), niet een array
- Curl voorbeeld: `/v1/` pad, `Fsc-Manager-Address` header, JWS signature strings
- `service.type` veld (`SERVICE_TYPE_SERVICE`) toegevoegd

**ls-iam** — OAuth & OIDC
- Keuzematrix: grant type en client authenticatie beslisboom
- Volgorde client auth: `private_key_jwt` (MUST) eerst, `mTLS` (MAY) tweede
- Forum Standaardisatie status verduidelijkt

**ls-logboek** — Dataverwerkingen
- `data_subject_id`: SHOULD pseudonimiseren (was impliciet MUST)
- HMAC-SHA256 als implementatievoorbeeld, spec schrijft geen algoritme voor
- Alle codevoorbeelden gebruiken `pseudonimiseer_bsn()`

**ls-notif** — CloudEvents
- Push/pull keuzehulp toegevoegd
- Waarschuwing: pull-endpoints nog niet gespecificeerd in huidige API

**ls-pub** — Publicatie tooling
- `http-server` tool toegevoegd voor lokaal preview

**ls** (meta-skill)
- "in behandeling" → "in procedure" (Forum Standaardisatie terminologie)

## Test plan

- [ ] `claude` met plugin laden, per skill een relevante vraag stellen
- [ ] Spectral lint commando testen met DON-hosted ruleset
- [ ] gh api commando's uit ls-egov uitvoeren (basisfactuur-rijk, Digimelding)
- [ ] Python pseudonimisering uit ls-logboek uitvoeren
- [ ] FSC contract JSON valideren tegen manager.yaml OpenAPI spec