### PR TITLE
fix: corrigeer 5 onjuistheden in skill-content (audit-findings)

### DIFF
--- a/skills/ls-api/SKILL.md
+++ b/skills/ls-api/SKILL.md
@@ -114,7 +114,7 @@ Geen technische details (stack traces, interne hints) in foutmeldingen.
 
 - OpenAPI 3.0+ specificatie verplicht
 - Publiceer JSON op standaardlocatie: `/openapi.json` (VERPLICHT); YAML (`/openapi.yaml`) is OPTIONEEL
-- Contactinformatie verplicht (name, email, url)
+- Contactinformatie (`info.contact` met `name`, `email`, `url`) wordt sterk aanbevolen voor publieke APIs (ADR `/core/doc-openapi-contact`: SHOULD); de Spectral linter dwingt deze velden af als error voor publieke APIs
 - CORS ondersteunen voor documentatie-toegang
 
 ## Modules

--- a/skills/ls-dk/reference.md
+++ b/skills/ls-dk/reference.md
@@ -71,13 +71,13 @@ ebMS2 (Electronic Business Messaging Service version 2) biedt asynchrone, betrou
 - **Berichtformaat**: SOAP 1.1 met ebMS2 headers, payload als MIME-attachment
 - **Profielen**:
   - **osb-be** (Best-effort): Asynchroon berichtverkeer zonder betrouwbaarheidsgaranties
-  - **osb-rm** (Reliable Messaging): Asynchroon berichtverkeer met MessageOrder, at-most-once delivery, duplicate-eliminatie en Message Acknowledgements
+  - **osb-rm** (Reliable Messaging): Asynchroon berichtverkeer met MessageOrder, **once-and-only-once** (exactly-once) delivery, duplicate-eliminatie en Message Acknowledgements
   - **osb-be-S** (Best-effort, Signed): Asynchroon met ondertekening op berichtniveau
   - **osb-rm-S** (Reliable, Signed): Betrouwbaar asynchroon met ondertekening
   - **osb-be-E** (Best-effort, Encrypted): Asynchroon met versleuteling op berichtniveau
   - **osb-rm-E** (Reliable, Encrypted): Betrouwbaar asynchroon met versleuteling
 - **Betrouwbaarheidsmechanismen** (rm-profielen):
-  - **At-most-once delivery**: Garandeert dat een bericht maximaal eenmaal wordt afgeleverd
+  - **Once-and-only-once delivery** (exactly-once): Garandeert end-to-end dat een bericht precies één keer wordt afgeleverd, op basis van end-to-end retransmission
   - **Duplicate-eliminatie**: Herkent en verwijdert duplicaten op basis van MessageId
   - **Message Acknowledgements**: Ontvangstbevestigingen (Message Status Response)
   - **Message Ordering**: Optionele volgordelijkheid van berichten via ConversationId en SequenceNumber

--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -117,7 +117,7 @@ Het ID Token moet minimaal de volgende claims bevatten:
 | `exp` | Verloopdatum van het token (expiration) |
 | `iat` | Tijdstip van uitgifte (issued at) |
 | `nonce` | Waarde uit het authorization request (voorkomt replay attacks) |
-| `acr` | Betrouwbaarheidsniveau (SHOULD — aanbevolen, niet verplicht) |
+| `acr` | Betrouwbaarheidsniveau (OPTIONAL per OIDC NL GOV; **als gezet MOET de waarde minimaal het gevraagde betrouwbaarheidsniveau zijn**) |
 
 ### ID Token validatie
 
@@ -128,7 +128,7 @@ Bij het valideren van een OIDC ID Token MOETEN de volgende stappen worden doorlo
 3. **aud** - MOET de `client_id` van de relying party bevatten
 4. **nonce** - MOET exact overeenkomen met de nonce uit het authorization request
 5. **exp** - MOET in de toekomst liggen (token niet verlopen)
