### PR TITLE
fix: update ls-pub pubDomain en normalize_html Apache timestamps

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -163,6 +163,8 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"<script\s*>self\.__next_f\.push\([^<]*\)</script>", "", html)
     # Next.js/React escaped JSON nonces: \"nonce\":\"base64value\"
     html = re.sub(r'\\"nonce\\":\\"[^"\\]*\\"', r'\\"nonce\\":\\"NONCE\\"', html)
+    # Apache directory listings: timestamps variëren bij server-deployments
+    html = re.sub(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}\s+", "", html)
     # Normaliseer opeenvolgende lege regels (variëren tussen requests bij sommige CMS'en)
     html = re.sub(r"\n{3,}", "\n\n", html)
     return html

--- a/skills/ls-pub/SKILL.md
+++ b/skills/ls-pub/SKILL.md
@@ -81,7 +81,7 @@ loadRespecWithConfiguration({
   license: "cc-by",
   specStatus: "WV",        // WV=Werkversie, CV=Consultatieversie, VV=Versie ter vaststelling, DEF=Vastgestelde versie
   specType: "HR",           // HR=Handreiking, ST=Standaard, PR=Praktijkrichtlijn, IM=Informatiemodel
-  pubDomain: "dk",          // Toegestane waarden: api, bomos, dk, fsc, logboek, notificatieservices
+  pubDomain: "dk",          // Toegestane waarden: api, bomos, dk, fsc, ftv, logboek, notificatieservices
   shortName: "template",    // Moet kebab-case zijn: alleen kleine letters, gescheiden door streepjes
   publishDate: "2023-06-21",
   publishVersion: "0.0.3",
@@ -154,7 +154,7 @@ jobs:
 ## Nieuw Document Starten
 
 1. **Fork het template**: Gebruik [ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius) als basis
-2. **Configureer `js/config.mjs`**: Pas `specStatus`, `specType`, `pubDomain`, `shortName`, `title` aan. `pubDomain` accepteert alleen `api`, `bomos`, `dk`, `fsc`, `logboek` of `notificatieservices`. `shortName` moet in kebab-case (alleen kleine letters, gescheiden door streepjes, bijv. `rest-api`)
+2. **Configureer `js/config.mjs`**: Pas `specStatus`, `specType`, `pubDomain`, `shortName`, `title` aan. `pubDomain` accepteert alleen `api`, `bomos`, `dk`, `fsc`, `ftv`, `logboek` of `notificatieservices`. `shortName` moet in kebab-case (alleen kleine letters, gescheiden door streepjes, bijv. `rest-api`)
 3. **Schrijf content**: Maak hoofdstukken als losse Markdown-bestanden
 4. **Push naar GitHub**: CI/CD bouwt automatisch HTML en PDF
 

--- a/skills/ls-pub/conflicts.md
+++ b/skills/ls-pub/conflicts.md
@@ -10,6 +10,14 @@ De publicatie-tooling repositories (respec, Automatisering, etc.) zijn tooling-r
 
 Er zijn geen bronconflicten geconstateerd. Tooling-versies worden via GitHub Releases beheerd, niet via gitdocumentatie.logius.nl.
 
+## pubDomain `ftv` (Federatieve Toegang Verlening)
+
+Geconstateerd: 2026-03-28
+
+In maart 2026 is `ftv` als nieuw pubDomain toegevoegd aan `organisation-config.mjs` ([PR #65](https://github.com/logius-standaarden/publicatie/pull/65)). De authorization-decision-log is verhuisd van pubDomain `dk` (Digikoppeling) naar `ftv` met shortName `adl`. De oude `dk/authorization-decision-log/` directory is verwijderd uit de publicatie-repo.
+
+Let op: `ftv` heeft nog geen email-mapping in `EMAIL_TO_DOMAIN_MAPPING` in organisation-config.mjs. ReSpec zal een error geven bij publicatie van een document met `pubDomain: "ftv"` tot die mapping is toegevoegd door Logius.
+
 ## Keuze in SKILL.md
 
 De skill beschrijft de publicatie-tooling en workflows zonder versieclaims voor de tooling zelf. Er zijn geen discrepanties tussen bronnen. Als er in de toekomst versiegebonden tooling-releases komen, moet dit document worden bijgewerkt.


### PR DESCRIPTION
## Summary

- `ftv` (Federatieve Toegang Verlening) als pubDomain toegevoegd aan ls-pub SKILL.md, conform upstream [logius-standaarden/publicatie#65](https://github.com/logius-standaarden/publicatie/pull/65)
- `conflicts.md` bijgewerkt: context over ftv-verhuizing authorization-decision-log van dk naar ftv, en ontbrekende email-mapping
- `normalize_html`: Apache directory listing timestamps strippen (voorkomt false positives bij docs.geostandaarden.nl)

## Test plan

- [ ] CI checks groen
- [ ] `uv run pytest -v` lokaal groen (65 passed)

Sluit monitoring issues #337 #338 #339 #340 #341