### PR TITLE
fix: strip Drupal /uploads/ dynamische elementen in normalize_html

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -94,9 +94,35 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"js-view-dom-id-[a-f0-9]+", "js-view-dom-id-HASH", html)
     # Drupal CMS: permissionsHash (verandert bij module/permissie updates)
     html = re.sub(r'"permissionsHash":"[a-f0-9]+"', '"permissionsHash":"HASH"', html)
+    # Drupal CMS: aggregatie filenames via /uploads/ pad (alternatief voor /sites/default/files/)
+    html = re.sub(
+        r"/uploads/css/css_[A-Za-z0-9_-]+\.css",
+        "/uploads/css/css_HASH.css",
+        html,
+    )
+    html = re.sub(
+        r"/uploads/js/js_[A-Za-z0-9_-]+\.js",
+        "/uploads/js/js_HASH.js",
+        html,
+    )
+    # Drupal CMS: ajaxPageState.libraries (base64-encoded library list, verandert bij cache rebuild)
+    html = re.sub(
+        r'"libraries":"[A-Za-z0-9+/=_-]+"',
+        '"libraries":"HASH"',
+        html,
+    )
+    # Drupal CMS: form_action CSRF tokens in ajaxTrustedUrl (veranderen bij cache rebuild)
+    html = re.sub(r"form_action_[A-Za-z0-9_-]+", "form_action_HASH", html)
     # Liferay CMS: authToken / p_auth CSRF token (verandert per request)
     html = re.sub(r"Liferay\.authToken\s*=\s*'[^']*'", "Liferay.authToken = 'TOKEN'", html)
     html = re.sub(r'name="p_auth"\s+value="[^"]*"', 'name="p_auth" value="TOKEN"', html)
+    # Liferay CMS: getRemoteAddr/getRemoteHost in ThemeDisplay (bevat IP van requester,
+    # varieert per CI runner)
+    html = re.sub(
+        r"(getRemote(?:Addr|Host):\s*function\s*\(\)\s*\{\s*return\s*')[^']*(')",
+        r"\1REMOTE_ADDR\2",
+        html,
+    )
     # Liferay CMS: cache-bust timestamp op resource URLs (bijv. ?t=1771832749422 of &t=...)
     html = re.sub(r"[?&]t=\d{10,15}", "?t=TIMESTAMP", html)
     # Liferay CMS: HTML-encoded cache-bust timestamps (&amp;t=DIGITS in combo servlet URLs)


### PR DESCRIPTION
## Samenvatting

Drupal CMS false positives opgelost in de content monitoring. Vier patronen die bij cache rebuilds veranderen worden nu genormaliseerd:
- `/uploads/css/` en `/uploads/js/` aggregatie filenames
- `ajaxPageState.libraries` (base64-encoded library list)
- `form_action_*` CSRF tokens in `ajaxTrustedUrl`

Identieke fix doorgevoerd in skills-geo, skills-internet en skills-nora.