### PR TITLE
Fix license for zaakgericht-werken-api to follow ReSpec

### DIFF
--- a/skills/ls-api/SKILL.md
+++ b/skills/ls-api/SKILL.md
@@ -46,7 +46,7 @@ Modules hebben geen eigen vaststellingsproces — ze ontlenen hun status aan de 
 | [API-mod-signing](https://github.com/logius-standaarden/API-mod-signing) | Module: HTTP Message Signing — draft | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | - | [Draft](https://logius-standaarden.github.io/API-mod-signing/) |
 | [API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption) | Module: Encryption (JWE) — draft | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | - | [Draft](https://logius-standaarden.github.io/API-mod-encryption/) |
 | [api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse) | Python tool: test Spectral regels tegen echte OpenAPI specs uit het API-register | Niet gespecificeerd | - | - |
-| [zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api) | API-specificatie voor zaakgericht werken | [W3C Software License](https://www.w3.org/copyright/software-license-2023/) | - | - |
+| [zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api) | API-specificatie voor zaakgericht werken | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | - | - |
 
 ## Technische Regels
 

--- a/skills/ls-api/conflicts.md
+++ b/skills/ls-api/conflicts.md
@@ -68,6 +68,7 @@ Sommige repositories bevatten een W3C Software License (afkomstig van het ReSpec
 | [API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security) | W3C Software License | CC-BY-4.0 (ReSpec) | Afwijkend |
 | [API-mod-signing](https://github.com/logius-standaarden/API-mod-signing) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
 | [API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption) | Geen | CC-BY-4.0 (ReSpec) | Discrepantie |
+| [zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api) | W3C Software License | CC-BY-4.0 (ReSpec, overgeërfd van organisatie-config) | Afwijkend |
 
 ### Aandachtspunt
 


### PR DESCRIPTION
## Summary
- Changed zaakgericht-werken-api license from W3C Software License to CC-BY-4.0
- The W3C license in the repo's LICENSE file is a template artifact; the ReSpec config inherits CC-BY-4.0 from the Logius organisation-config
- Added the repo to the license discrepancy table in conflicts.md

## Context
Full audit of all upstream repo licenses verified against actual ReSpec configs. The ReSpec config is the source of truth for standard document licensing.