### PR TITLE
Update repo references for org move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,50 +5,50 @@ Alle noemenswaardige wijzigingen aan deze plugin worden hier gedocumenteerd.
 Het formaat is gebaseerd op [Keep a Changelog](https://keepachangelog.com/nl/1.1.0/)
 en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 
-## [1.3.4](https://github.com/MinBZK/logius-standaarden-plugin/compare/v1.3.3...v1.3.4) (2026-02-22)
+## [1.3.4](https://github.com/developer-overheid-nl/standaarden-plugin/compare/v1.3.3...v1.3.4) (2026-02-22)
 
 
 ### Opgelost
 
-* verbeter bruikbaarheid en correctheid van skills ([#53](https://github.com/MinBZK/logius-standaarden-plugin/issues/53)) ([b68942f](https://github.com/MinBZK/logius-standaarden-plugin/commit/b68942fe185f45afc97bc29898e1a6ca5be70d5f))
+* verbeter bruikbaarheid en correctheid van skills ([#53](https://github.com/developer-overheid-nl/standaarden-plugin/issues/53)) ([b68942f](https://github.com/developer-overheid-nl/standaarden-plugin/commit/b68942fe185f45afc97bc29898e1a6ca5be70d5f))
 
-## [1.3.3](https://github.com/MinBZK/logius-standaarden-plugin/compare/v1.3.2...v1.3.3) (2026-02-22)
-
-
-### Opgelost
-
-* vervang /publicatie/dk/ (403) door /publicatie/dk/actueel/ ([#46](https://github.com/MinBZK/logius-standaarden-plugin/issues/46)) ([66d405e](https://github.com/MinBZK/logius-standaarden-plugin/commit/66d405e32b870c0b7d3d38d99f00089083aee2eb))
-
-## [1.3.2](https://github.com/MinBZK/logius-standaarden-plugin/compare/v1.3.1...v1.3.2) (2026-02-22)
+## [1.3.3](https://github.com/developer-overheid-nl/standaarden-plugin/compare/v1.3.2...v1.3.3) (2026-02-22)
 
 
 ### Opgelost
 
-* elimineer monitoring false positives ([#45](https://github.com/MinBZK/logius-standaarden-plugin/issues/45)) ([13434d5](https://github.com/MinBZK/logius-standaarden-plugin/commit/13434d5ca452ab5c6457ad1e2a8c80600ffdacff))
-* gebruik Actions cache voor monitoring checksums i.p.v. git push ([#40](https://github.com/MinBZK/logius-standaarden-plugin/issues/40)) ([c0b2f5e](https://github.com/MinBZK/logius-standaarden-plugin/commit/c0b2f5e3b2b8a1e1eb6ce09e0cff69836222b92e))
+* vervang /publicatie/dk/ (403) door /publicatie/dk/actueel/ ([#46](https://github.com/developer-overheid-nl/standaarden-plugin/issues/46)) ([66d405e](https://github.com/developer-overheid-nl/standaarden-plugin/commit/66d405e32b870c0b7d3d38d99f00089083aee2eb))
 
-## [1.3.1](https://github.com/MinBZK/logius-standaarden-plugin/compare/v1.3.0...v1.3.1) (2026-02-21)
+## [1.3.2](https://github.com/developer-overheid-nl/standaarden-plugin/compare/v1.3.1...v1.3.2) (2026-02-22)
 
 
 ### Opgelost
 
-* gebruik dynamische shields.io badge voor versienummer ([#27](https://github.com/MinBZK/logius-standaarden-plugin/issues/27)) ([08344df](https://github.com/MinBZK/logius-standaarden-plugin/commit/08344df969b3e410dfe93fadafdf29a6c2be392d))
-* negeer ETag/Last-Modified false positives in monitoring ([#29](https://github.com/MinBZK/logius-standaarden-plugin/issues/29)) ([ae64994](https://github.com/MinBZK/logius-standaarden-plugin/commit/ae649941af21c9a9068ae70ba1dc2b948bc15655))
+* elimineer monitoring false positives ([#45](https://github.com/developer-overheid-nl/standaarden-plugin/issues/45)) ([13434d5](https://github.com/developer-overheid-nl/standaarden-plugin/commit/13434d5ca452ab5c6457ad1e2a8c80600ffdacff))
+* gebruik Actions cache voor monitoring checksums i.p.v. git push ([#40](https://github.com/developer-overheid-nl/standaarden-plugin/issues/40)) ([c0b2f5e](https://github.com/developer-overheid-nl/standaarden-plugin/commit/c0b2f5e3b2b8a1e1eb6ce09e0cff69836222b92e))
 
-## [1.3.0](https://github.com/MinBZK/logius-standaarden-plugin/compare/v1.2.0...v1.3.0) (2026-02-21)
+## [1.3.1](https://github.com/developer-overheid-nl/standaarden-plugin/compare/v1.3.0...v1.3.1) (2026-02-21)
+
+
+### Opgelost
+
+* gebruik dynamische shields.io badge voor versienummer ([#27](https://github.com/developer-overheid-nl/standaarden-plugin/issues/27)) ([08344df](https://github.com/developer-overheid-nl/standaarden-plugin/commit/08344df969b3e410dfe93fadafdf29a6c2be392d))
+* negeer ETag/Last-Modified false positives in monitoring ([#29](https://github.com/developer-overheid-nl/standaarden-plugin/issues/29)) ([ae64994](https://github.com/developer-overheid-nl/standaarden-plugin/commit/ae649941af21c9a9068ae70ba1dc2b948bc15655))
+
+## [1.3.0](https://github.com/developer-overheid-nl/standaarden-plugin/compare/v1.2.0...v1.3.0) (2026-02-21)
 
 
 ### Toegevoegd
 
-* Automatische releases met release-please ([#17](https://github.com/MinBZK/logius-standaarden-plugin/issues/17)) ([08ead1a](https://github.com/MinBZK/logius-standaarden-plugin/commit/08ead1a7a85d1252c297406483fd320559fb3c49))
-* Python linting met ruff ([#15](https://github.com/MinBZK/logius-standaarden-plugin/issues/15)) ([741a1f1](https://github.com/MinBZK/logius-standaarden-plugin/commit/741a1f1c9907635832c5f7257a4ecc39f50105bb))
-* Tests toevoegen met pytest ([#19](https://github.com/MinBZK/logius-standaarden-plugin/issues/19)) ([f0d81dc](https://github.com/MinBZK/logius-standaarden-plugin/commit/f0d81dc7f971fb272efa40a84ef95489e5ce53c1))
+* Automatische releases met release-please ([#17](https://github.com/developer-overheid-nl/standaarden-plugin/issues/17)) ([08ead1a](https://github.com/developer-overheid-nl/standaarden-plugin/commit/08ead1a7a85d1252c297406483fd320559fb3c49))
+* Python linting met ruff ([#15](https://github.com/developer-overheid-nl/standaarden-plugin/issues/15)) ([741a1f1](https://github.com/developer-overheid-nl/standaarden-plugin/commit/741a1f1c9907635832c5f7257a4ecc39f50105bb))
+* Tests toevoegen met pytest ([#19](https://github.com/developer-overheid-nl/standaarden-plugin/issues/19)) ([f0d81dc](https://github.com/developer-overheid-nl/standaarden-plugin/commit/f0d81dc7f971fb272efa40a84ef95489e5ce53c1))
 
 
 ### Opgelost
 
-* markdownlint regels compatibel met release-please CHANGELOG ([#25](https://github.com/MinBZK/logius-standaarden-plugin/issues/25)) ([40879cd](https://github.com/MinBZK/logius-standaarden-plugin/commit/40879cdc9eedd643b5e6ea393485e5a3950103ca))
-* versie-badge in README automatisch bijwerken bij release ([#26](https://github.com/MinBZK/logius-standaarden-plugin/issues/26)) ([08edcce](https://github.com/MinBZK/logius-standaarden-plugin/commit/08edcce71d213ca5b340bbb5e37247265ca9a9e1))
+* markdownlint regels compatibel met release-please CHANGELOG ([#25](https://github.com/developer-overheid-nl/standaarden-plugin/issues/25)) ([40879cd](https://github.com/developer-overheid-nl/standaarden-plugin/commit/40879cdc9eedd643b5e6ea393485e5a3950103ca))
+* versie-badge in README automatisch bijwerken bij release ([#26](https://github.com/developer-overheid-nl/standaarden-plugin/issues/26)) ([08edcce](https://github.com/developer-overheid-nl/standaarden-plugin/commit/08edcce71d213ca5b340bbb5e37247265ca9a9e1))
 
 ## [1.2.0] - 2026-02-21
 
@@ -75,7 +75,7 @@ en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 
 ### Gewijzigd
 
-- Marketplace gescheiden van plugin: marketplace.json is verplaatst naar [MinBZK/overheid-claude-plugins](https://github.com/MinBZK/overheid-claude-plugins)
+- Marketplace gescheiden van plugin: marketplace.json is verplaatst naar [developer-overheid-nl/overheid-claude-plugins](https://github.com/developer-overheid-nl/overheid-claude-plugins)
 - Installatie-instructies bijgewerkt naar de nieuwe overheid-plugins marketplace
 
 ### Verwijderd

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Logius Standaarden - Claude Code Plugin
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![versie](https://img.shields.io/github/v/tag/MinBZK/logius-standaarden-plugin?label=versie&color=green)](CHANGELOG.md)
+[![versie](https://img.shields.io/github/v/tag/developer-overheid-nl/standaarden-plugin?label=versie&color=green)](CHANGELOG.md)
 
 Claude Code plugin voor het werken met 77 van de 88 GitHub repositories van [Logius standaarden](https://github.com/logius-standaarden) voor Nederlandse overheidsinteroperabiliteit.
 
@@ -9,10 +9,10 @@ Claude Code plugin voor het werken met 77 van de 88 GitHub repositories van [Log
 
 ### Globaal installeren (aanbevolen)
 
-Voeg de [overheid-plugins marketplace](https://github.com/MinBZK/overheid-claude-plugins) toe en installeer de plugin. De skills zijn daarna beschikbaar in elke Claude Code sessie.
+Voeg de [overheid-plugins marketplace](https://github.com/developer-overheid-nl/overheid-claude-plugins) toe en installeer de plugin. De skills zijn daarna beschikbaar in elke Claude Code sessie.
 
 ```bash
-claude plugin marketplace add MinBZK/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
 claude plugin install logius-standaarden@overheid-plugins
 ```
 
@@ -21,8 +21,8 @@ claude plugin install logius-standaarden@overheid-plugins
 Alternatief: laad de plugin alleen voor de huidige sessie via `--plugin-dir`:
 
 ```bash
-git clone https://github.com/MinBZK/logius-standaarden-plugin.git
-claude --plugin-dir ./logius-standaarden-plugin
+git clone https://github.com/developer-overheid-nl/standaarden-plugin.git
+claude --plugin-dir ./standaarden-plugin
 ```
 
 ## Wat doet deze plugin?

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -49,8 +49,8 @@ maintenance:
     - name: Logius
       email: standaarden@logius.nl
   type: community
-name: logius-standaarden-plugin
+name: standaarden-plugin
 releaseDate: '2026-02-21'
 softwareVersion: 1.3.4
 softwareType: standalone/other
-url: https://github.com/MinBZK/logius-standaarden-plugin
+url: https://github.com/developer-overheid-nl/standaarden-plugin


### PR DESCRIPTION
## Summary
- Updated all references from `MinBZK/logius-standaarden-plugin` to `developer-overheid-nl/standaarden-plugin`
- Updated all references from `MinBZK/overheid-claude-plugins` to `developer-overheid-nl/overheid-claude-plugins`
- Updated `publiccode.yml` software name and URL
- Updated git remote origin URL

## Files changed
- `README.md` - shields.io badge, marketplace instructions, clone URL, plugin-dir path
- `CHANGELOG.md` - all compare/issue/commit links
- `publiccode.yml` - software name and repository URL