### PR TITLE
fix: corrigeer feitelijke onjuistheden in skills na grondige verificatie

### DIFF
--- a/skills/ls-bomos/reference.md
+++ b/skills/ls-bomos/reference.md
@@ -26,6 +26,7 @@ De tactieklaag vertaalt strategie naar concrete beheerafspraken en kwaliteitsnor
 - **Adoptiestrategie** - Beleid voor het bevorderen van adoptie: verplichte open standaarden lijsten, comply-or-explain
 - **Kwaliteitsbeleid** - Kwaliteitscriteria voor de standaard zelf en het beheerproces
 - **Rechtenmanagement** - Intellectueel eigendom, licentiemodel, en gebruiksvoorwaarden
+- **Community** - Opbouwen en onderhouden van een actieve community van gebruikers en ontwikkelaars
 
 **Rol:** Autorisator
 
@@ -38,6 +39,7 @@ De operationele laag omvat het daadwerkelijke dagelijkse werk van standaardontwi
 - **Ontwikkeling** - Technische uitwerking van wijzigingen, review, en oplevering van nieuwe versies
 - **Uitvoering** - Doorvoeren van goedgekeurde wijzigingen in de operationele omgeving
 - **Documentatie** - Bijhouden van alle documentatie: specificaties, release notes, handleidingen
+- **Klachtenafhandeling** - Proces voor het ontvangen, registreren en afhandelen van klachten van gebruikers
 
 **Rollen:** Functioneel Beheerder, Technisch Beheerder
 
@@ -56,9 +58,7 @@ Deze laag ondersteunt organisaties bij de daadwerkelijke implementatie van de st
 De communicatielaag zorgt voor zichtbaarheid en betrokkenheid rond de standaard.
 
 - **Promotie** - Actieve promotie van de standaard bij potentiële gebruikers en stakeholders
-- **Community management** - Opbouwen en onderhouden van een actieve community van gebruikers en ontwikkelaars
-- **Events** - Organiseren van bijeenkomsten, werkgroepen, en plugfests
-- **Distributie** - Publicatie en verspreiding van de standaard en bijbehorende documentatie
+- **Publicatie** - Publicatie en verspreiding van de standaard en bijbehorende documentatie
 
 **Rol:** Distributeur
 

--- a/skills/ls-dk/reference.md
+++ b/skills/ls-dk/reference.md
@@ -87,9 +87,9 @@ ebMS2 is geschikt voor scenario's waar betrouwbare, asynchrone aflevering essent
 
 ### Grote Berichten
 
-De koppelvlakstandaard Grote Berichten biedt een oplossing voor het uitwisselen van berichten groter dan 20 MB. Het gebruikt het claim-check patroon: het grote bestand wordt buiten de reguliere berichtenuitwisseling om overgedragen, terwijl een referentie (claim-check) via het normale kanaal wordt verstuurd.
+De koppelvlakstandaard Grote Berichten biedt een oplossing voor het uitwisselen van berichten groter dan 20 MiB. Het gebruikt het claim-check patroon: het grote bestand wordt buiten de reguliere berichtenuitwisseling om overgedragen, terwijl een referentie (claim-check) via het normale kanaal wordt verstuurd.
 
-- **Drempelwaarde**: Berichten groter dan 20 MB moeten via Grote Berichten worden uitgewisseld
+- **Drempelwaarde**: Berichten groter dan 20 MiB moeten via Grote Berichten worden uitgewisseld
 - **Patroon**: Claim-check (ook wel Attachment Deferral genoemd)
 - **Protocol**: HTTP 1.1 met ondersteuning voor BYTE-RANGE (RFC 7233) voor hervatbare downloads
 

