### PR TITLE
fix: kort skill descriptions in om listing budget te ontlasten

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Elk domein heeft een `conflicts.md` met vaste structuur:
 De `SKILL.md` verwijst naar `conflicts.md` in de Achtergrondinfo-sectie.
 
 ### Description triggers
-Descriptions bevatten zowel Nederlandse als technische Engelse triggerwoorden zodat de skill bij relevante vragen wordt geactiveerd.
+Descriptions bevatten zowel Nederlandse als technische Engelse triggerwoorden zodat de skill bij relevante vragen wordt geactiveerd. Houd descriptions kort: doel **~150 chars, max 200**. Eén functionele zin met de eigennamen die mensen daadwerkelijk gebruiken (DMARC, OAuth, NEN 3610) is genoeg; voeg alleen een korte triggerstaart toe voor termen die niet uit de hoofdzin volgen. Geen "Gebruik deze skill wanneer..."-aanhef en geen quoted keyword-lijsten — die vreten skill listing budget op zonder triggerwaarde toe te voegen.
 
 ### Allowed tools
 Pas per skill aan. Niet elke skill heeft alle tools nodig. Standaard set:

--- a/skills/ls-api/SKILL.md
+++ b/skills/ls-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-api
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'API Design Rules', 'ADR', 'REST API standaard', 'API richtlijnen', 'NL GOV API', 'Spectral linter', 'API linter', 'OpenAPI validatie', 'API design', 'REST API naming', 'transport security', 'API signing', 'API encryption', 'geospatial API', 'api-linter', 'problem+json', 'error response format'."
+description: "API Design Rules (ADR) voor NL GOV REST APIs: Spectral-linting, naming, transport security, signing, encryption, problem+json errors, geo-extensie."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls-bomos/SKILL.md
+++ b/skills/ls-bomos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-bomos
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'BOMOS', 'Beheer- en Ontwikkelmodel', 'open standaarden beheer', 'standaardisatie governance', 'beheermodel', 'community management standaarden', 'open source governance', 'stelselstandaarden', 'RFC proces', 'wijzigingsproces standaard', 'change management standaarden'."
+description: "BOMOS (Beheer- en Ontwikkelmodel voor Open Standaarden): governance, RFC-proces, community management voor stelselstandaarden bij de overheid."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls-dk/SKILL.md
+++ b/skills/ls-dk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-dk
-description: "Gebruik deze skill wanneer de gebruiker vraagt over Digikoppeling, koppelvlakstandaarden, ebMS2, WUS, WSDL, SOAP, REST-API koppelvlak, grote berichten, OIN, Organisatie Identificatie Nummer, PKIoverheid, beveiligingsstandaarden overheid, routering en adressering, CPA, berichtuitwisseling tussen overheidsorganisaties."
+description: "Digikoppeling koppelvlakken (ebMS2, WUS, REST-API, grote berichten) voor berichtuitwisseling tussen overheidsorganisaties. Ook OIN, PKIoverheid, CPA, routering."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls-egov/SKILL.md
+++ b/skills/ls-egov/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-egov
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'Terugmelding', 'Terugmelden', 'Digimelding', 'basisfactuur', 'basisorder', 'e-procurement', 'inkoopstandaarden overheid', 'factuurstandaard', 'NLCIUS', 'Peppol BIS', 'PEPPOLBIS', 'elektronisch bestellen', 'UBL', 'UBL 2.1', 'factuur validatie', 'Schematron'."
+description: "E-procurement bij de overheid: Peppol BIS, NLCIUS, UBL 2.1, basisfactuur, basisorder, Schematron-validatie. Ook Digimelding/Terugmelden voor basisregistraties."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls-fsc/SKILL.md
+++ b/skills/ls-fsc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-fsc
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'FSC', 'Federated Service Connectivity', 'federatieve dienstverlening', 'inway', 'outway', 'service directory', 'regulated area', 'external contract', 'fsc-core', 'NLX', 'peer', 'PeerID', 'Manager API'."
+description: "Federated Service Connectivity (FSC, voorheen NLX): inway, outway, service directory, peers, external contracts, Manager API."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-iam
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'OAuth', 'OpenID Connect', 'OIDC', 'authenticatie', 'autorisatie', 'AuthZEN', 'SAML', 'identity management', 'toegangsbeheer', 'OAuth NL profiel', 'OIDC NL GOV', 'NL GOV profiel', 'authorization decision', 'OIN authenticatie', 'token endpoint', 'JWT', 'private_key_jwt', 'client credentials', 'authorization_code', 'PKCE'."
+description: "OAuth, OpenID Connect, AuthZEN, SAML voor authenticatie en autorisatie bij de overheid. NL GOV profielen, JWT, PKCE, private_key_jwt, OIN authenticatie."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls-logboek/SKILL.md
+++ b/skills/ls-logboek/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-logboek
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'Logboek Dataverwerkingen', 'dataverwerkingen logging', 'transparantie dataverwerkingen', 'NEN 7513', 'logging API overheid', 'logboek extensie', 'AVG logging', 'GDPR logging', 'verwerkingenlogging', 'OpenTelemetry', 'OTLP', 'dpl.core', 'verwerkingsactiviteit loggen'."
+description: "Logboek Dataverwerkingen voor AVG/GDPR-transparantie. NEN 7513, OpenTelemetry/OTLP, dpl.core, verwerkingenlogging in overheidssystemen."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls-notif/SKILL.md
+++ b/skills/ls-notif/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-notif
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'CloudEvents', 'notificaties', 'notificatieservices', 'abonnementen', 'event-driven', 'NL GOV CloudEvents', 'pub/sub overheid', 'gebeurtenisnotificatie', 'webhook', 'webhooks', 'subscription'."
+description: "NL GOV CloudEvents profiel voor notificatieservices: abonnementen, webhooks, pub/sub tussen overheidsorganisaties."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls-pub/SKILL.md
+++ b/skills/ls-pub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls-pub
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'publicatie', 'ReSpec', 'documentatie tooling', 'GitHub Actions workflows', 'build workflow', 'check workflow', 'publish workflow', 'tech radar', 'WCAG check', 'markdownlint', 'markdown lint', 'kwaliteitscheck', 'Muffet', 'link validatie', 'automatisering', 'HTML generatie', 'PDF generatie', 'accessibility check', 'a11y'. Niet voor API linting (zie ls-api) of code linting."
+description: "Logius publicatieworkflow voor standaardenrepos: ReSpec, GitHub Actions, markdownlint, WCAG/a11y, Muffet linkvalidatie, tech radar. Niet voor API of code linting."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/ls/SKILL.md
+++ b/skills/ls/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ls
-description: "Overzicht van alle Logius standaarden. Gebruik deze skill wanneer de gebruiker vraagt over 'Logius standaarden', 'Nederlandse overheidsstandaarden', 'interoperabiliteit', 'welke standaarden zijn er', 'standaarden overzicht', 'welke standaard moet ik gebruiken', of een vraag heeft die niet duidelijk bij een domein past."
+description: "Overzicht van Logius standaarden voor de Nederlandse overheid. Routeert naar sub-skills (Digikoppeling, API Design Rules, OAuth, FSC, BOMOS, etc.) of geeft hulp bij interoperabiliteitsvragen."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)


