### PR TITLE
ci: niet-blokkerende audit-zichtbaarheidscheck

### DIFF
--- a/.github/workflows/audit-visibility.yml
+++ b/.github/workflows/audit-visibility.yml
@@ -1,0 +1,141 @@
+name: Audit-zichtbaarheid
+
+# Niet-blokkerend. Als een PR een SKILL.md of reference.md raakt en de
+# bijbehorende audit.md bevat UNSUPPORTED_ASSERTION (mogelijke hallucinatie)
+# of CONTRADICTED (bron spreekt de claim tegen), zet deze workflow een label
+# en plaatst een sticky comment met de geflagde claims. De check faalt nooit:
+# het doel is de bevinding in het PR-gesprek krijgen, niet merges tegenhouden.
+# Verscherpen naar blocking kan later, als de false-positive-ratio bekend is.
+
+# pull_request_target i.p.v. pull_request: anders heeft een PR van een externe
+# fork een read-only token en kan de workflow geen label/comment zetten. We
+# checken expliciet de PR-head uit en lezen alleen audit.md (geen uitvoering
+# van PR-code), dus de write-token is hier veilig.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'skills/**/SKILL.md'
+      - 'skills/**/reference.md'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  audit-visibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            // Gewijzigde bestanden via de PR-files-API.
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: issue_number },
+            );
+            const skillDirs = new Set();
+            for (const f of files) {
+              const m = f.filename.match(/^(skills\/.+?)\/(SKILL|reference)\.md$/);
+              if (m) skillDirs.add(m[1]);
+            }
+
+            // Per skill: pak de secties UNSUPPORTED_ASSERTION en CONTRADICTED
+            // tot aan de volgende '## ' kop. report.py schrijft die koppen zo.
+            const blocks = [];
+            for (const dir of [...skillDirs].sort()) {
+              const auditPath = path.join(dir, 'audit.md');
+              if (!fs.existsSync(auditPath)) continue;
+              const lines = fs.readFileSync(auditPath, 'utf8').split('\n');
+              const kept = [];
+              let grab = false;
+              for (const line of lines) {
+                if (/^## (UNSUPPORTED_ASSERTION|CONTRADICTED)/.test(line)) {
+                  grab = true;
+                  kept.push(line);
+                } else if (/^## /.test(line)) {
+                  grab = false;
+                } else if (grab) {
+                  kept.push(line);
+                }
+              }
+              if (kept.length) {
+                const slug = dir.replace(/^skills\//, '');
+                blocks.push(`### \`${slug}\`\n\n${kept.join('\n')}`);
+              }
+            }
+
+            const marker = '<!-- audit-visibility -->';
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number },
+            );
+            const existing = comments.find(
+              c => c.body && c.body.includes(marker),
+            );
+
+            if (!blocks.length) {
+              // Niets meer geflagd: ruim een oude comment op zodat de PR
+              // niet blijft hangen met een verouderde waarschuwing.
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id,
+                  body: `${marker}\n✅ Audit-zichtbaarheid: geen geflagde `
+                    + `claims meer in de gewijzigde skills.`,
+                });
+              }
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number, name: 'audit-flagged',
+                });
+              } catch (e) {
+                core.info(`Label niet verwijderd: ${e.message}`);
+              }
+              return;
+            }
+
+            const body = [
+              marker,
+              '🔎 **Audit-zichtbaarheid** — deze PR raakt skills met claims '
+                + 'die de audit-pipeline markeerde.',
+              '',
+              '**UNSUPPORTED_ASSERTION** = stellige bewering zonder enige '
+                + 'bronsteun (mogelijke hallucinatie).',
+              '**CONTRADICTED** = een bron spreekt de claim expliciet tegen.',
+              '',
+              'Dit blokkeert de merge niet, maar controleer deze claims '
+                + 'voordat je merget:',
+              '',
+              blocks.join('\n\n'),
+              '',
+              '_Regenereer `audit.md` met de audit-tooling als je de skill '
+                + 'aanpast._',
+            ].join('\n');
+
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number, labels: ['audit-flagged'],
+              });
+            } catch (e) {
+              core.info(`Label kon niet worden gezet: ${e.message}`);
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }


### PR DESCRIPTION
## Beschrijving

Voegt een niet-blokkerende workflow toe die bij PRs op SKILL.md/reference.md de bijbehorende `audit.md` scant op `UNSUPPORTED_ASSERTION` (stellige bewering zonder enige bronsteun — mogelijke hallucinatie) en `CONTRADICTED`. Bij een match: label `audit-flagged` + een sticky comment met de geflagde claims. Verdwijnen de flags, dan ruimt de workflow de comment/label weer op.

**Bewust niet blokkerend.** Het doel is de bevinding in het PR-gesprek krijgen waar de reviewer hem ziet, niet merges tegenhouden. Verscherpen kan later, als de false-positive-ratio bekend is.

Achtergrond: een verzonnen PDOK-API-key (zie skills-geo #232/#234) leefde maanden ongezien. De audit-pipeline detecteerde het wél, maar de bevinding stond alleen in een lokale JSON die niemand opent.

Identieke workflow gaat ook naar skills-geo en skills-internet.

## Checklist

- [x] Workflow is niet-blokkerend (faalt nooit de PR)
- [x] Geen hardcoded paden of persoonlijke gegevens