### PR TITLE
fix: Clarify major version URI in OAS

### DIFF
--- a/skills/ls-api/SKILL.md
+++ b/skills/ls-api/SKILL.md
@@ -56,7 +56,7 @@ Modules hebben geen eigen vaststellingsproces — ze ontlenen hun status aan de 
 - Gebruik **camelCase** voor query-parameters: `?sortOrder=desc`
 - Geen trailing slashes: `/api/v1/users` (niet `/api/v1/users/`)
 - Geen bestandsextensies (gebruik Accept-header voor content negotiation)
-- Major versie in URI: `/v1/resources`
+- Major versie in URI: `/v1/resources` (Let op: in de OAS moet dit op serverniveau worden gespecificeerd, niet in individuele paden. Dit om uit te sluiten dat één API meerdere major versies in verschillende paden heeft, wat verwarrend is. De linter controleert op aanwezigheid van major versie in server URL, niet in individuele paden.)
 - Operaties als sub-resources: laatste padsegment mag starten met `_` (bijv. `/_search`)
 - Geen gevoelige informatie in URIs (niet beschermd door TLS)
 


### PR DESCRIPTION
## Beschrijving

Geeft extra duiding dat de major versie (`/v1`) in het server gedeelte moet staan en niet per individueel path mag worden gespecificeerd in OAS.

## Conventional Commits

Gebruik een van deze prefixes in de PR-titel zodat release-please de juiste
versie-bump bepaalt:

- `feat:` — nieuw feature → **minor** bump (0.3.0 → 0.4.0)
- `fix:` — bugfix → **patch** bump (0.3.0 → 0.3.1)
- `feat!:` of `fix!:` — breaking change → **major** bump (0.3.0 → 1.0.0)
- `chore:`, `docs:`, `ci:`, `refactor:` — geen release

## Checklist

- [x] Skills laden correct (`claude --plugin-dir .`)
- [x] Geen hardcoded paden of persoonlijke gegevens

<!-- Versies en CHANGELOG worden automatisch beheerd door release-please -->