--- a/skills/ls-egov/conflicts.md
+++ b/skills/ls-egov/conflicts.md
@@ -13,7 +13,7 @@ Alle E-Government repositories beheerd door Logius hebben alleen werkversies. Er
 | [Terugmelding](https://github.com/logius-standaarden/Terugmelding) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
 | [Terugmelden-API](https://github.com/logius-standaarden/Terugmelden-API) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
 | [Digimelding-Koppelvlakspecificatie](https://github.com/logius-standaarden/Digimelding-Koppelvlakspecificatie) | _(geen DEF)_ | `1.3` | N.v.t. — alleen werkversies |
-| [basisfactuur-rijk](https://github.com/logius-standaarden/basisfactuur-rijk) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [basisfactuur-rijk](https://github.com/logius-standaarden/basisfactuur-rijk) | _(geen DEF)_ | `v1.0.8` | Tags aanwezig (`v1.0.8`, `v1.0.6`) maar geen DEF op gitdocumentatie |
 | [basisorder-rijk](https://github.com/logius-standaarden/basisorder-rijk) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
 | [e-procurement](https://github.com/logius-standaarden/e-procurement) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
 

--- a/skills/ls-fsc/SKILL.md
+++ b/skills/ls-fsc/SKILL.md
@@ -241,7 +241,7 @@ FSC definieert twee poorten voor verschillende typen verkeer:
 
 - **HTTP/1.1** is verplicht als minimale versie voor alle FSC-verbindingen
 - **HTTP/2** is optioneel en mag worden ondersteund als aanvulling
-- Alle verbindingen gebruiken **TLS 1.2** of hoger
+- **TLS** is verplicht; de minimale TLS-versie wordt bepaald door de Group Rules (in de praktijk minimaal TLS 1.2)
 - **mTLS** is verplicht: zowel client als server presenteren een certificaat
 
 ## Logging Extensie

--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -51,14 +51,14 @@ Het Nederlandse OAuth 2.0 profiel scherpt de basisspecificatie (RFC 6749) aan me
 
 ### Verplichte beveiligingseisen
 
-- **PKCE (Proof Key for Code Exchange)** is verplicht voor alle clients, inclusief confidential clients. Dit voorkomt authorization code interception aanvallen. Clients genereren een `code_verifier` en sturen een `code_challenge` mee in het authorization request.
-- **Grant types**: uitsluitend `authorization_code` en `client_credentials` zijn toegestaan. Implicit grant en Resource Owner Password Credentials zijn expliciet verboden vanwege bekende beveiligingsrisico's.
-- **Tokens als HTTP headers**: access tokens worden uitsluitend als HTTP `Authorization` header (Bearer scheme) meegegeven. Transport via query parameters is niet toegestaan om te voorkomen dat tokens in server logs en browser history terechtkomen.
+- **PKCE (Proof Key for Code Exchange)** is verplicht voor public clients. Confidential clients die zich authenticeren met `private_key_jwt` of mTLS zijn vrijgesteld. Dit voorkomt authorization code interception aanvallen. Clients genereren een `code_verifier` en sturen een `code_challenge` mee in het authorization request.
+- **Grant types**: `authorization_code` is verplicht (MUST); `client_credentials` is toegestaan (MAY) voor machine-to-machine communicatie. Implicit grant en Resource Owner Password Credentials zijn expliciet verboden vanwege bekende beveiligingsrisico's.
+- **Tokens als HTTP headers**: access tokens worden als HTTP `Authorization` header (Bearer scheme) meegegeven. Transport via query parameters is verboden (MUST NOT). Form-encoded body parameters (RFC 6750 Section 2.2) zijn wel toegestaan.
 
 ### Token specificaties
 
-- **Access tokens**: JWT-formaat (RFC 9068) wordt aanbevolen. Dit maakt lokale validatie mogelijk zonder een introspection endpoint aan te roepen, wat de prestaties verbetert.
-- **Refresh tokens**: verplicht bij de `authorization_code` flow. Hiermee kunnen clients nieuwe access tokens verkrijgen zonder hernieuwde gebruikersinteractie. Refresh token rotation wordt aanbevolen.
+- **Access tokens**: JWT-formaat (RFC 9068) is verplicht (MUST). Dit maakt lokale validatie mogelijk zonder een introspection endpoint aan te roepen, wat de prestaties verbetert.
+- **Refresh tokens**: worden ondersteund (MAY) bij de `authorization_code` flow. Hiermee kunnen clients nieuwe access tokens verkrijgen zonder hernieuwde gebruikersinteractie. Refresh token rotation wordt aanbevolen.
 - **Token levensduur**: access tokens hebben een korte levensduur. De exacte duur wordt bepaald door de authorization server, maar korte TTL's (minuten) verdienen de voorkeur.
 
 ### Client authenticatie
@@ -109,7 +109,8 @@ Het ID Token moet minimaal de volgende claims bevatten:
 | `aud` | Identifier van de Relying Party (audience) |
 | `exp` | Verloopdatum van het token (expiration) |
 | `iat` | Tijdstip van uitgifte (issued at) |
-| `acr` | Betrouwbaarheidsniveau van de authenticatie (authentication context class reference) |
+| `nonce` | Waarde uit het authorization request (voorkomt replay attacks) |
+| `acr` | Betrouwbaarheidsniveau (SHOULD — aanbevolen, niet verplicht) |
 
 ### ID Token validatie
 
@@ -122,7 +123,7 @@ Bij het valideren van een OIDC ID Token MOETEN de volgende stappen worden doorlo
 5. **exp** - MOET in de toekomst liggen (token niet verlopen)
 6. **iat** - MAG niet te ver in het verleden liggen (max 5 minuten aanbevolen)
 7. **acr** - MOET minimaal het gevraagde betrouwbaarheidsniveau bevatten
-8. **jti** - MOET uniek zijn (bewaar 12+ maanden om hergebruik te detecteren)
+8. **jti** - MOET uniek zijn (bewaar voldoende lang om hergebruik te detecteren)
 
 ---
 
@@ -132,7 +133,7 @@ Het AuthZEN NL GOV profiel specificeert een architectuur voor geëxternaliseerde
 
 ### Architectuurcomponenten
 
-Het profiel volgt het XACML-referentiemodel met vier kerncomponenten:
+Het profiel definieert PDP en PEP als kerncomponenten. PAP en PIP komen uit het XACML-referentiemodel en worden in de praktijk vaak samen ingezet:
 
 | Component | Rol | Beschrijving |
 |-----------|-----|-------------|
@@ -219,11 +220,16 @@ De Authorization Decision Log standaard definieert een gestructureerd formaat vo
 | Veld | Beschrijving |
 |------|-------------|
 | `timestamp` | Tijdstip van de beslissing (ISO 8601) |
-| `trace_id` | Unieke trace identifier conform W3C Trace Context |
-| `span_id` | Span identifier binnen de trace |
 | `type` | Type van het record, bijvoorbeeld `evaluation` |
 | `request` | Het oorspronkelijke autorisatieverzoek (subject, action, resource, context) |
 | `response` | De autorisatiebeslissing (decision en eventuele context) |
+
+### Aanbevolen velden (SHOULD)
+
+| Veld | Beschrijving |
+|------|-------------|
+| `trace_id` | Unieke trace identifier conform W3C Trace Context |
+| `span_id` | Span identifier binnen de trace |
 
 ### Optionele velden
 

--- a/skills/ls-iam/conflicts.md
+++ b/skills/ls-iam/conflicts.md
@@ -37,7 +37,7 @@ Voor compleetheid worden hier ook de IAM-repositories vermeld waar tags en publi
 
 ### Details OAuth-Beheermodel
 
-- **Enige tag:** `0.2`
+- **Tags:** `0.1`, `0.2`
 - De repository is **gearchiveerd**
 - De gepubliceerde DEF-versie op gitdocumentatie is `v1.0`
 - De tag `0.2` is een conceptversie; de definitieve versie v1.0 is gepubliceerd zonder bijbehorende Git-tag

--- a/skills/ls-logboek/SKILL.md
+++ b/skills/ls-logboek/SKILL.md
@@ -33,7 +33,7 @@ Logboek Dataverwerkingen heeft momenteel **alleen werkversies**. Er zijn nog gee
 
 | Repository | Beschrijving | Vastgesteld | Draft |
 |-----------|-------------|------------|-------|
-| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen) | Hoofdspecificatie met REST API definitie | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen/) |
+| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen) | Normatieve hoofdspecificatie (logging-interface) | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen/) |
 | [logboek-dataverwerkingen-inleiding](https://github.com/logius-standaarden/logboek-dataverwerkingen-inleiding) | Introductie en achtergrond | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen-inleiding/) |
 | [logboek-dataverwerkingen-juridisch-beleidskader](https://github.com/logius-standaarden/logboek-dataverwerkingen-juridisch-beleidskader) | Juridisch en beleidskader | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen-juridisch-beleidskader/) |
 | [logboek-dataverwerkingen-demo](https://github.com/logius-standaarden/logboek-dataverwerkingen-demo) | Docker demo-omgeving met meerdere services | - | - |
@@ -143,16 +143,7 @@ De standaard schrijft geen specifiek transportprotocol voor, maar beveelt **Open
 
 - Het Logboek **MOET** TLS kunnen afdwingen voor alle communicatie.
 - Het Logboek **MOET** elke schrijfactie bevestigen met een bevestigingsbericht (acknowledgement). De applicatie weet hierdoor zeker dat de logregel is opgeslagen.
-- OTLP ondersteunt zowel gRPC als HTTP/protobuf als transportlaag.
-- Bij gebruik van gRPC wordt bidirectionele streaming ondersteund voor hoge volumes.
-- Bij gebruik van HTTP/protobuf worden standaard REST-semantieken gevolgd.
-
-**Transportopties:**
-
-| Protocol | Poort | Beschrijving |
-|----------|-------|--------------|
-| OTLP/gRPC | 4317 | Primair protocol, geschikt voor hoge volumes |
-| OTLP/HTTP | 4318 | Alternatief voor omgevingen zonder gRPC-ondersteuning |
+- OTLP ondersteunt zowel gRPC als HTTP/protobuf als transportlaag (standaard OTLP-poorten: 4317 voor gRPC, 4318 voor HTTP — niet voorgeschreven door de Logboek-standaard zelf).
 
 ## Extensies
 
@@ -160,7 +151,7 @@ De standaard is modulair uitbreidbaar via extensies. Elke extensie voegt aanvull
 
 ### Object Extensie
 
-Voegt geo-object informatie toe aan logregels. Bruikbaar wanneer verwerkingen betrekking hebben op specifieke objecten (bijv. kadastrale percelen, voertuigen, gebouwen). Definieert aanvullende attributes in de `dpl.object` namespace.
+Voegt objectgegevens toe aan logregels. Bruikbaar wanneer verwerkingen betrekking hebben op specifieke objecten (bijv. kadastrale percelen, voertuigen, gebouwen, maar ook andere domeinobjecten). Definieert aanvullende attributes in de `dpl.objects` namespace.
 
 - Repository: [logboek-extensie-object](https://github.com/logius-standaarden/logboek-extensie-object)
 

--- a/skills/ls-notif/SKILL.md
+++ b/skills/ls-notif/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools:
 
 **Agent-instructie:** Deze skill helpt bij het implementeren van event-driven communicatie met CloudEvents NL GOV profiel. Gebruik de `cloudevents` SDK voor Python/JavaScript. Source moet URN nld-notatie gebruiken: `urn:nld:oin:<OIN>:systeem:<naam>`.
 
-De notificatiestandaarden definiëren hoe overheidsorganisaties gebeurtenissen (events) kunnen publiceren en daarop kunnen abonneren. Gebaseerd op de internationale CNCF CloudEvents specificatie (v1.0.1) met een NL GOV profiel dat specifieke eisen stelt aan naamgeving, identificatie en het gebruik van context-attributen binnen de Nederlandse overheid.
+De notificatiestandaarden definiëren hoe overheidsorganisaties gebeurtenissen (events) kunnen publiceren en daarop kunnen abonneren. Gebaseerd op de internationale CNCF CloudEvents specificatie (v1.0.2) met een NL GOV profiel dat specifieke eisen stelt aan naamgeving, identificatie en het gebruik van context-attributen binnen de Nederlandse overheid.
 
 ## Versiemodel
 
@@ -61,7 +61,8 @@ Het NL GOV profiel scherpt de CNCF CloudEvents specificatie aan voor gebruik bin
 | `subject` | String | Het onderwerp waarop het event betrekking heeft, bijvoorbeeld een BSN (`999990342`) of zaak-ID. Hiermee kunnen afnemers filteren zonder de payload te openen. |
 | `time` | Timestamp | Tijdstip in RFC 3339 formaat. Let op: dit is het tijdstip van logging/registratie van het event, niet noodzakelijk het moment van de werkelijke gebeurtenis. Voorbeeld: `2024-01-15T10:30:00Z`. |
 | `dataref` | URI | Verwijzing naar een externe locatie waar de volledige event payload beschikbaar is. Implementeert het Claim Check Pattern voor grote payloads die niet in het event zelf passen. |
-| `sequence` | String | Geeft de relatieve volgorde van events aan. Nuttig wanneer de volgorde van verwerking van belang is voor de afnemer. |
+| `sequence` | String | Geeft de relatieve volgorde van events aan. Nuttig wanneer de volgorde van verwerking van belang is voor de afnemer. Dit is een NL GOV extensie-attribuut (niet in de CNCF-kernspec). |
+| `sequencetype` | String | Geeft het type sequentie aan (bijv. `Integer`). Verplicht als `sequence` wordt gebruikt. Dit is een NL GOV extensie-attribuut. |
 
 ## Notificatieservices API
 

--- a/skills/ls-pub/conflicts.md
+++ b/skills/ls-pub/conflicts.md
@@ -6,7 +6,7 @@ Dit document beschrijft bekende discrepanties en bewuste keuzes voor de Publicat
 
 ## GitHub-tags vs. gepubliceerde versies
 
-De publicatie-tooling repositories (respec, respec-tools, build-push-action, etc.) zijn tooling-repos, geen standaard-documenten. Ze hebben geen vastgestelde (DEF) versies op gitdocumentatie.logius.nl.
+De publicatie-tooling repositories (respec, Automatisering, etc.) zijn tooling-repos, geen standaard-documenten. Ze hebben geen vastgestelde (DEF) versies op gitdocumentatie.logius.nl.
 
 Er zijn geen bronconflicten geconstateerd. Tooling-versies worden via GitHub Releases beheerd, niet via gitdocumentatie.logius.nl.
 


### PR DESCRIPTION
## Samenvatting

Eenmalige grondige verificatie van alle claims in 29 markdown-bestanden tegen live bronnen. 300 claims geëxtraheerd en geverifieerd via geautomatiseerd script + 9 parallelle sub-agents voor technische claims per domein.

- **ls-iam**: PKCE scope, grant types MUST/MAY, JWT verplicht, refresh tokens MAY, token transport, ID Token claims, trace_id/span_id SHOULD, PAP/PIP herkomst
- **ls-logboek**: repo-beschrijving, OTLP poorten, `dpl.objects` namespace, Object Extensie scope
- **ls-fsc**: TLS versie door Group Rules bepaald
- **ls-notif**: CNCF v1.0.2, `sequencetype` attribuut, extensie-attributen markering
- **ls-egov**: basisfactuur-rijk tags gedocumenteerd
- **ls-bomos**: Community naar Tactiek, Klachtenafhandeling, Publicatie
- **ls-dk**: 20 MB → 20 MiB
- **ls-pub**: fictieve repos verwijderd uit conflicts.md

## Test plan

- [x] `uv run pytest -v` — 65 tests pass
- [x] `npx markdownlint-cli2 "skills/**/*.md"` — 0 errors
- [x] Pre-commit hooks pass (ruff, markdownlint, yaml, json)
- [ ] CI validation checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)