### PR DESCRIPTION
## Probleem

Per `developer-overheid-nl/skills-marketplace#61` melden gebruikers dat onze plugin descriptions zoveel skill listing budget vreten dat in gemengde sessies skills uit de listing vallen ("60 descriptions dropped, 3.1%/1% of context").

Onze 10 standaarden-skills gingen tot 427 chars (`ls-pub`), gemiddeld 324 chars. Het patroon was vrijwel altijd `Gebruik deze skill wanneer de gebruiker vraagt over 'X', 'Y', 'Z', ...` met 10-20 quoted keywords. Die aanhef en quotes voegen geen triggerwaarde toe — het model matcht semantisch op de termen, niet op de aanhalingstekens of de "Gebruik deze skill" formule.

## Wat verandert

Per skill: één Nederlandse functionele zin met de eigennamen die mensen daadwerkelijk gebruiken (OAuth, Digikoppeling, NEN 7513, Peppol BIS), eventueel een korte triggerstaart voor termen die niet uit de hoofdzin volgen. Doel ~150 chars, max 200.

Niet-afleidbare jargon blijft expliciet:
- `ls-iam`: PKCE, JWT, private_key_jwt, OIN authenticatie
- `ls-pub`: ReSpec, Muffet, markdownlint, WCAG, a11y, tech radar
- `ls-egov`: Peppol BIS, NLCIUS, UBL 2.1, Schematron, Digimelding/Terugmelden
- `ls-logboek`: NEN 7513, OpenTelemetry/OTLP, dpl.core
- `ls-dk`: ebMS2, WUS, OIN, PKIoverheid, CPA
- `ls-fsc`: inway, outway, service directory, peers
- `ls-bomos`: BOMOS

Synoniemen die het model semantisch dekt zijn weg: 'OIDC' + 'OpenID Connect' + 'OIDC NL GOV' + 'NL GOV profiel' werd één term + "NL GOV profielen". 'AVG logging' + 'GDPR logging' werd "AVG/GDPR-transparantie".

## Resultaat

| Skill | Was | Nu |
|---|---:|---:|
| `ls` | 320 | 191 |
| `ls-api` | 348 | 147 |
| `ls-bomos` | 322 | 142 |
| `ls-dk` | 318 | 160 |
| `ls-egov` | 310 | 159 |
| `ls-fsc` | 254 | 125 |
| `ls-iam` | 374 | 152 |
| `ls-logboek` | 320 | 135 |
| `ls-notif` | 244 | 114 |
| `ls-pub` | 427 | 162 |
| **Totaal** | **3 237** | **1 487** |

Reductie: -54%.

`CLAUDE.md` bijgewerkt met expliciete lengte-richtlijn voor toekomstige skills.

## Test plan

- [x] `uv run pytest -q` — 61 passed
- [x] `uv run ruff check / format --check` — schoon
- [ ] Verificatievragen uit `CLAUDE.md` triggeren nog steeds de juiste skills (handmatig na merge)

Refs developer-overheid-nl/skills-marketplace#61