### PR TITLE
fix: voeg disclaimer toe dat axe-core WCAG check beperkt is

### DIFF
--- a/skills/ls-pub/SKILL.md
+++ b/skills/ls-pub/SKILL.md
@@ -110,7 +110,7 @@ Alle standaarden-repos roepen centrale workflows aan uit de `Automatisering` rep
 
 ### check.yml - Kwaliteitschecks (3 parallelle checks)
 
-1. **WCAG check**: `npx @axe-core/cli http://localhost:8080/index.html --tags wcag2aa` (geautomatiseerde check; dekt ~30% van WCAG-criteria, handmatige toetsing blijft nodig). axe-core is een van meerdere tools die gestandaardiseerde [W3C ACT Rules](https://www.w3.org/WAI/standards-guidelines/act/rules/) implementeren; alternatieven zijn o.a. Alfa (Siteimprove) en Linter van het NL Design System.
+1. **WCAG check**: `npx @axe-core/cli http://localhost:8080/index.html --tags wcag2aa` (geautomatiseerde check; dekt ~30% van WCAG-criteria, handmatige toetsing blijft nodig). axe-core is een van meerdere tools die gestandaardiseerde [W3C ACT Rules](https://www.w3.org/WAI/standards-guidelines/act/rules/) implementeren; alternatieven zijn o.a. [Alfa](https://github.com/Siteimprove/alfa) (Siteimprove) en [QualWeb](https://github.com/qualweb/qualweb).
 2. **Markdown lint**: `npx markdownlint-cli sections/`
 3. **Link validatie**: Muffet valideert alle hyperlinks
 
@@ -163,7 +163,7 @@ npx @axe-core/cli output.html --tags wcag2aa
 # Een groene check betekent NIET dat je volledig voldoet aan EN 301 549 / WCAG 2.1 AA.
 # Handmatige toetsing op alle 55 succescriteria in WCAG 2.1 AA blijft nodig.
 # axe-core implementeert W3C ACT Rules (https://www.w3.org/WAI/standards-guidelines/act/rules/)
-# Alternatieven: Alfa (Siteimprove), Linter van NL Design System
+# Alternatieven: Alfa (Siteimprove), QualWeb
 
 # Markdown linting
 npx markdownlint-cli 'sections/**/*.md'


### PR DESCRIPTION
## Summary

- Voegt op drie plekken in `/ls-pub` een waarschuwing toe dat axe-core slechts ~30% van de WCAG 2.1 AA criteria automatisch kan testen
- Een groene check kan onterecht zekerheid geven dat een document volledig voldoet aan EN 301 549 / WCAG 2.1 AA
- Handmatige toetsing door een toegankelijkheidsexpert blijft nodig

## Aanleiding

Feedback dat de WCAG-check in de skill description een mate van zekerheid suggereert die de tooling niet kan waarmaken. Deze disclaimer maakt de beperkingen expliciet.

## Test plan

- [ ] Controleer dat `/ls-pub` skill nog correct triggert op "WCAG check"
- [ ] Controleer dat de disclaimer zichtbaar is bij het uitvoeren van een WCAG check