### PR TITLE
fix(ls-iam): update Authorization Decision Log naar OpenTelemetry-vorm

### DIFF
--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -220,55 +220,117 @@ Bij een weigering kan het PDP een reden meegeven:
 
 ## Authorization Decision Log
 
-De Authorization Decision Log standaard definieert een gestructureerd formaat voor het vastleggen van autorisatiebeslissingen. Dit is essentieel voor audit, verantwoording en het kunnen reproduceren van historische beslissingen.
+De Authorization Decision Log standaard definieert een gestructureerd formaat voor het vastleggen van autorisatiebeslissingen. Dit is essentieel voor audit, verantwoording en het reproduceren van historische beslissingen.
+
+De werkversie volgt sinds april 2026 een **OpenTelemetry-vorm** op basis van de AuthZEN-informatiemodel. Het record-model is transport-onafhankelijk; OTLP wordt aanbevolen, maar elke transport (REST, gRPC, messaging) is toegestaan zolang het record de gespecificeerde velden draagt.
 
 ### Verplichte velden
 
+| Veld | Type | Beschrijving |
+|------|------|-------------|
+| `trace_id` | 16 byte hex (32 chars) | Trace-identifier conform [W3C Trace Context](https://www.w3.org/TR/trace-context/), MUST cryptografisch random gegenereerd worden |
+| `span_id` | 8 byte hex (16 chars) | Span-identifier voor deze beslissing |
+| `event_name` | string | Type beslissing — een van vijf vaste waarden (zie hieronder) |
+| `timestamp` | uint64 | Aantal milliseconden sinds Unix epoch |
+| `status` | enum | `Unset`, `Ok` of `Error` |
+
+### Conditioneel verplicht
+
 | Veld | Beschrijving |
 |------|-------------|
-| `timestamp` | Tijdstip van de beslissing (ISO 8601) |
-| `type` | Type van het record, bijvoorbeeld `evaluation` |
-| `request` | Het oorspronkelijke autorisatieverzoek (subject, action, resource, context) |
-| `response` | De autorisatiebeslissing (decision en eventuele context) |
-
-### Aanbevolen velden (SHOULD)
-
-| Veld | Beschrijving |
-|------|-------------|
-| `trace_id` | Unieke trace identifier conform W3C Trace Context |
-| `span_id` | Span identifier binnen de trace |
+| `parent_span_id` | Verplicht wanneer een upstream `traceparent` aanwezig is; alleen weglaatbaar bij root-span |
 
 ### Optionele velden
 
 | Veld | Beschrijving |
 |------|-------------|
-| `policies` | Referenties naar toegepaste beleidsregels, inclusief versienummers |
-| `information` | Aanvullende data die het PIP heeft geleverd voor de besluitvorming |
-| `configuration` | Configuratie van het PDP ten tijde van de beslissing |
+| `attributes` | Source-referenties en metadata (`adl.core.*` keys) |
+| `resource` | OpenTelemetry resource-object (component-context) |
+| `body` | Raw payload (`adl.core.request`, `adl.core.response`, etc.) |
 
-### Voorbeeld log record
+### `event_name` waarden
+
+Elk record correspondeert met één van de vijf AuthZEN APIs:
+
+| AuthZEN API | `event_name` |
+|-------------|--------------|
+| Access Evaluation API | `adl.access_evaluation` |
+| Access Evaluations API | `adl.access_evaluations` |
+| Subject Search API | `adl.search_subject` |
+| Action Search API | `adl.search_action` |
+| Resource Search API | `adl.search_resource` |
+
+### `status` waarden
+
+- `Unset` (default) — PDP heeft geëvalueerd zonder fout. Een denial (`decision: false`) is `Unset`, niet `Error`.
+- `Ok` — optionele expliciete markering van succesvolle evaluatie, functioneel gelijk aan `Unset`.
+- `Error` — PDP kon geen beslissing produceren (engine fault, missende attributen, downstream timeout).
+
+### `attributes.adl.core.*`
+
+Source-referenties (geen raw data — die hoort in `body`). Een veld MOET in precies één van beide locaties staan.
+
+| Attribute | Beschrijving |
+|-----------|-------------|
+| `adl.core.request` | Source-referentie naar de input van de beslissing (AuthZEN-formaat) |
+| `adl.core.response` | Source-referentie naar de output (verplicht retrieveerbaar bij `status: Unset`/`Ok`) |
+| `adl.core.policies` | Object met per policy-source een versie-identifier (timestamp, hash, semver) |
+| `adl.core.information` | Referenties naar PIP-data die voor de beslissing is gebruikt |
+| `adl.core.configuration` | Configuratie van PDP/PIP/PAP ten tijde van de beslissing |
+| `adl.fsc.transaction_id` | FSC transaction-id voor correlatie met FSC logs |
+
+Aanvullende keys buiten `adl.*` mogen worden opgenomen volgens `<vendor>.<area>.<name>`-conventie. Onbekende keys MOETEN zonder fout worden genegeerd door consumers.
+
+### Levels of detail
+
+Vier niveaus van replayability, oplopend in detail:
+
+| Niveau | Bevat | Doel |
+|--------|-------|------|
+| 1 | Request + response | Basis-accountability |
+| 2 | + `adl.core.policies` | Policy-versie reproduceerbaar |
+| 3 | + `adl.core.information` | PIP-data reconstrueerbaar (full replayability bij deterministische engine) |
+| 4 | + `adl.core.configuration` | Volledige replayability inclusief engine-configuratie |
+
+### Voorbeeld log record (Level 1)
 
 ```json
 {
-  "timestamp": "2025-09-07T10:14:18Z",
   "trace_id": "28dbeec32e77635cc19bc3204ec56c41",
-  "span_id": "893e1b2ac52d712f",
-  "type": "evaluation",
-  "request": {
-    "subject": { "type": "user", "id": "alice" },
-    "action": { "name": "approve" },
-    "resource": { "type": "holiday-request", "id": "446epbc8y7" }
-  },
-  "response": {
-    "decision": false,
-    "context": {
-      "reason": {
-        "48": "No signing authority"
+  "span_id": "5e3c8a4f9b2d1e07",
+  "parent_span_id": "893e1b2ac52d712f",
+  "event_name": "adl.access_evaluation",
+  "timestamp": 1757240058042,
+  "status": "Unset",
+  "attributes": {},
+  "body": {
+    "adl.core.request": {
+      "subject": { "type": "user", "id": "alice" },
+      "action": { "name": "approve" },
+      "resource": {
+        "type": "holiday-request",
+        "id": "446epbc8y7",
+        "properties": { "employee": "bob" }
+      },
+      "context": {
+        "traceparent": "00-28dbeec32e77635cc19bc3204ec56c41-dec5220770f8f4f4-01"
       }
+    },
+    "adl.core.response": {
+      "decision": false,
+      "context": { "reason": { "48": "No signing authority" } }
     }
   }
 }
 ```
+
+### Trace context propagatie
+
+Alle componenten in een autorisatie-evaluatie (PEP, PDP, PIP, PAP) MOETEN W3C Trace Context propageren. De `trace_id` blijft ongewijzigd over organisatiegrenzen heen — een nieuwe `trace_id` mag NIET binnen een lopende beslissingsflow worden gealloceerd. Logging is onafhankelijk van het `sampled`-bit in `traceparent`: ADL-records MOETEN altijd worden geproduceerd, ongeacht sampling.
+
+### Idempotente ingestion
+
+Re-submission van hetzelfde log record (bijvoorbeeld door queue-redelivery in een write-ahead-log patroon) MOET niet leiden tot duplicate records. De idempotency-sleutel is implementatie-specifiek; gangbare keuzes zijn `(trace_id, span_id)` of een content-hash van het record.
 
 ---
 

--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -220,37 +220,25 @@ Bij een weigering kan het PDP een reden meegeven:
 
 ## Authorization Decision Log
 
-De Authorization Decision Log standaard definieert een gestructureerd formaat voor het vastleggen van autorisatiebeslissingen. Dit is essentieel voor audit, verantwoording en het reproduceren van historische beslissingen.
+De ADL-standaard definieert een gestructureerd formaat voor het vastleggen van autorisatiebeslissingen voor audit, verantwoording en replay. De werkversie volgt sinds april 2026 een **OpenTelemetry-vorm** op basis van het AuthZEN-informatiemodel. Het record-model is transport-onafhankelijk; OTLP wordt aanbevolen, maar elke transport (REST, gRPC, messaging) is toegestaan zolang het record de gespecificeerde velden draagt.
 
-De werkversie volgt sinds april 2026 een **OpenTelemetry-vorm** op basis van de AuthZEN-informatiemodel. Het record-model is transport-onafhankelijk; OTLP wordt aanbevolen, maar elke transport (REST, gRPC, messaging) is toegestaan zolang het record de gespecificeerde velden draagt.
+### Record-velden
 
-### Verplichte velden
+| Veld | Type | Verplicht? | Beschrijving |
+|------|------|-----------|-------------|
+| `trace_id` | 16 byte hex (32 chars) | Ja | Trace-id conform [W3C Trace Context](https://www.w3.org/TR/trace-context/), cryptografisch random |
+| `span_id` | 8 byte hex (16 chars) | Ja | Span-id voor deze beslissing |
+| `parent_span_id` | 8 byte hex (16 chars) | Conditioneel | Verplicht bij upstream `traceparent`; alleen weglaatbaar bij root-span |
+| `event_name` | string | Ja | Een van vijf vaste waarden (zie hieronder) |
+| `timestamp` | uint64 | Ja | Milliseconden sinds Unix epoch |
+| `status` | enum | Ja | `Unset` (default, ook bij denial), `Ok`, of `Error` (PDP kon geen beslissing produceren) |
+| `attributes` | object | Optioneel | Source-referenties en metadata (`adl.core.*`) |
+| `resource` | object | Optioneel | OpenTelemetry resource-object (component-context) |
+| `body` | object | Optioneel | Raw payload (`adl.core.request`, `adl.core.response`, etc.) |
 
-| Veld | Type | Beschrijving |
-|------|------|-------------|
-| `trace_id` | 16 byte hex (32 chars) | Trace-identifier conform [W3C Trace Context](https://www.w3.org/TR/trace-context/), MUST cryptografisch random gegenereerd worden |
-| `span_id` | 8 byte hex (16 chars) | Span-identifier voor deze beslissing |
-| `event_name` | string | Type beslissing — een van vijf vaste waarden (zie hieronder) |
-| `timestamp` | uint64 | Aantal milliseconden sinds Unix epoch |
-| `status` | enum | `Unset`, `Ok` of `Error` |
-
-### Conditioneel verplicht
-
-| Veld | Beschrijving |
-|------|-------------|
-| `parent_span_id` | Verplicht wanneer een upstream `traceparent` aanwezig is; alleen weglaatbaar bij root-span |
-
-### Optionele velden
-
-| Veld | Beschrijving |
-|------|-------------|
-| `attributes` | Source-referenties en metadata (`adl.core.*` keys) |
-| `resource` | OpenTelemetry resource-object (component-context) |
-| `body` | Raw payload (`adl.core.request`, `adl.core.response`, etc.) |
+Een denial (`decision: false`) is `Unset`, niet `Error`.
 
 ### `event_name` waarden
-
-Elk record correspondeert met één van de vijf AuthZEN APIs:
 
 | AuthZEN API | `event_name` |
 |-------------|--------------|
@@ -260,37 +248,24 @@ Elk record correspondeert met één van de vijf AuthZEN APIs:
 | Action Search API | `adl.search_action` |
 | Resource Search API | `adl.search_resource` |
 
-### `status` waarden
-
-- `Unset` (default) — PDP heeft geëvalueerd zonder fout. Een denial (`decision: false`) is `Unset`, niet `Error`.
-- `Ok` — optionele expliciete markering van succesvolle evaluatie, functioneel gelijk aan `Unset`.
-- `Error` — PDP kon geen beslissing produceren (engine fault, missende attributen, downstream timeout).
-
 ### `attributes.adl.core.*`
 
-Source-referenties (geen raw data — die hoort in `body`). Een veld MOET in precies één van beide locaties staan.
+Source-referenties — geen raw data, die hoort in `body`. Een veld MOET in precies één van beide locaties staan.
 
 | Attribute | Beschrijving |
 |-----------|-------------|
-| `adl.core.request` | Source-referentie naar de input van de beslissing (AuthZEN-formaat) |
-| `adl.core.response` | Source-referentie naar de output (verplicht retrieveerbaar bij `status: Unset`/`Ok`) |
+| `adl.core.request` | Input van de beslissing (AuthZEN-formaat) |
+| `adl.core.response` | Output (verplicht retrieveerbaar bij `status: Unset`/`Ok`) |
 | `adl.core.policies` | Object met per policy-source een versie-identifier (timestamp, hash, semver) |
-| `adl.core.information` | Referenties naar PIP-data die voor de beslissing is gebruikt |
-| `adl.core.configuration` | Configuratie van PDP/PIP/PAP ten tijde van de beslissing |
+| `adl.core.information` | Referenties naar PIP-data |
+| `adl.core.configuration` | Configuratie van PDP/PIP/PAP |
 | `adl.fsc.transaction_id` | FSC transaction-id voor correlatie met FSC logs |
 
-Aanvullende keys buiten `adl.*` mogen worden opgenomen volgens `<vendor>.<area>.<name>`-conventie. Onbekende keys MOETEN zonder fout worden genegeerd door consumers.
+Aanvullende keys volgen `<vendor>.<area>.<name>`. Onbekende keys MOETEN door consumers worden genegeerd.
 
 ### Levels of detail
 
-Vier niveaus van replayability, oplopend in detail:
-
-| Niveau | Bevat | Doel |
-|--------|-------|------|
-| 1 | Request + response | Basis-accountability |
-| 2 | + `adl.core.policies` | Policy-versie reproduceerbaar |
-| 3 | + `adl.core.information` | PIP-data reconstrueerbaar (full replayability bij deterministische engine) |
-| 4 | + `adl.core.configuration` | Volledige replayability inclusief engine-configuratie |
+Vier niveaus van replayability (zie [reference.md](reference.md)): (1) request+response, (2) + `adl.core.policies`, (3) + `adl.core.information`, (4) + `adl.core.configuration`.
 
 ### Voorbeeld log record (Level 1)
 
@@ -302,35 +277,23 @@ Vier niveaus van replayability, oplopend in detail:
   "event_name": "adl.access_evaluation",
   "timestamp": 1757240058042,
   "status": "Unset",
-  "attributes": {},
   "body": {
     "adl.core.request": {
-      "subject": { "type": "user", "id": "alice" },
-      "action": { "name": "approve" },
-      "resource": {
-        "type": "holiday-request",
-        "id": "446epbc8y7",
-        "properties": { "employee": "bob" }
-      },
-      "context": {
-        "traceparent": "00-28dbeec32e77635cc19bc3204ec56c41-dec5220770f8f4f4-01"
-      }
+      "subject": {"type": "user", "id": "alice"},
+      "action": {"name": "approve"},
+      "resource": {"type": "holiday-request", "id": "446epbc8y7"}
     },
     "adl.core.response": {
       "decision": false,
-      "context": { "reason": { "48": "No signing authority" } }
+      "context": {"reason": {"48": "No signing authority"}}
     }
   }
 }
 ```
 
-### Trace context propagatie
+### Trace context en ingestion
 
-Alle componenten in een autorisatie-evaluatie (PEP, PDP, PIP, PAP) MOETEN W3C Trace Context propageren. De `trace_id` blijft ongewijzigd over organisatiegrenzen heen — een nieuwe `trace_id` mag NIET binnen een lopende beslissingsflow worden gealloceerd. Logging is onafhankelijk van het `sampled`-bit in `traceparent`: ADL-records MOETEN altijd worden geproduceerd, ongeacht sampling.
-
-### Idempotente ingestion
-
-Re-submission van hetzelfde log record (bijvoorbeeld door queue-redelivery in een write-ahead-log patroon) MOET niet leiden tot duplicate records. De idempotency-sleutel is implementatie-specifiek; gangbare keuzes zijn `(trace_id, span_id)` of een content-hash van het record.
+Alle componenten (PEP, PDP, PIP, PAP) MOETEN W3C Trace Context propageren; `trace_id` blijft ongewijzigd over organisatiegrenzen, ook bij sampling=0 (records worden altijd geproduceerd). Ingestion MOET idempotent zijn met `(trace_id, span_id)` of content-hash als sleutel. Zie [reference.md](reference.md) voor details.
 
 ---
 

--- a/skills/ls-iam/reference.md
+++ b/skills/ls-iam/reference.md
@@ -158,6 +158,35 @@ Clients moeten vooraf worden geregistreerd bij de OpenID Provider. Bij registrat
 
 ## Authorization Decision Log - Uitgebreide Documentatie
 
+### Levels of detail
+
+De standaard definieert vier niveaus van replayability, elk oplopend in detail:
+
+| Niveau | Bevat | Doel |
+|--------|-------|------|
+| 1 | Request + response | Basis-accountability |
+| 2 | + `adl.core.policies` | Policy-versie reproduceerbaar |
+| 3 | + `adl.core.information` | PIP-data reconstrueerbaar (full replayability bij deterministische engine) |
+| 4 | + `adl.core.configuration` | Volledige replayability inclusief engine-configuratie |
+
+Het juiste niveau hangt af van de organisatorische context en wettelijke vereisten — het hoogste niveau is niet altijd nodig.
+
+### Trace context propagatie
+
+Alle componenten in een autorisatie-evaluatie (PEP, PDP, PIP, PAP) MOETEN W3C Trace Context propageren en trace-continuïteit over componentgrenzen behouden. Bij een inkomende request creëert een component een span als child van de span uit `traceparent`, of start een nieuwe trace als root-span bij afwezigheid. De `trace_id` blijft ongewijzigd over organisatiegrenzen heen — een nieuwe `trace_id` mag NIET binnen een lopende beslissingsflow worden gealloceerd.
+
+Logging is onafhankelijk van het `sampled`-bit in `traceparent`: dat bit regelt alleen telemetry-sampling. ADL-records zijn accountability records en MOETEN altijd worden geproduceerd, ongeacht sampling. ADL-emitters MOGEN het `sampled`-flag NIET wijzigen.
+
+Pro-actieve interacties (zoals een PAP die policies distribueert naar een PDP) vallen buiten de trace van een individuele autorisatiebeslissing — die hebben hun eigen lifecycle en, waar van toepassing, eigen traces.
+
+### Idempotente ingestion
+
+Ingestion van log records MOET idempotent zijn: re-submission van hetzelfde record (bijvoorbeeld door queue-redelivery in een write-ahead-log patroon) MOET niet leiden tot een duplicate persisted record. De idempotency-sleutel is implementatie-specifiek; gangbare keuzes zijn `(trace_id, span_id)` of een content-hash.
+
+### Cached decisions
+
+Caching van autorisatiebeslissingen wordt afgeraden: een gecachte beslissing verwijst naar policies en informatie die actueel waren bij cache-populatie, en replay tegen de huidige state kan een ander resultaat geven. Per-cache-use logging — vereist voor accountability — erodeert het performance-voordeel van caching. Indien toch toegepast, MOET de toepassing van een gecachte beslissing een nieuw log record produceren met de `trace_id` en `parent_span_id` van de nieuwe request en een vers gealloceerde `span_id`.
+
 ### Integratie en Transport
 
 **FSC Logging**: de Authorization Decision Log integreert met FSC (Federated Service Connectivity) logging via het `adl.fsc.transaction_id` attribute. Hiermee kunnen autorisatiebeslissingen worden gerelateerd aan de bredere transactieketen.

--- a/skills/ls-iam/reference.md
+++ b/skills/ls-iam/reference.md
@@ -160,11 +160,11 @@ Clients moeten vooraf worden geregistreerd bij de OpenID Provider. Bij registrat
 
 ### Integratie en Transport
 
-**FSC Logging**: de Authorization Decision Log integreert met FSC (Federated Service Connectivity) logging via het `transaction_id` veld. Hiermee kunnen autorisatiebeslissingen worden gerelateerd aan de bredere transactieketen.
+**FSC Logging**: de Authorization Decision Log integreert met FSC (Federated Service Connectivity) logging via het `adl.fsc.transaction_id` attribute. Hiermee kunnen autorisatiebeslissingen worden gerelateerd aan de bredere transactieketen.
 
-**FSC Transactieketen**: Wanneer een API-aanroep meerdere services doorloopt, wordt de `transaction_id` doorgegeven. Elke service logt zijn autorisatiebeslissingen met deze ID, waardoor de volledige transactieketen kan worden gereconstrueerd voor audit doeleinden.
+**FSC Transactieketen**: Wanneer een API-aanroep meerdere services doorloopt, wordt de FSC transaction-id doorgegeven. Elke service logt zijn autorisatiebeslissingen met deze ID in `attributes.adl.fsc.transaction_id`, waardoor de volledige transactieketen kan worden gereconstrueerd voor audit doeleinden.
 
-**OpenTelemetry Protocol (OTLP)**: OTLP wordt aanbevolen als transportprotocol voor het verzenden van log records naar centrale logging-infrastructuur. Dit sluit aan bij de W3C Trace Context die al in de `trace_id` en `span_id` velden wordt gebruikt.
+**OpenTelemetry Protocol (OTLP)**: OTLP wordt aanbevolen als transportprotocol voor het verzenden van log records naar centrale logging-infrastructuur. Het record-model zelf is bewust transport-onafhankelijk (REST, gRPC, messaging, file ingestion zijn allemaal toegestaan), maar de OpenTelemetry-vorm sluit aan bij W3C Trace Context die al in `trace_id`, `span_id` en `parent_span_id` wordt gebruikt.
 
 **OTLP Integratie**:
 - Log records worden verzonden als OTLP log events


### PR DESCRIPTION
## Summary
- ADL-werkversie is gerefactored naar een OpenTelemetry-vormig log-record (upstream PR #21, commit `a910e4d` op 2026-04-28)
- Skill-content vervangen: oude flat record (`timestamp`/`type`/`request`/`response`) is vervangen door OTel-shape met `trace_id`, `span_id`, `parent_span_id`, `event_name` (5 vaste waarden), `timestamp` (uint64 ms), `status` enum, `attributes.adl.core.*` source-references vs `body` voor raw payloads
- Reference.md correctie: FSC-veld is nu `adl.fsc.transaction_id` (was `transaction_id`)
- Sluit #570, #571

## Test plan
- [x] `uv run pytest -q` (61 passed)
- [x] `uv run ruff check scripts/ tests/` (clean)
- [x] Pre-commit hooks: ruff + markdownlint passed