### PR TITLE
Fix: point release-please at .plugin/plugin.json source of truth

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
       "extra-files": [
         {
           "type": "json",
-          "path": ".claude-plugin/plugin.json",
+          "path": ".plugin/plugin.json",
           "jsonpath": "$.version"
         },
         {


### PR DESCRIPTION
## Summary
- Release-please was bumping `.claude-plugin/plugin.json` directly, but `.plugin/plugin.json` is the source of truth for `generate_plugin.py`
- This caused CI to fail on skills-geo v0.2.0 release — applying same fix preventively here
- Now release-please bumps `.plugin/plugin.json` instead

Mirrors: developer-overheid-nl/skills-geo#45