### PR TITLE
Fix OAuth-NL-profiel licentie: CC-BY-4.0 → CC-BY-ND-4.0

### DIFF
--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -41,7 +41,7 @@ Op het Forum Standaardisatie staat het OAuth-NL-profiel **v1.0** als verplicht (
 
 | Repository | Beschrijving | Licentie | Vastgesteld | Draft |
 |-----------|-------------|--------|------------|-------|
-| [OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel) | Nederlands profiel voor OAuth 2.0 | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | [v1.1.0](https://gitdocumentatie.logius.nl/publicatie/api/oauth/) | [Draft](https://logius-standaarden.github.io/OAuth-NL-profiel/) |
+| [OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel) | Nederlands profiel voor OAuth 2.0 | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/legalcode.en) | [v1.1.0](https://gitdocumentatie.logius.nl/publicatie/api/oauth/) | [Draft](https://logius-standaarden.github.io/OAuth-NL-profiel/) |
 | [OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV) | OpenID Connect profiel voor NL overheid | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | [v1.0.1](https://gitdocumentatie.logius.nl/publicatie/api/oidc/) | [Draft](https://logius-standaarden.github.io/OIDC-NLGOV/) |
 | [OAuth-Inleiding](https://github.com/logius-standaarden/OAuth-Inleiding) | Introductie en achtergrond OAuth | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | - | [Draft](https://logius-standaarden.github.io/OAuth-Inleiding/) |
 | [OAuth-Beheermodel](https://github.com/logius-standaarden/OAuth-Beheermodel) | Beheermodel voor OAuth standaarden — **gearchiveerd** | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | [v1.0](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer/) | - |

--- a/skills/ls-iam/conflicts.md
+++ b/skills/ls-iam/conflicts.md
@@ -75,7 +75,7 @@ Sommige repositories bevatten een W3C Software License (afkomstig van het ReSpec
 
 | Repository | GitHub LICENSE | Gepubliceerde licentie | Status |
 |-----------|--------------|----------------------|--------|
-| [OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel) | Geen | CC-BY-ND-4.0 (ReSpec) | Discrepantie |
 | [OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV) | W3C Software License | CC-BY-4.0 (ReSpec) | Afwijkend |
 | [OAuth-Inleiding](https://github.com/logius-standaarden/OAuth-Inleiding) | W3C Software License | CC-BY-4.0 (ReSpec) | Afwijkend |
 | [OAuth-Beheermodel](https://github.com/logius-standaarden/OAuth-Beheermodel) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |


### PR DESCRIPTION
## Summary

- De ReSpec config van [OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel) zet expliciet `licence: "cc-by-nd"` (CC-BY-ND-4.0), niet `cc-by` (CC-BY-4.0)
- CC-BY-ND verbiedt afgeleide werken — dit is een significante restrictie die correct vermeld moet worden
- Gecorrigeerd in `skills/ls-iam/SKILL.md` (repositorytabel) en `skills/ls-iam/conflicts.md` (licentie-statustabel)

## Test plan

- [ ] Controleer dat de licentie-link in SKILL.md correct verwijst naar CC-BY-ND-4.0
- [ ] Controleer dat conflicts.md consistent is met SKILL.md