### PR TITLE
feat(ls-logboek,ls-bomos): update naar vastgestelde versies

### DIFF
--- a/skills/ls-bomos/SKILL.md
+++ b/skills/ls-bomos/SKILL.md
@@ -37,7 +37,7 @@ BOMOS is geen interoperabiliteitsstandaard en staat niet op de 'pas-toe-of-leg-u
 
 | Repository | Beschrijving | Licentie | Vastgesteld | Draft |
 |-----------|-------------|--------|------------|-------|
-| [BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament) | Kernmodel: activiteiten, rollen, structuur | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | [v3.0.1](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/) | [Draft](https://logius-standaarden.github.io/BOMOS-Fundament/) |
+| [BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament) | Kernmodel: activiteiten, rollen, structuur | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | [v3.0.2](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/) | [Draft](https://logius-standaarden.github.io/BOMOS-Fundament/) |
 | [BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping) | Verdiepende beschrijving van BOMOS activiteiten | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | [v3.1.0](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/) | [Draft](https://logius-standaarden.github.io/BOMOS-Verdieping/) |
 
 ### Aanvullende modules en documenten (alleen werkversies)

--- a/skills/ls-bomos/conflicts.md
+++ b/skills/ls-bomos/conflicts.md
@@ -1,6 +1,7 @@
 # BOMOS - Bronconflicten
 
 Geconstateerd: 2026-02-21
+Bijgewerkt: 2026-04-14
 
 Dit document beschrijft bekende discrepanties tussen GitHub-repository tags en de gepubliceerde versies op [gitdocumentatie.logius.nl](https://gitdocumentatie.logius.nl). De **gepubliceerde versie op gitdocumentatie.logius.nl is leidend** voor DEF-versies.
 
@@ -8,7 +9,7 @@ Dit document beschrijft bekende discrepanties tussen GitHub-repository tags en d
 
 | Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
 |-----------|---------------------------|-------------------|-------------|
-| [BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament) | [v3.0.1](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/) | `0.2.1` | Volledig afwijkend versienummerschema |
+| [BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament) | [v3.0.2](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/) | `0.2.1` | Volledig afwijkend versienummerschema |
 | [BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping) | [v3.1.0](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/) | `0.2.1` | Volledig afwijkend versienummerschema |
 
 ### Details: Dubbel versienummerschema
@@ -25,7 +26,7 @@ De documentversie v3.0.1 resp. v3.1.0 is bevestigd via de ReSpec `localBiblio` c
 **BOMOS-Fundament:**
 - Tags: `0.2.1`, `0.2`, `0.1`
 - Geen GitHub Releases
-- Documentversie (ReSpec): `3.0.1`
+- Documentversie (ReSpec): `3.0.2`
 
 **BOMOS-Verdieping:**
 - Tags: `0.2.1`, `0.2`, `0.1`
@@ -34,7 +35,7 @@ De documentversie v3.0.1 resp. v3.1.0 is bevestigd via de ReSpec `localBiblio` c
 
 ## Keuze in SKILL.md
 
-De skill gebruikt de documentversies (`v3.0.1` en `v3.1.0`) van gitdocumentatie.logius.nl, niet de Git-tags die een onafhankelijk versienummerschema voor de repo-structuur hanteren. Dit is een bijzonderheid van BOMOS. Als het versienummerschema wordt geharmoniseerd, moet dit conflict opnieuw worden beoordeeld.
+De skill gebruikt de documentversies (`v3.0.2` en `v3.1.0`) van gitdocumentatie.logius.nl, niet de Git-tags die een onafhankelijk versienummerschema voor de repo-structuur hanteren. Dit is een bijzonderheid van BOMOS. Als het versienummerschema wordt geharmoniseerd, moet dit conflict opnieuw worden beoordeeld.
 
 ## Licentie-status GitHub-repositories
 

--- a/skills/ls-logboek/SKILL.md
+++ b/skills/ls-logboek/SKILL.md
@@ -34,13 +34,13 @@ Net als andere Logius-standaarden kent Logboek Dataverwerkingen twee publicatiek
 - **Vastgestelde versie (DEF)**: officieel goedgekeurd, gepubliceerd op `gitdocumentatie.logius.nl`
 - **Werkversie (draft)**: werk-in-uitvoering, gepubliceerd op `logius-standaarden.github.io`
 
-Logboek Dataverwerkingen heeft momenteel **alleen werkversies**. Er zijn nog geen vastgestelde versies gepubliceerd. Extensies ontlenen hun status aan de hoofdspecificatie. Logboek Dataverwerkingen is nog niet opgenomen op de lijst van het Forum Standaardisatie; de standaard is in ontwikkeling.
+De normatieve hoofdspecificatie **logboek-dataverwerkingen** heeft sinds 9 april 2026 een vastgestelde versie v1.0.0. De overige onderdelen (inleiding, juridisch-beleidskader, extensies) hebben nog alleen werkversies. Extensies ontlenen hun status aan de hoofdspecificatie. Logboek Dataverwerkingen is nog niet opgenomen op de lijst van het Forum Standaardisatie.
 
 ## Repositories
 
 | Repository | Beschrijving | Licentie | Vastgesteld | Draft |
 |-----------|-------------|--------|------------|-------|
-| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen) | Normatieve hoofdspecificatie (logging-interface) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen/) |
+| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen) | Normatieve hoofdspecificatie (logging-interface) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | [v1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0/) | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen/) |
 | [logboek-dataverwerkingen-inleiding](https://github.com/logius-standaarden/logboek-dataverwerkingen-inleiding) | Introductie en achtergrond | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen-inleiding/) |
 | [logboek-dataverwerkingen-juridisch-beleidskader](https://github.com/logius-standaarden/logboek-dataverwerkingen-juridisch-beleidskader) | Juridisch en beleidskader | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) | - | [Draft](https://logius-standaarden.github.io/logboek-dataverwerkingen-juridisch-beleidskader/) |
 | [logboek-dataverwerkingen-demo](https://github.com/logius-standaarden/logboek-dataverwerkingen-demo) | Docker demo-omgeving met meerdere services | [EUPL-1.2](https://eupl.eu/1.2/en) | - | - |

--- a/skills/ls-logboek/conflicts.md
+++ b/skills/ls-logboek/conflicts.md
@@ -1,16 +1,17 @@
 # Logboek Dataverwerkingen - Bronconflicten
 
 Geconstateerd: 2026-02-21
+Bijgewerkt: 2026-04-14
 
 Dit document beschrijft bekende discrepanties en bewuste keuzes voor de Logboek-skill.
 
 ## GitHub-tags vs. gepubliceerde versies
 
-Er zijn geen vastgestelde (DEF) versies voor Logboek Dataverwerkingen. De publicatie-URL `gitdocumentatie.logius.nl/publicatie/logboek/logging/` geeft een 404. De GitHub-repositories hebben geen tags.
+De normatieve hoofdspecificatie heeft sinds 9 april 2026 een vastgestelde versie v1.0.0 op `gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0/`. De GitHub-repo `logboek-dataverwerkingen` heeft nog geen tag die overeenkomt met deze publicatie — dit is een bekend beheerproces-issue. Alle overige repositories hebben nog alleen werkversies en geen tags.
 
 | Repository | Gepubliceerde versie (DEF) | Laatste GitHub-tag | Discrepantie |
 |-----------|---------------------------|-------------------|-------------|
-| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
+| [logboek-dataverwerkingen](https://github.com/logius-standaarden/logboek-dataverwerkingen) | [v1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0/) | _(geen tags)_ | Publicatie loopt voor op tag |
 | [logboek-extensie-lezen](https://github.com/logius-standaarden/logboek-extensie-lezen) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
 | [logboek-extensie-nen7513](https://github.com/logius-standaarden/logboek-extensie-nen7513) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
 | [logboek-extensie-object](https://github.com/logius-standaarden/logboek-extensie-object) | _(geen DEF)_ | _(geen tags)_ | N.v.t. — alleen werkversies |
@@ -21,7 +22,7 @@ Er zijn geen vastgestelde (DEF) versies voor Logboek Dataverwerkingen. De public
 
 ## Keuze in SKILL.md
 
-Alle repositories hebben alleen werkversies; er zijn geen bronconflicten. Als er een DEF-versie wordt vastgesteld, moet dit document worden bijgewerkt met de versie-informatie.
+De hoofdspecificatie `logboek-dataverwerkingen` wordt vermeld met versie v1.0.0 (DEF) op basis van `gitdocumentatie.logius.nl`. Overige onderdelen blijven als werkversies vermeld totdat zij ook een DEF-publicatie krijgen. Bij een nieuwe DEF-publicatie van extensies of inleiding moet dit document worden bijgewerkt.
 
 ## Licentie-status GitHub-repositories
 


### PR DESCRIPTION
## Samenvatting

- **ls-logboek**: `logboek-dataverwerkingen` heeft sinds 9 april 2026 een eerste vastgestelde versie v1.0.0 op gitdocumentatie.logius.nl. De SKILL vermeldde tot nu toe alleen werkversies.
- **ls-bomos**: `BOMOS-Fundament` is bijgewerkt van v3.0.1 naar v3.0.2 op gitdocumentatie.logius.nl.

Beide bronnen zijn geverifieerd via de ReSpec-configuratie (\`specStatus: DEF\`).

## Aanleiding

Monitoring issues in skills-standaarden:
- #481 (github.com/logius-standaarden/publicatie - logboek release-commit 1f70648)
- #482 (publicatie/pull/65 - logboek release-commit 1f70648)

Daarnaast bleek uit een vervolgcommit (113cdf3) dat ook BOMOS-Fundament was herpubliceerd.

Closes #481
Closes #482