-6. **iat** - MAG niet te ver in het verleden liggen (max 5 minuten aanbevolen)
+6. **iat** - MOET in het verleden liggen; de acceptabele afstand is per Client te bepalen (OIDC NL GOV laat dit expliciet aan de Client; veelvoorkomende keuze in de praktijk: enkele minuten)
 7. **acr** - MOET minimaal het gevraagde betrouwbaarheidsniveau bevatten
 8. **jti** - MOET uniek zijn (bewaar voldoende lang om hergebruik te detecteren)
 

--- a/skills/ls-logboek/SKILL.md
+++ b/skills/ls-logboek/SKILL.md
@@ -148,7 +148,7 @@ De standaard schrijft geen specifiek transportprotocol voor, maar beveelt **Open
 
 **Vereisten:**
 
-- Het Logboek **MOET** TLS kunnen afdwingen voor alle communicatie.
+- Het Logboek **MOET** TLS kunnen afdwingen (capability-eis aan de software). De spec verduidelijkt expliciet dat hiermee niet wordt bedoeld dat TLS verplicht is — of TLS-connecties daadwerkelijk worden toegepast is een organisatie-keuze.
 - Het Logboek **MOET** elke schrijfactie bevestigen met een bevestigingsbericht (acknowledgement). De applicatie weet hierdoor zeker dat de logregel is opgeslagen.
 - OTLP ondersteunt zowel gRPC als HTTP/protobuf als transportlaag (standaard OTLP-poorten: 4317 voor gRPC, 4318 voor HTTP — niet voorgeschreven door de Logboek-standaard zelf).
 


### PR DESCRIPTION
## Samenvatting

Een fact-grounding audit heeft elke verifieerbare claim in alle skills systematisch tegen de Logius-bronnen getoetst. **5 claims spreken hun bron expliciet tegen** en zijn nu hersteld.

| Skill | Bestand | Claim | Bron |
|---|---|---|---|
| `ls-api` | SKILL.md | OpenAPI `info.contact` was "verplicht" → moet SHOULD voor publieke APIs zijn | [ADR 2.1.0 §3.6](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/) |
| `ls-dk` | reference.md | osb-rm garandeerde "at-most-once" → moet "once-and-only-once" (exactly-once) zijn | [ebMS2 3.3.2](https://gitdocumentatie.logius.nl/publicatie/dk/ebms) |
| `ls-iam` | SKILL.md | `acr` claim was SHOULD → spec markeert OPTIONAL | [OIDC NL GOV 1.0.1](https://gitdocumentatie.logius.nl/publicatie/api/oidc) |
| `ls-iam` | SKILL.md | iat "max 5 min aanbevolen" → spec laat dit aan de Client | [OIDC NL GOV 1.0.1](https://gitdocumentatie.logius.nl/publicatie/api/oidc) |
| `ls-logboek` | SKILL.md | "MOET TLS afdwingen voor alle communicatie" → capability-eis, geen runtime-eis | [Logboek 1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0) |

Voor elke fix staat de exacte bron-quote in de commit-body.

## Achtergrond

Deze audit vond in totaal **6 echte tegenstrijdigheden** (op 421 claims in skills-standaarden, ~1.4%). 1 daarvan (de andere ls-dk claim over berichtgrootte 20 MiB Grote Berichten) is een duplicaat-extractie en pakken we niet apart aan.

Naast deze CONTRADICTED bevindingen identificeerde de audit:
- 14 KNOWN_DISCREPANCY claims die al gedocumenteerd zijn in `conflicts.md` (geen actie)
- ~110 PARTIALLY_GROUNDED claims waar de bron deels ondersteunt — die kunnen later in een aparte herformuleringsronde

## Test plan
- [ ] Per fix: de gewijzigde tekst representeert de bron correct
- [ ] Geen onbedoelde semantische verschuivingen elders in de skill
- [ ] CI groen