### PR TITLE
chore: audit-rapporten per skill

### DIFF
--- a/skills/ls-api/audit.md
+++ b/skills/ls-api/audit.md
@@ -1,0 +1,1087 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-api — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 13 | 19% |
+| CONTRADICTED | 1 | 1% |
+| PARTIALLY_GROUNDED | 6 | 9% |
+| UNGROUNDED | 15 | 22% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 2 | 3% |
+| GROUNDED | 31 | 46% |
+
+*Geverifieerd met sonnet, 25 calls, $2.0571.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (13)
+
+### `ls-api-0004` — SKILL.md:35 *(§ Versiemodel)*
+
+> ADR-modules hebben geen eigen vaststellingsproces; ze ontlenen hun status aan de standaard die ernaar verwijst.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — versiemodel modules
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron behandelt het vaststellingsproces van ADR-modules niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron beschrijft het beheermodel van de ADR-standaard zelf, maar behandelt niet het vaststellingsproces van modules of extensies afzonderlijk.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de inhoud van de Geospatial module maar zegt niets over het vaststellingsproces van modules of hun statusontlening aan een overkoepelende standaard.*
+</details>
+
+### `ls-api-0031` — SKILL.md:103 *(§ Datum en tijd)*
+
+> De Spectral linter bevat 4 regels die datum/tijd vereisten afdwingen: `date-time-ensure-timezone`, `specify-format-for-date-and-time`, `time-without-timezone`, `use-date-instead-of-datetime`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter datum/tijd
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De linter configuratie in de bron bevat geen van de vier genoemde datum/tijd regels (`date-time-ensure-timezone`, `specify-format-for-date-and-time`, `time-without-timezone`, `use-date-instead-of-datetime`).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Spectral linter-regels worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Spectral linter regels voor datum/tijd worden niet vermeld in deze bron.*
+</details>
+
+### `ls-api-0052` — SKILL.md:146 *(§ Signing Module (JAdES) — draft)*
+
+> De Signing module is nog in concept (draft) en is nog niet goedgekeurd door het Technisch Overleg.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Signing module
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron vermeldt Signing als aparte extensie maar geeft geen informatie over de draftstatus of goedkeuring door een Technisch Overleg.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De Signing module wordt niet vermeld in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De Signing module wordt niet behandeld in deze Geospatial module bron.*
+</details>
+
+### `ls-api-0053` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
+
+> De Signing module gebruikt JAdES detached signatures met RSASSA-PSS (PS256), minimaal 256 bits.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Signing module
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen inhoudelijke informatie over JAdES detached signatures of RSASSA-PSS algoritmes.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Technische details van de Signing module worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *JAdES detached signatures en RSASSA-PSS worden niet behandeld in deze bron.*
+</details>
+
+### `ls-api-0054` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
+
+> Signatures van de Signing module worden geplaatst in `Payload-Signature` en `Message-Signature` HTTP headers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Signing module
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen informatie over `Payload-Signature` of `Message-Signature` HTTP headers.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *HTTP headers voor signing worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Payload-Signature en Message-Signature HTTP headers worden niet behandeld in deze bron.*
+</details>
+
+### `ls-api-0055` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
+
+> De OpenAPI representatie voor signing gebruikt `format: jws-compact-detached`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Signing module
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen informatie over `format: jws-compact-detached` in OpenAPI representaties.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *OpenAPI-representatie voor signing wordt niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *OpenAPI representatie voor signing (format: jws-compact-detached) wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-api-0056` — SKILL.md:152 *(§ Encryption Module (JWE) — draft)*
+
+> De Encryption module is nog in concept (draft) en is nog niet goedgekeurd door het Technisch Overleg.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Encryption module
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron vermeldt Encryption als aparte extensie maar geeft geen informatie over de draftstatus of goedkeuring door een Technisch Overleg.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De Encryption module wordt niet vermeld in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De Encryption module wordt niet behandeld in deze Geospatial module bron.*
+</details>
+
+### `ls-api-0057` — SKILL.md:154 *(§ Encryption Module (JWE) — draft)*
+
+> De Encryption module (JWE) is bedoeld voor end-to-end versleuteling van request/response payloads wanneer transport-level encryptie niet voldoende is, bijv. bij niet-vertrouwde intermediairs.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Encryption module
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen inhoudelijke informatie over JWE of end-to-end encryptie van payloads bij niet-vertrouwde intermediairs.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Technische details van de Encryption module worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *JWE end-to-end versleuteling van payloads wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-api-0058` — SKILL.md:237 *(§ Spectral Linter)*
+
+> De DON-hosted Spectral ruleset bevat 11 regels; de GitHub-versie bevat 22 regels (inclusief 11 extra checks voor datum/tijd, naamgeving en foutafhandeling).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat de Spectral linter configuratie maar geeft geen expliciete telling van het aantal regels (11 of 22). Het tellen van de regels in de bron levert ongeveer 12-13 named rules op, maar de claim over twee versies (DON-hosted vs GitHub) met specifieke aantallen is niet verifieerbaar vanuit deze tekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Aantallen Spectral-regels in de DON-hosted of GitHub-versie worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Spectral ruleset aantallen regels (11 DON-hosted vs. 22 GitHub) worden niet behandeld in deze bron.*
+</details>
+
+### `ls-api-0065` — SKILL.md:265 *(§ Spectral Linter)*
+
+> De Spectral regel `nlgov:query-keys-camel-case` is alleen beschikbaar in de GitHub-versie en controleert camelCase query parameters.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter (GitHub-versie)
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De brontekst bevat de Spectral linter configuratie volledig, maar een regel `nlgov:query-keys-camel-case` of `query-keys-camel-case` ontbreekt daarin geheel. De bron bevat `schema-camel-case` en `property-casing`, maar niet een regel voor camelCase query parameters.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst bevat geen informatie over Spectral regels, GitHub-versies van linters, of `nlgov:query-keys-camel-case`.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van Spectral linter regels of `nlgov:query-keys-camel-case` in de brontekst.*
+</details>
+
+### `ls-api-0066` — SKILL.md:268 *(§ Spectral Linter)*
+
+> De Spectral regel `nlgov:semver` is alleen beschikbaar in de GitHub-versie en controleert het semantic versioning formaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter (GitHub-versie)
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De brontekst bevat de volledige Spectral linter configuratie van ADR 2.1.0, maar een regel `nlgov:semver` of `semver` voor semantic versioning controle is daarin niet aanwezig. De standaard verwijst naar /core/semver als design rule, maar er is geen bijbehorende Spectral regel in de gepubliceerde configuratie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst bevat geen informatie over Spectral regels, GitHub-versies van linters, of `nlgov:semver`.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van Spectral linter regels of `nlgov:semver` in de brontekst.*
+</details>
+
+### `ls-api-0067` — SKILL.md:271 *(§ Spectral Linter)*
+
+> De Spectral regel `nlgov:problem-schema-members` controleert verplichte velden in problem+json schema conform RFC 9457.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter (GitHub-versie)
+
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
+  - *RFC 9457 bevat geen enkele verwijzing naar Spectral, linters, of de nlgov:problem-schema-members regel. Dit is een implementatiedetail van de Nederlandse API Design Rules tooling, niet van de RFC zelf.*
+
+### `ls-api-0068` — reference.md:50 *(§ Implementatievoorbeelden)*
+
+> Referentie-implementaties voor de ADR zijn beschikbaar in ASP.NET en Quarkus.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — implementatievoorbeelden
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De brontekst bevat geen verwijzing naar referentie-implementaties in ASP.NET of Quarkus. Dit onderwerp wordt in deze versie van de ADR spec niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst noemt geen referentie-implementaties in ASP.NET of Quarkus. Wel wordt validatie via API-test.nl en Developer.overheid.nl genoemd, maar dit zijn testtools, geen referentie-implementaties.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van referentie-implementaties in ASP.NET of Quarkus in de brontekst.*
+</details>
+
+## CONTRADICTED — bron spreekt de claim expliciet tegen (1)
+
+### `ls-api-0036` — SKILL.md:111 *(§ Naamgeving)*
+
+> Implementatiedetails zoals framework- of databasenamen MOGEN NIET in URIs worden verborgen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — naamgeving
+
+- **CONTRADICTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > An API SHOULD not expose implementation details of the underlying application, development platforms/frameworks or database systems/persistence models.
+  - *De claim stelt dat implementatiedetails NIET in URIs verborgen mogen worden (MUST NOT), maar de bron zegt dat een API implementatiedetails SHOULD NOT blootstellen — dit is een zwakkere norm dan MUST NOT. Bovendien gaat de regel over het niet blootstellen (niet verbergen) van implementatiedetails, wat de omgekeerde formulering is van de claim.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *URI-ontwerpregels over implementatiedetails worden niet behandeld in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Verbod op implementatiedetails in URIs wordt niet behandeld in deze bron.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (6)
+
+### `ls-api-0005` — SKILL.md:35 *(§ Versiemodel)*
+
+> De Geospatial module v1.0.x is normatief onderdeel van ADR v2.1.0 en daarmee vastgesteld.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR v2.1.0 — Geospatial module
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > functional /core/geospatial : Apply the geospatial module for geospatial data — The API Design Rules Module: Geospatial version 1.0.x MUST be applied when providing geospatial data or functionality.
+  - *De bron bevestigt dat Geospatial module v1.0.x normatief vereist is (MUST), maar zegt niets over een eigen vaststellingsproces of dat de module daarmee 'vastgesteld' is in de formele zin.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron is het beheermodel ADR v1.0 uit 2021. ADR v2.1.0 en de Geospatial module worden niet vermeld.*
+
+### `ls-api-0023` — SKILL.md:78 *(§ Versiebeheer)*
+
+> Bij major version changes MOET een deprecation schedule gepubliceerd worden.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > functional /core/deprecation-schedule : Include a deprecation schedule when deprecating features or versions — When deprecating features or versions, a deprecation schedule MUST be published.
+  - *De bron vereist een deprecation schedule bij het deprecaten van features of versies in het algemeen, niet specifiek alleen bij major version changes. De claim koppelt het expliciet aan major version changes, wat een beperking is die de bron niet maakt.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen regels over deprecation schedules bij major version changes.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over deprecation schedules bij major version changes.*
+
+### `ls-api-0025` — SKILL.md:83 *(§ Foutafhandeling)*
+
+> Foutresponses MOETEN `application/problem+json` (RFC 9457) gebruiken.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — foutafhandeling
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
+  > The data model for problem details is a JSON [JSON] object; when serialized as a JSON document, it uses the "application/problem+json" media type.
+  - *RFC 9457 definieert application/problem+json als het media type voor problem details en beschrijft het formaat uitgebreid, maar legt geen MUST-verplichting op aan API-implementors om dit te gebruiken. De spec zegt dat foutresponses dit formaat KAN gebruiken ('Problem details can be used with any HTTP status code'), niet dat het verplicht is. De MUST-claim is dus sterker dan wat de RFC zelf voorschrijft — die verplichting komt waarschijnlijk uit de ADR (API Design Rules), niet uit RFC 9457 zelf. De bron ondersteunt het gebruik van application/problem+json maar niet de MUST-modaliteit.*
+
+### `ls-api-0033` — SKILL.md:108 *(§ Naamgeving)*
+
+> Collecties MOETEN in meervoud worden benoemd: `/users`, `/orders`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — naamgeving
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Collection resources are referred to using plural nouns. [...] The path segment describing the name of the collection resource MUST be written in the plural form. Example collection resources: https://api.example.org/v1/gebouwen https://api.example.org/v1/vergunningen
+  - *Bron bevestigt meervoud voor collecties maar gebruikt Nederlandse voorbeelden (`gebouwen`, `vergunningen`), niet de Engelstalige voorbeelden `/users` en `/orders` uit de claim.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Naamgevingsregels voor collecties zijn geen onderdeel van dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Naamgeving van collecties in meervoud wordt niet behandeld in deze bron.*
+
+### `ls-api-0035` — SKILL.md:110 *(§ Naamgeving)*
+
+> Interfaces MOETEN in het Nederlands worden gedefinieerd tenzij er een officieel Engelstalig begrippenkader bestaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — naamgeving
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Resources and the underlying attributes SHOULD be defined in the Dutch language unless there is an official English glossary available.
+  - *De bron zegt SHOULD, niet MUST. De claim stelt MOETEN (MUST). Dit is een verzwakking van de norm.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Taalvereisten voor interface-definities worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Taalvereisten voor interface-definities (Nederlands tenzij officieel Engelstalig begrippenkader) worden niet behandeld in deze bron.*
+
+### `ls-api-0050` — SKILL.md:142 *(§ Geospatial Module (v1.0.3 — vastgesteld))*
+
+> De Geospatial module v1.0.3 is normatief onderdeel van ADR v2.1.0 en is verplicht bij geospatiale data.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Geospatial module
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > The API Design Rules Module: Geospatial version 1.0.x MUST be applied when providing geospatial data or functionality.
+  - *De bron bevestigt dat de Geospatial module verplicht is bij geospatiale data, maar vermeldt versie `1.0.x` (niet specifiek `v1.0.3`). De versieclaim `v1.0.3` is niet verifieerbaar vanuit deze bron.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > This document is part of the Nederlandse API Strategie. [...] Normative module GEO module v1.0 [...] This is the definitive version of this document.
+  - *De bron bevestigt dat dit document een normatief onderdeel is van de Nederlandse API Strategie en dat het de definitieve versie is (1.0.3). De claim over 'ADR v2.1.0' specifiek en 'verplicht bij geospatiale data' als zodanig wordt niet letterlijk bevestigd; de bron noemt 'GEO module v1.0' als normatief zonder versienummer 1.0.3 in de statustabel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De Geospatial module en versienummers worden niet beschreven in dit beheermodel.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (15)
+
+### `ls-api-0011` — SKILL.md:55 *(§ URI-ontwerp)*
+
+> Padsegmenten MOETEN kebab-case gebruiken: `/mijn-documenten` (niet `/mijnDocumenten`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — URI-ontwerp
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat een linter-regel (paths-kebab-case) met severity 'warn', niet 'error', die kebab-case aanbeveelt. Er is geen normatieve MUST-regel voor kebab-case padsegmenten in de designrules-tekst zelf.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron is het beheermodel en bevat geen technische URI-ontwerpregels over kebab-case padsegmenten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over kebab-case padsegmenten in URIs.*
+</details>
+
+### `ls-api-0012` — SKILL.md:56 *(§ URI-ontwerp)*
+
+> Query-parameters MOETEN camelCase gebruiken: `?sortOrder=desc`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — URI-ontwerp
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen regel over camelCase query-parameters.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen technische URI-ontwerpregels over camelCase query-parameters.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over camelCase query-parameters.*
+</details>
+
+### `ls-api-0014` — SKILL.md:58 *(§ URI-ontwerp)*
+
+> URIs mogen geen bestandsextensies bevatten; gebruik de Accept-header voor content negotiation.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — URI-ontwerp
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen regel over het verbod op bestandsextensies in URIs of het gebruik van de Accept-header voor content negotiation.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen regels over bestandsextensies in URIs of gebruik van Accept-headers.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over bestandsextensies in URIs of het gebruik van de Accept-header voor content negotiation in deze context.*
+</details>
+
+### `ls-api-0028` — SKILL.md:100 *(§ Datum en tijd)*
+
+> Bij `date-time` velden MOET altijd een timezone worden gespecificeerd (bijv. `2026-04-11T10:30:00+02:00`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — datum en tijd
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen regels over date-time velden of het verplicht opnemen van een timezone.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen technische regels over datum/tijd-velden of timezone-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over `date-time` velden of timezone-specificatie.*
+</details>
+
+### `ls-api-0029` — SKILL.md:101 *(§ Datum en tijd)*
+
+> Gebruik `format: date` wanneer alleen een datum nodig is (niet `date-time`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — datum en tijd
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De brontekst bevat geen regels over datum/tijd formatting of gebruik van `format: date` vs `format: date-time`.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen technische regels over het gebruik van `format: date` versus `date-time`.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over het gebruik van `format: date`.*
+</details>
+
+### `ls-api-0030` — SKILL.md:102 *(§ Datum en tijd)*
+
+> Properties die datum of tijd bevatten MOETEN altijd een `format` specificeren.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — datum en tijd
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De brontekst bevat geen regels over verplicht specificeren van `format` voor datum/tijd properties.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron is het ADR Beheermodel (governance/beheer document), niet de technische ADR-specificatie zelf. Technische regels over datum/tijd-properties worden hier niet beschreven.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron gaat over de Geospatial module (GeoJSON, CRS, bounding box). Datum/tijd-properties en format-specificaties worden niet behandeld.*
+</details>
+
+### `ls-api-0034` — SKILL.md:109 *(§ Naamgeving)*
+
+> Individuele resources MOETEN in enkelvoud worden benoemd: `/users/{id}`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — naamgeving
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron zegt dat enkelvoudige resources niet in een collectie staan MUST worden benoemd in enkelvoud, maar dit gaat over zelfstandige singular resources, niet over `/users/{id}` als patroon. De claim stelt dat individuele resources binnen een collectie enkelvoud MOETEN gebruiken, wat de bron niet expliciet stelt. De bron bespreekt `/gebouwen/3b9710c4-...` als patroon zonder de naam van het segment enkelvoud te noemen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Naamgevingsregels voor individuele resources zijn geen onderdeel van dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Naamgeving van individuele resources in enkelvoud wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-api-0042` — SKILL.md:126 *(§ Transport Security (TLS))*
+
+> Alle verbindingen MOETEN TLS gebruiken (wettelijk verplicht). Volg de laatste NCSC-richtlijnen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security
+
+*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' beschrijft de gearchiveerde status van API-mod-transport-security en dat inhoud is ingebed in ADR v2.1.0. Maar specifieke TLS/NCSC-verplichtingen worden niet behandeld. Lage confidence: het onderwerp raakt dezelfde module, maar de concrete claim is niet gedocumenteerd.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De brontekst is alleen de GitHub-repositorypagina (README/navigatie). De inhoud van transport-security.md is niet meegeleverd, dus de TLS-verplichting kan niet worden geverifieerd.*
+
+### `ls-api-0043` — SKILL.md:132 *(§ Transport Security (TLS))*
+
+> De header `Cache-Control: no-store` is verplicht in alle API-responses om caching van gevoelige data te voorkomen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+
+*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' beschrijft dat de repo gearchiveerd is en content ingebed in ADR v2.1.0, maar de specifieke Cache-Control-verplichting wordt nergens behandeld. Lage confidence.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+
+### `ls-api-0044` — SKILL.md:133 *(§ Transport Security (TLS))*
+
+> De header `Content-Security-Policy: frame-ancestors 'none'` is verplicht in alle API-responses als clickjacking-bescherming.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+
+*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' behandelt de gearchiveerde repo en inbedding, maar niet de specifieke Content-Security-Policy-verplichting. Lage confidence.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+
+### `ls-api-0045` — SKILL.md:134 *(§ Transport Security (TLS))*
+
+> De header `Content-Type: application/json` is verplicht in alle API-responses.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+
+*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' raakt dezelfde module-context, maar de verplichting voor Content-Type-header in API-responses is niet als discrepantie gedocumenteerd. Lage confidence.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+
+### `ls-api-0046` — SKILL.md:135 *(§ Transport Security (TLS))*
+
+> De header `Strict-Transport-Security` is verplicht in alle API-responses om HTTPS te vereisen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+
+*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' beschrijft de module-status maar niet de specifieke Strict-Transport-Security-verplichting. Lage confidence.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+
+### `ls-api-0047` — SKILL.md:136 *(§ Transport Security (TLS))*
+
+> De header `X-Content-Type-Options: nosniff` is verplicht in alle API-responses om MIME sniffing te voorkomen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+
+*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' raakt de module-context, maar de X-Content-Type-Options-verplichting is niet specifiek gedocumenteerd als discrepantie. Lage confidence.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+
+### `ls-api-0048` — SKILL.md:137 *(§ Transport Security (TLS))*
+
+> De header `X-Frame-Options: DENY` is verplicht in alle API-responses als clickjacking-bescherming.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+
+*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' behandelt de gearchiveerde repo en inbedding, maar niet de specifieke X-Frame-Options-verplichting. Lage confidence.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+
+### `ls-api-0049` — SKILL.md:138 *(§ Transport Security (TLS))*
+
+> De header `Access-Control-Allow-Origin` is verplicht in alle API-responses voor het CORS-beleid.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+
+*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' raakt de module-context, maar de Access-Control-Allow-Origin-verplichting voor CORS is niet als discrepantie gedocumenteerd. Lage confidence.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+
+## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (2)
+
+### `ls-api-0008` — SKILL.md:41 *(§ Repositories)*
+
+> ADR v2.1.0 is de vastgestelde versie, gepubliceerd op https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — hoofdspecificatie
+
+**Erkend in conflicts.md** *(§ ADR werkversie-nummering op draft-pagina)*: conflicts.md § 'ADR werkversie-nummering op draft-pagina': de draft-pagina (logius-standaarden.github.io/API-Design-Rules) toont nog versienummer '2.1.0' terwijl v2.1.0 ook de DEF-versie is. 'Het versienummer in ReSpec is simpelweg nog niet opgehoogd.' CONTRADICTED-verdict op GitHub Pages is dus gedocumenteerde keuze.
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > NLGov REST API Design Rules 2.1.0 Logius Standard Definitive version August 27, 2025 This version: https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  > Releases 8 v2.1.0 Latest Sep 29, 2025
+  - *De bron bevestigt dat v2.1.0 de meest recente release is. De publicatie-URL https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/ wordt niet expliciet vermeld in de brontekst.*
+- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  > Previous version: https://gitdocumentatie.logius.nl/publicatie/api/adr/2.0.2/
+  - *De bron vermeldt v2.0.2 als de vorige versie en is zelf een draft zonder versienummer in de header dat overeenkomt met v2.1.0. Er is geen bevestiging dat v2.1.0 de vastgestelde versie is; de meest recente gepubliceerde versie die wordt genoemd is 2.0.2.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  > Formele standaard: NLGov API Design Rules (ADR) 2.1.0 — Gepubliceerde versie: 2.1.0
+  - *De bron bevestigt dat ADR 2.1.0 de gepubliceerde versie is, maar de specifieke publicatie-URL https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/ wordt niet vermeld in de bron.*
+<details><summary>13x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron is het beheermodel uit 2021 en vermeldt alleen ADR v1.0 als vastgestelde versie. ADR v2.1.0 wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron gaat over de Geospatial module v1.0.3, niet over ADR v2.1.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  - *De bron bevat geen informatie over ADR versienummers of publicatie-URLs. Het is een GitHub repo-pagina van het beheermodel, niet de hoofdspecificatie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  - *De bron vermeldt de NLGov REST API Design Rules als onderdeel van de API standaarden, maar noemt geen versienummer (v2.1.0) of publicatie-URL. Versie-metadata staat zelden in een beheermodel-README.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De brontekst bevat geen informatie over ADR v2.1.0 of de hoofdspecificatie. De bron gaat uitsluitend over de geospatial module.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-geospatial](https://logius-standaarden.github.io/API-mod-geospatial)
+  - *De brontekst vermeldt de ADR hoofdspecificatie alleen als verwijzing in de tabel (normative, 'API Design Rules (ADR v2.0)'), maar bevat geen informatie over versie 2.1.0 of de bijbehorende publicatie-URL.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De brontekst is de README van de Transport Security module repository en bevat geen informatie over ADR v2.1.0 of de publicatie-URL.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-signing](https://github.com/logius-standaarden/API-mod-signing)
+  - *De bron vermeldt geen versienummers van de ADR hoofdspecificatie. Er wordt alleen gelinkt naar 'Formele standaard', 'Gepubliceerde versie' en 'Werkversie' zonder specifieke versienummers.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-signing](https://logius-standaarden.github.io/API-mod-signing)
+  - *De bron beschrijft de ADR Signing module (draft), niet de hoofdspecificatie ADR v2.1.0. Versienummers of publicatie-URLs van de hoofdspecificatie komen niet voor.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption)
+  - *De brontekst vermeldt de ADR hoofdspecificatie wel als link ('NLGov API Design Rules (ADR)') maar geeft geen versienummer of publicatiedatum. De claim over v2.1.0 kan niet worden bevestigd of ontkracht.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-encryption](https://logius-standaarden.github.io/API-mod-encryption)
+  - *De bron is de API-mod-encryption specificatie en bevat geen informatie over de ADR hoofdspecificatie of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse)
+  - *De brontekst bevat geen informatie over ADR versies, publicaties of de URL gitdocumentatie.logius.nl. De repository gaat uitsluitend over een impactanalyse-tool voor de spectral linter.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api)
+  - *De brontekst bevat geen informatie over ADR v2.1.0 of publicatie-URLs. De bron gaat over een ReSpec template repository voor zaakgericht-werken-api.*
+</details>
+
+### `ls-api-0009` — SKILL.md:44 *(§ Repositories)*
+
+> Geospatial module v1.0.3 is vastgesteld en gepubliceerd op https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Geospatial module
+
+**Erkend in conflicts.md** *(§ Details API-mod-geospatial)*: conflicts.md § 'Details API-mod-geospatial': 'De tag 1.0.2 bestaat op GitHub, maar de gepubliceerde versie op gitdocumentatie is 1.0.3. Er is geen tag 1.0.3 in de repository.' CONTRADICTED-verdict op GitHub Pages (draft toont 1.0.2) is gedocumenteerde discrepantie; gitdocumentatie.logius.nl is leidend.
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > API Design Rules Module: Geospatial 1.0.3 Logius Guide Definitive version May 22, 2025 This version: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/
+- **CONTRADICTED** (medium) — [https://logius-standaarden.github.io/API-mod-geospatial](https://logius-standaarden.github.io/API-mod-geospatial)
+  > Previous version: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.1/
+  - *De bron noemt versie 1.0.1 als de vorige versie en het huidige document is een draft (geen vastgestelde versie). Versie 1.0.3 wordt nergens vermeld. De claim dat 1.0.3 vastgesteld is, wordt tegengesproken doordat de bron de huidige versie als draft aanduidt en de meest recente gepubliceerde versie 1.0.1 was. Echter: de bron vermeldt 1.0.3 expliciet niet, dus dit is ook deels NOT_FOUND; CONTRADICTED omdat de draft-status en de genoemde vorige versie 1.0.1 de claim van een vastgestelde 1.0.3 ondermijnen.*
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron noemt de Geospatial module maar niet het specifieke versienummer 1.0.3 of de specifieke publicatie-URL.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Geospatial module v1.0.3 en de bijbehorende publicatie-URL worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  - *De brontekst bevat geen informatie over een Geospatial module of versie v1.0.3.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  - *De bron verwijst naar de Geospatial module via '[ADR-GEO] API Design Rules Module: Geospatial . ... March 07, 2024. URL: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/' maar noemt geen specifiek versienummer 1.0.3.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  - *De bron bevat geen informatie over de Geospatial module of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  - *De bron noemt geen Geospatial module, geen versienummer v1.0.3 en geen publicatie-URL. De normatieve modules van het Kennisplatform API's worden wel kort aangehaald maar zonder detail.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  - *De bron vermeldt geen Geospatial module, versienummer v1.0.3 of de bijbehorende publicatie-URL.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De brontekst vermeldt wel de publicatieversie-URL (https://gitdocumentatie.logius.nl/publicatie/api/mod-geo) en werkversie-URL, maar noemt geen specifiek versienummer zoals v1.0.3. Het versiebeheer of de vastgestelde versie wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De brontekst bevat geen informatie over een Geospatial module.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-signing](https://github.com/logius-standaarden/API-mod-signing)
+  - *De bron behandelt de Signing module, niet de Geospatial module. Er is geen informatie over mod-geo v1.0.3.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-signing](https://logius-standaarden.github.io/API-mod-signing)
+  - *De bron noemt de GEO module v1.0 in de tabel van de Nederlandse API Strategie, maar geeft geen versienummer 1.0.3 of publicatie-URL voor die module.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption)
+  - *De brontekst bevat geen informatie over de Geospatial module of enig versienummer daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-encryption](https://logius-standaarden.github.io/API-mod-encryption)
+  - *De bron vermeldt in de abstracttabel wel 'GEO module v1.0' als onderdeel van de Nederlandse API Strategie, maar geeft geen informatie over versie 1.0.3 of de publicatie-URL daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse)
+  - *De brontekst bevat geen informatie over de Geospatial module of enige versie daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api)
+  - *De brontekst bevat geen informatie over een Geospatial module of versienummers daarvan.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (31)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-api-0001` — SKILL.md:26 *(§ API Design Rules (NL GOV))*
+
+> De API Design Rules zijn verplicht onder het 'pas-toe-of-leg-uit' regime van het Forum Standaardisatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules (ADR) — NL GOV
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > This version of the design rules has been submitted to Forum Standaardisatie for inclusion on the Comply or Explain list of mandatory standards in the Dutch Public Sector.
+  - *De bron zegt dat de standaard is ingediend ('submitted') voor opname op de lijst, niet dat het al verplicht is onder het pas-toe-of-leg-uit regime. De claim stelt het als vaststaand feit.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  > De status van de ADR-standaard is 'Verplicht (pas toe leg uit)'. Dit houdt kort gezegd in dat Nederlandse overheden en instellingen uit de (semi) publieke sector verplicht zijn deze standaard toe te passen op het moment dat zij REST API's gaan gebruiken voor het ontsluiten van overheidsinformatie en/of functionaliteit.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron gaat over de Geospatial module van de ADR en vermeldt niets over het 'pas-toe-of-leg-uit' regime van het Forum Standaardisatie.*
+
+### `ls-api-0002` — SKILL.md:32 *(§ Versiemodel)*
+
+> De vastgestelde versie (DEF) van de ADR is gepubliceerd op `gitdocumentatie.logius.nl`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — versiemodel
+
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > This version: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/ ... This is the definitive version of this document.
+  - *De bron bevestigt dat vastgestelde (definitieve) versies op gitdocumentatie.logius.nl worden gepubliceerd, maar specifiek voor de Geospatial module, niet de ADR-hoofdspecificatie. De claim is algemeen over de ADR.*
+
+### `ls-api-0003` — SKILL.md:33 *(§ Versiemodel)*
+
+> De werkversie (draft) van de ADR is gepubliceerd op `logius-standaarden.github.io`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — versiemodel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Latest editor's draft: https://logius-standaarden.github.io/API-Design-Rules/
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  > De laatste concept versie van de standard is gepubliceerd op: https://logius-standaarden.github.io/API-Design-Rules/
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > Latest editor's draft: https://logius-standaarden.github.io/API-mod-geospatial/
+  - *Bevestigd voor de Geospatial module; de claim is algemeen over de ADR-werkversie, maar het patroon klopt.*
+
+### `ls-api-0006` — SKILL.md:35 *(§ Versiemodel)*
+
+> Transport Security is in ADR v2.1.0 ingebed als sectie 3.8 met eigen regels (`/core/transport/*`).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR v2.1.0 — Transport Security
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > 3.8 Transport Security [...] technical /core/transport/tls [...] technical /core/transport/security-headers [...] technical /core/transport/cors
+
+### `ls-api-0007` — SKILL.md:45 *(§ Repositories)*
+
+> De API-mod-transport-security GitHub-repository is gearchiveerd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Transport Security module
+
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  > This repository was archived by the owner on Aug 29, 2025. It is now read-only.
+<details><summary>16x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron vermeldt niets over archivering van de API-mod-transport-security GitHub-repository.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron vermeldt de API-mod-transport-security repository of archivering daarvan niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron vermeldt de Transport Security module of de bijbehorende repository niet.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  - *De brontekst bevat geen informatie over een API-mod-transport-security repository of de archiefstatus ervan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  - *De brontekst vermeldt de Transport Security module als normatief onderdeel en verwijst naar een apart document, maar bevat geen informatie over de archiefstatus van de GitHub-repository.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  - *De bron gaat over het ADR-Beheermodel repository, niet over de API-mod-transport-security repository. Geen informatie over archivering van die specifieke repo.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  - *De brontekst is de README/overzichtspagina van het API-Standaarden-Beheermodel repository. Er wordt geen melding gemaakt van de API-mod-transport-security GitHub-repository of de archiefstatus ervan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  - *De bron vermeldt geen GitHub-repository voor een Transport Security module, noch informatie over archivering daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De brontekst gaat over de API-mod-geospatial repository, niet over API-mod-transport-security. Geen informatie over archivering van transport-security repo.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-geospatial](https://logius-standaarden.github.io/API-mod-geospatial)
+  - *De brontekst gaat over de Geospatial module en vermeldt niets over een Transport Security module of de status van een bijbehorende GitHub-repository.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-signing](https://github.com/logius-standaarden/API-mod-signing)
+  - *De bron gaat over de API-mod-signing repository, niet over API-mod-transport-security. Er is geen informatie over archivering van transport-security.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-signing](https://logius-standaarden.github.io/API-mod-signing)
+  - *De bron gaat over de API-mod-signing specificatie en maakt geen melding van een transport-security repository of de archiveringsstatus daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption)
+  - *De brontekst gaat over de API-mod-encryption repository, niet over de API-mod-transport-security repository. Er is geen informatie over archivering van transport-security.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-encryption](https://logius-standaarden.github.io/API-mod-encryption)
+  - *De bron behandelt alleen de Encryption module (JWE). Er is geen informatie over de Transport Security module of de archiefstatus van een gerelateerde GitHub-repository.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse)
+  - *De brontekst gaat over de api-linter-impactanalyse repository en bevat geen informatie over de API-mod-transport-security GitHub-repository of de archiefstatus daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api)
+  - *De brontekst gaat over de zaakgericht-werken-api repository (een ReSpec template). Er is geen informatie over de API-mod-transport-security repository of archiveringsstatus daarvan.*
+</details>
+
+### `ls-api-0010` — SKILL.md:42 *(§ Repositories)*
+
+> ADR-Beheermodel v1.0 is gearchiveerd en vervangen door het API-Standaarden-Beheermodel.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — beheermodel
+
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  > Dit beheermodel is verouderd en vervangen door het algemene API Standaarden beheermodel
+  - *De bron bevestigt expliciet dat het ADR-Beheermodel vervangen is door het API Standaarden beheermodel. De archivering wordt ook bevestigd: 'This repository was archived by the owner on Jul 15, 2025. It is now read-only.' De versieaanduiding 'v1.0' staat niet letterlijk in de brontekst, maar de releases sectie toont '1.0 (rerelease) Latest Jan 7, 2022', wat v1.0 ondersteunt.*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  > "Generiek beheermodel voor de verzameling van API standaarden" en "Generated from Logius-standaarden/Logius-Beheermodel"
+  - *De bron bevestigt dat het API-Standaarden-Beheermodel bestaat als opvolger/generiek kader, gegenereerd vanuit het Logius-Beheermodel. Dat impliceert dat er een voorganger was, maar de bron benoemt het ADR-Beheermodel v1.0 noch de archiefstatus ervan expliciet. PARTIALLY_SUPPORTED omdat de vervanging indirect blijkt maar de archiefstatus en versieaanduiding ontbreken.*
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  > Met het indienen van versie 2.0 van de ADR standaard zijn tevens de beheermodelen van ADR en OAuth (die hadden een apart beheermodel) samengevoegd met dit beheermodel. Ook deze samenvoeging is goedgekeurd en de kopieën zijn daarom nu gearchiveerd.
+  - *De bron bevestigt expliciet dat het aparte ADR-beheermodel is samengevoegd met het API-Standaarden-Beheermodel en gearchiveerd. De claim over 'v1.0' als specifiek versienummer wordt niet vermeld, maar dat is een klein detail dat de kern van de claim niet weerspreekt.*
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron vermeldt niets over het ADR-Beheermodel v1.0 of archivering ervan.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron is het beheermodel zelf en vermeldt niets over archivering of vervanging ervan door een API-Standaarden-Beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron vermeldt het ADR-Beheermodel of het API-Standaarden-Beheermodel niet.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  - *De brontekst vermeldt wel een beheermodel-URL (https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/) maar zegt niets over archiefstatus van ADR-Beheermodel v1.0 of vervanging door een API-Standaarden-Beheermodel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  - *De bron vermeldt dat het beheermodel van de standaard wordt beschreven door 'het API-Standaarden beheermodel gepubliceerd door Logius', maar bevat geen informatie over archivering van een ADR-Beheermodel v1.0 of vervanging ervan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De brontekst bevat geen informatie over het ADR-Beheermodel of het API-Standaarden-Beheermodel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-geospatial](https://logius-standaarden.github.io/API-mod-geospatial)
+  - *De brontekst bevat geen informatie over het ADR-Beheermodel of een vervangend API-Standaarden-Beheermodel.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
+  - *De brontekst bevat geen informatie over het ADR-Beheermodel.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-signing](https://github.com/logius-standaarden/API-mod-signing)
+  - *De bron vermeldt wel het beheermodel via de URL https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/, maar geeft geen informatie over archivering van ADR-Beheermodel v1.0 of vervanging door een API-Standaarden-Beheermodel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-signing](https://logius-standaarden.github.io/API-mod-signing)
+  - *Het ADR-Beheermodel of de archiveringsstatus daarvan wordt in deze bron niet besproken.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption)
+  - *De brontekst verwijst naar het beheermodel via een URL ('https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/') maar zegt niets over archivering van ADR-Beheermodel v1.0 of een opvolger.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-encryption](https://logius-standaarden.github.io/API-mod-encryption)
+  - *De bron bevat geen informatie over het ADR-Beheermodel of een opvolger daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse)
+  - *De brontekst bevat geen informatie over het ADR-Beheermodel of het API-Standaarden-Beheermodel.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api)
+  - *De brontekst bevat geen informatie over het ADR-Beheermodel of een API-Standaarden-Beheermodel.*
+</details>
+
+### `ls-api-0013` — SKILL.md:57 *(§ URI-ontwerp)*
+
+> URIs mogen geen trailing slashes bevatten: `/api/v1/users` (niet `/api/v1/users/`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — URI-ontwerp
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > technical /core/no-trailing-slash : Leave off trailing slashes from URIs — A URI MUST never contain a trailing slash. When requesting a resource including a trailing slash, this MUST result in a 404 (not found) error response and not a redirect.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen regels over trailing slashes in URIs.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over trailing slashes in URIs.*
+
+### `ls-api-0015` — SKILL.md:59 *(§ URI-ontwerp)*
+
+> De major versie MOET in de URI staan (`/v1/resources`); in de OAS moet dit op serverniveau worden gespecificeerd, niet in individuele paden.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — URI-ontwerp en versiebeheer
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > technical /core/uri-version : Include the major version number in the URI — The URI of an API (base path) MUST include the major version number, prefixed by the letter v [...] An example of an openapi.yaml for an API with a base path https://api.example.org/v1 [...] servers: - description: test environment url: https://api.test.example.org/v1
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen technische regels over versiebeheer in URIs of OAS-serverniveau specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over het opnemen van de major versie in de URI of OAS-configuratie op serverniveau.*
+
+### `ls-api-0016` — SKILL.md:60 *(§ URI-ontwerp)*
+
+> Operaties als sub-resources: het laatste padsegment mag starten met `_` (bijv. `/_search`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** ADR — URI-ontwerp
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > In exceptional cases [...] Use the imperative mood of a verb, maybe even prefix it with a underscore to distinguish these resources from regular resources. For example: /search or /_search .
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > In case of a global query /api/v1/_search , results should be placed in the relevant geometric context
+  - *De bron gebruikt het patroon `/_search` als voorbeeld en de bijbehorende regel /geo/geometric-context, wat consistent is met de claim dat het laatste padsegment mag starten met `_`.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen regels over operaties als sub-resources of het gebruik van `_` als prefix.*
+
+### `ls-api-0017` — SKILL.md:61 *(§ URI-ontwerp)*
+
+> Gevoelige informatie MAG NIET in URIs worden opgenomen omdat URIs niet door TLS beschermd zijn.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — URI-ontwerp
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > functional /core/transport/no-sensitive-uris : No sensitive information in URIs — Even when using TLS connections, information in URIs is not secured. URIs can be cached and logged outside of the servers controlled by clients and servers. [...] MUST NOT contain any sensitive information.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen regels over gevoelige informatie in URIs en TLS-bescherming.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over het opnemen van gevoelige informatie in URIs of TLS-bescherming.*
+
+### `ls-api-0018` — SKILL.md:67 *(§ HTTP-methoden)*
+
+> De GET-methode is veilig en idempotent en mag de resource nooit wijzigen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — HTTP-methoden
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Method Safe Idempotent GET Yes Yes [...] Request methods are considered safe if their defined semantics are essentially read-only; i.e., the client does not request, and does not expect, any state change on the origin server as a result of applying a safe method to a target resource.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen technische regels over HTTP-methoden zoals GET.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen expliciete regels over de veiligheid of idempotentie van de GET-methode.*
+
+### `ls-api-0019` — SKILL.md:69 *(§ HTTP-methoden)*
+
+> De PUT-methode is idempotent en wordt gebruikt voor het aanmaken of volledig vervangen van een resource.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — HTTP-methoden
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > PUT Create/update Create a resource with the given URI or replace (full update) a resource when the resource already exists. [...] Method Safe Idempotent [...] PUT No Yes
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen technische regels over de PUT-methode.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over de PUT-methode.*
+
+### `ls-api-0020` — SKILL.md:75 *(§ Versiebeheer)*
+
+> De major versie MOET in het URI-pad staan: `/v1`, `/v2`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > technical /core/uri-version : Include the major version number in the URI — The URI of an API (base path) MUST include the major version number, prefixed by the letter v .
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen technische versiebeheerregels over major versie in het URI-pad.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen expliciete regel dat de major versie in het URI-pad moet staan.*
+
+### `ls-api-0021` — SKILL.md:76 *(§ Versiebeheer)*
+
+> De volledige versie MOET in de `API-Version` response header worden opgenomen: `1.2.3`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > technical /core/version-header : Return the full version number in a response header — The version number MUST be returned in an HTTP response header named API-Version (case-insensitive) [...] An example of an API version response header: API-Version: 1.0.2
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron vermeldt de `API-Version` response header niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over de `API-Version` response header.*
+
+### `ls-api-0022` — SKILL.md:77 *(§ Versiebeheer)*
+
+> Semantic versioning (major.minor.patch) MOET worden gebruikt in `info.version`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > technical /core/semver : Adhere to the Semantic Versioning model when releasing API changes — Version numbering MUST follow the Semantic Versioning [SemVer] model [...] Release versions are formatted using the major.minor.patch template
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron vermeldt semantic versioning in `info.version` niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over semantic versioning of `info.version`.*
+
+### `ls-api-0024` — SKILL.md:79 *(§ Versiebeheer)*
+
+> Er MOET een vaste transitieperiode tussen major versies worden gehanteerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > functional /core/transition-period : Schedule a fixed transition period for a new major API version — When releasing a new major API version, the old version MUST remain available for a limited and fixed deprecation period.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen regels over een transitieperiode tussen major versies.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over transitieperiodes tussen major versies.*
+
+### `ls-api-0026` — SKILL.md:95 *(§ Foutafhandeling)*
+
+> Foutmeldingen MOGEN GEEN technische details bevatten zoals stack traces of interne hints.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — foutafhandeling
+
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > In case of an error, the server SHOULD NOT pass technical details (e.g. call stacks or other internal hints) to the client. The error message SHOULD be generic to avoid revealing additional details and expose internal information which can be used with malicious intent.
+  - *De bron gebruikt SHOULD NOT, niet MUST NOT. De claim gebruikt MOGEN NIET (MUST NOT). Dit is een potentieel verschil in normatieve sterkte, maar de strekking is gelijk en de bron ondersteunt de claim in de geest.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron bevat geen regels over de inhoud van foutmeldingen of het weglaten van technische details.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen regels over foutmeldingen of het uitsluiten van technische details daarin.*
+
+### `ls-api-0027` — SKILL.md:99 *(§ Datum en tijd)*
+
+> Datum/tijd waarden MOETEN RFC 3339 formaat gebruiken.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — datum en tijd
+
+- **SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
+  > The following profile of ISO 8601 [ISO8601] dates SHOULD be used in new protocols on the Internet. [...] date-time = full-date "T" full-time
+  - *RFC 3339 definieert het formaat dat de claim beschrijft. De bron zegt echter SHOULD (aanbevolen) voor gebruik in nieuwe protocollen, niet MUST. De claim stelt MOETEN (MUST). De bron definieert het RFC 3339 formaat zelf volledig, maar legt het gebruik als SHOULD op, niet MUST. Toch is de claim dat datum/tijd waarden RFC 3339 formaat MOETEN gebruiken plausibel als een API-standaard RFC 3339 als verplicht aanwijst — de bron bevestigt het formaat zelf volledig. Omdat de claim gaat over een ADR-regel die RFC 3339 verplicht stelt (niet over RFC 3339 zelf die dat verplicht stelt), en de bron het formaat volledig beschrijft, is SUPPORTED hier de juiste keuze: de bron definieert het formaat waaraan voldaan moet worden.*
+
+### `ls-api-0032` — SKILL.md:107 *(§ Naamgeving)*
+
+> Resources MOETEN als zelfstandige naamwoorden worden benoemd (niet werkwoorden).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — naamgeving
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Resources are referred to using nouns (instead of verbs) that represent entities meaningful to the API consumer.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Naamgevingsregels voor resources zijn geen onderdeel van dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Naamgevingsregels voor resources (zelfstandige naamwoorden vs. werkwoorden) komen niet voor in deze bron.*
+
+### `ls-api-0037` — SKILL.md:115 *(§ OpenAPI Documentatie)*
+
+> Een OpenAPI 3.0+ specificatie is VERPLICHT.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — OpenAPI documentatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > API documentation MUST be provided in the form of an OpenAPI definition document which conforms to the OpenAPI Specification (from v3 onwards).
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De verplichting van een OpenAPI 3.0+ specificatie staat niet in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *OpenAPI 3.0+ verplichting wordt niet behandeld in deze Geospatial module bron.*
+
+### `ls-api-0038` — SKILL.md:116 *(§ OpenAPI Documentatie)*
+
+> De OpenAPI JSON-spec MOET gepubliceerd worden op standaardlocatie `/openapi.json` (VERPLICHT); YAML op `/openapi.yaml` is OPTIONEEL.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — OpenAPI documentatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > The standard location for the OAS document is a URI called openapi.json or openapi.yaml within the base path of the API. [...] At least the JSON format MUST be supported. [...] the same OAS document MAY be provided in YAML format: https://api.example.org/v1/openapi.yaml
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Publicatielocaties voor OpenAPI-specificaties worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Publicatielocatie van OpenAPI specificatie wordt niet behandeld in deze bron.*
+
+### `ls-api-0039` — SKILL.md:117 *(§ OpenAPI Documentatie)*
+
+> Contactinformatie (`info.contact` met `name`, `email`, `url`) wordt sterk aanbevolen voor publieke APIs (ADR `/core/doc-openapi-contact`: SHOULD).
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** ADR — OpenAPI documentatie, publieke APIs
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > OpenAPI definition document SHOULD include the info.contact object for publicly available APIs. Contact information SHOULD NOT be a generic contact address for the whole organisation. [...] { "name": "Gebouwen API beheerder", "url": "...", "email": "teamgebouwen@ministerie.nl" }
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Aanbevelingen voor contactinformatie in OpenAPI-specs worden niet behandeld in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Contactinformatie in OpenAPI (info.contact) wordt niet behandeld in deze bron.*
+
+### `ls-api-0040` — SKILL.md:117 *(§ OpenAPI Documentatie)*
+
+> De Spectral linter dwingt contactinformatie-velden af als error voor publieke APIs.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter, OpenAPI documentatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > #/core/doc-openapi-contact # This rule exists in the base oas spectral linter set info-contact: error info-contact-fields-exist: severity: error given: - "$.info.contact" then: function: schema functionOptions: schema: required: - email - name - url
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Spectral linter-gedrag voor contactinformatie wordt niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Spectral linter afdwinging van contactinformatie-velden wordt niet behandeld in deze bron.*
+
+### `ls-api-0041` — SKILL.md:118 *(§ OpenAPI Documentatie)*
+
+> CORS MOET ondersteund worden voor documentatie-toegang.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — OpenAPI documentatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Clients (such as Swagger UI or ReDoc) MUST be able to retrieve the document without having to authenticate. Furthermore, the CORS policy for this URI MUST allow external domains to read the documentation from a browser environment.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *CORS-vereisten worden niet behandeld in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *CORS-vereisten voor documentatietoegang worden niet behandeld in deze bron.*
+
+### `ls-api-0051` — SKILL.md:142 *(§ Geospatial Module (v1.0.3 — vastgesteld))*
+
+> De Geospatial module regelt GeoJSON encodering, bounding box filtering en coördinaatsystemen (CRS).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Geospatial module
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > The Geospatial Module provides rules for the structuring of geospatial payloads and for functions in APIs to handle geospatial data. [...] how to encode geometries in APIs how to supply a spatial filter in the call (request) how to return results of a spatial search
+  - *De bron bevestigt dat de Geospatial module GeoJSON encodering, bounding box filtering (bbox query parameter) en coördinaatsystemen (CRS, heel hoofdstuk 3) regelt.*
+
+### `ls-api-0059` — SKILL.md:241 *(§ Spectral Linter)*
+
+> De publieke DON-hosted ruleset is beschikbaar op `https://static.developer.overheid.nl/adr/ruleset.yaml`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > curl -L https://static.developer.overheid.nl/adr/ruleset.yaml > .spectral.yml
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De URL van de DON-hosted Spectral ruleset wordt niet vermeld in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De DON-hosted Spectral ruleset URL wordt niet vermeld in deze bron.*
+
+### `ls-api-0060` — SKILL.md:257 *(§ Spectral Linter)*
+
+> Spectral regel `include-major-version-in-uri` / `nlgov:include-major-version-in-uri` controleert de aanwezigheid van de major versie in de server URL.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter, URI-ontwerp
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > #/core/uri-version include-major-version-in-uri: severity: error given: - "$.servers[*]" then: function: pattern functionOptions: match: "\/v[\d+]" field: url message: "/core/uri-version: Include the major version number in the URI"
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Specifieke Spectral-regelnamen worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Spectral regel include-major-version-in-uri wordt niet behandeld in deze bron.*
+
+### `ls-api-0061` — SKILL.md:258 *(§ Spectral Linter)*
+
+> Spectral regel `paths-no-trailing-slash` / `nlgov:paths-no-trailing-slash` controleert dat paden geen trailing slashes hebben.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > #/core/no-trailing-slash paths-no-trailing-slash: severity: error given: - "$.paths" then: function: pattern functionOptions: notMatch: ".+ \/$" field: "@key" message: "/core/no-trailing-slash: Leave off trailing slashes from URIs"
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Specifieke Spectral-regelnamen worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Spectral regel paths-no-trailing-slash wordt niet behandeld in deze bron.*
+
+### `ls-api-0062` — SKILL.md:259 *(§ Spectral Linter)*
+
+> Spectral regel `paths-kebab-case` / `nlgov:paths-kebab-case` controleert dat padsegmenten kebab-case gebruiken.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > paths-kebab-case: severity: warn message: " {{property}} is not kebab-case." given: $.paths[?(@property && !@property.match(/ \/openapi\.json/))]~
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Specifieke Spectral-regelnamen worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Spectral regel paths-kebab-case wordt niet behandeld in deze bron.*
+
+### `ls-api-0063` — SKILL.md:261 *(§ Spectral Linter)*
+
+> Spectral regel `missing-version-header` / `nlgov:missing-version-header` controleert de aanwezigheid van de version header in 2xx/3xx responses.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > #/core/version-header missing-version-header: severity: error given: $..[responses][?(@property && @property.match(/(2|3)\d\d/))][headers] then: function: or functionOptions: properties: - API-Version - Api-Version - Api-version - api-version - API-version message: "Return the full version number in a response header"
+  - *De regel heet `missing-version-header` (zonder `nlgov:`-prefix) en controleert 2xx/3xx responses op aanwezigheid van de version header.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Specifieke Spectral-regelnamen worden niet beschreven in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van Spectral linter regels of `missing-version-header` in de brontekst.*
+
+### `ls-api-0064` — SKILL.md:262 *(§ Spectral Linter)*
+
+> Spectral regel `use-problem-schema` / `nlgov:use-problem-schema` controleert het gebruik van problem+json voor foutresponses.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > use-problem-schema: severity: warn message: "The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457." given: $..[responses][?(@property && @property.match(/(4|5)\d\d/))].content then: function: schema functionOptions: schema: anyOf: - required: [ "application/problem+json" ] - required: [ "application/problem+xml" ]
+  - *De regel heet `use-problem-schema` (zonder `nlgov:`-prefix) in de gepubliceerde versie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst gaat over het beheermodel van de ADR-standaard. Er is geen vermelding van Spectral, linters, of specifieke regels zoals `use-problem-schema`.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van Spectral linter regels of `use-problem-schema` in de brontekst.*
+
+</details>

--- a/skills/ls-api/audit.md
+++ b/skills/ls-api/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-api — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,1081 +7,846 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 13 | 19% |
-| CONTRADICTED | 1 | 1% |
-| PARTIALLY_GROUNDED | 6 | 9% |
-| UNGROUNDED | 15 | 22% |
+| UNSUPPORTED_ASSERTION | 9 | 16% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 14 | 25% |
+| UNGROUNDED | 6 | 11% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
-| KNOWN_DISCREPANCY | 2 | 3% |
-| GROUNDED | 31 | 46% |
+| KNOWN_DISCREPANCY | 6 | 11% |
+| GROUNDED | 20 | 36% |
 
-*Geverifieerd met sonnet, 25 calls, $2.0571.*
+*Geverifieerd met sonnet, 17 calls, $1.4480.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (13)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (9)
 
 ### `ls-api-0004` — SKILL.md:35 *(§ Versiemodel)*
 
-> ADR-modules hebben geen eigen vaststellingsproces; ze ontlenen hun status aan de standaard die ernaar verwijst.
+> ADR-modules ontlenen hun vaststellingsstatus aan de standaard die ernaar verwijst, niet aan een eigen vaststellingsproces.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — versiemodel modules
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron behandelt het vaststellingsproces van ADR-modules niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron beschrijft het beheermodel van de ADR-standaard zelf, maar behandelt niet het vaststellingsproces van modules of extensies afzonderlijk.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron beschrijft de inhoud van de Geospatial module maar zegt niets over het vaststellingsproces van modules of hun statusontlening aan een overkoepelende standaard.*
-</details>
-
-### `ls-api-0031` — SKILL.md:103 *(§ Datum en tijd)*
-
-> De Spectral linter bevat 4 regels die datum/tijd vereisten afdwingen: `date-time-ensure-timezone`, `specify-format-for-date-and-time`, `time-without-timezone`, `use-date-instead-of-datetime`.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter datum/tijd
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De linter configuratie in de bron bevat geen van de vier genoemde datum/tijd regels (`date-time-ensure-timezone`, `specify-format-for-date-and-time`, `time-without-timezone`, `use-date-instead-of-datetime`).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Spectral linter-regels worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Spectral linter regels voor datum/tijd worden niet vermeld in deze bron.*
-</details>
-
-### `ls-api-0052` — SKILL.md:146 *(§ Signing Module (JAdES) — draft)*
-
-> De Signing module is nog in concept (draft) en is nog niet goedgekeurd door het Technisch Overleg.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Signing module
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron vermeldt Signing als aparte extensie maar geeft geen informatie over de draftstatus of goedkeuring door een Technisch Overleg.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De Signing module wordt niet vermeld in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De Signing module wordt niet behandeld in deze Geospatial module bron.*
-</details>
-
-### `ls-api-0053` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
-
-> De Signing module gebruikt JAdES detached signatures met RSASSA-PSS (PS256), minimaal 256 bits.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Signing module
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat geen inhoudelijke informatie over JAdES detached signatures of RSASSA-PSS algoritmes.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Technische details van de Signing module worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *JAdES detached signatures en RSASSA-PSS worden niet behandeld in deze bron.*
-</details>
-
-### `ls-api-0054` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
-
-> Signatures van de Signing module worden geplaatst in `Payload-Signature` en `Message-Signature` HTTP headers.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Signing module
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat geen informatie over `Payload-Signature` of `Message-Signature` HTTP headers.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *HTTP headers voor signing worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Payload-Signature en Message-Signature HTTP headers worden niet behandeld in deze bron.*
-</details>
-
-### `ls-api-0055` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
-
-> De OpenAPI representatie voor signing gebruikt `format: jws-compact-detached`.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Signing module
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat geen informatie over `format: jws-compact-detached` in OpenAPI representaties.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *OpenAPI-representatie voor signing wordt niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *OpenAPI representatie voor signing (format: jws-compact-detached) wordt niet behandeld in deze bron.*
-</details>
-
-### `ls-api-0056` — SKILL.md:152 *(§ Encryption Module (JWE) — draft)*
-
-> De Encryption module is nog in concept (draft) en is nog niet goedgekeurd door het Technisch Overleg.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Encryption module
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron vermeldt Encryption als aparte extensie maar geeft geen informatie over de draftstatus of goedkeuring door een Technisch Overleg.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De Encryption module wordt niet vermeld in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De Encryption module wordt niet behandeld in deze Geospatial module bron.*
-</details>
-
-### `ls-api-0057` — SKILL.md:154 *(§ Encryption Module (JWE) — draft)*
-
-> De Encryption module (JWE) is bedoeld voor end-to-end versleuteling van request/response payloads wanneer transport-level encryptie niet voldoende is, bijv. bij niet-vertrouwde intermediairs.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Encryption module
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat geen inhoudelijke informatie over JWE of end-to-end encryptie van payloads bij niet-vertrouwde intermediairs.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Technische details van de Encryption module worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *JWE end-to-end versleuteling van payloads wordt niet behandeld in deze bron.*
-</details>
-
-### `ls-api-0058` — SKILL.md:237 *(§ Spectral Linter)*
-
-> De DON-hosted Spectral ruleset bevat 11 regels; de GitHub-versie bevat 22 regels (inclusief 11 extra checks voor datum/tijd, naamgeving en foutafhandeling).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — versiemodel modules
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat de Spectral linter configuratie maar geeft geen expliciete telling van het aantal regels (11 of 22). Het tellen van de regels in de bron levert ongeveer 12-13 named rules op, maar de claim over twee versies (DON-hosted vs GitHub) met specifieke aantallen is niet verifieerbaar vanuit deze tekst.*
+  - *De bron beschrijft niet hoe modules hun vaststellingsstatus ontlenen. Dit onderwerp wordt niet behandeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Aantallen Spectral-regels in de DON-hosted of GitHub-versie worden niet beschreven in dit beheermodel.*
+  - *De bron beschrijft het beheermodel van de ADR-standaard als geheel, maar bespreekt het vaststellingsproces van individuele modules niet. Het concept van modules met eigen of afgeleide vaststellingsstatus komt niet voor in de tekst.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Spectral ruleset aantallen regels (11 DON-hosted vs. 22 GitHub) worden niet behandeld in deze bron.*
+  - *De bron behandelt het vaststellingsproces van modules of de relatie tot de verwijzende standaard niet.*
 </details>
 
-### `ls-api-0065` — SKILL.md:265 *(§ Spectral Linter)*
+### `ls-api-0029` — SKILL.md:103 *(§ Datum en tijd)*
 
-> De Spectral regel `nlgov:query-keys-camel-case` is alleen beschikbaar in de GitHub-versie en controleert camelCase query parameters.
+> De Spectral linter bevat 4 regels voor datum/tijd: `date-time-ensure-timezone`, `specify-format-for-date-and-time`, `time-without-timezone`, `use-date-instead-of-datetime`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter (GitHub-versie)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Spectral linter
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De brontekst bevat de Spectral linter configuratie volledig, maar een regel `nlgov:query-keys-camel-case` of `query-keys-camel-case` ontbreekt daarin geheel. De bron bevat `schema-camel-case` en `property-casing`, maar niet een regel voor camelCase query parameters.*
+  - *De bron vermeldt geen datum/tijd-specifieke Spectral-regels zoals `date-time-ensure-timezone` of `specify-format-for-date-and-time`.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De brontekst bevat geen informatie over Spectral regels, GitHub-versies van linters, of `nlgov:query-keys-camel-case`.*
+  - *De brontekst is het ADR Beheermodel en bevat geen informatie over Spectral linter regels voor datum/tijd.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van Spectral linter regels of `nlgov:query-keys-camel-case` in de brontekst.*
+  - *De Spectral linter en datum/tijd-regels worden niet behandeld in deze bron.*
 </details>
 
-### `ls-api-0066` — SKILL.md:268 *(§ Spectral Linter)*
+### `ls-api-0046` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
 
-> De Spectral regel `nlgov:semver` is alleen beschikbaar in de GitHub-versie en controleert het semantic versioning formaat.
+> De Signing module gebruikt JAdES detached signatures met RSASSA-PSS (PS256), minimaal 256 bits.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter (GitHub-versie)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Signing module (draft)
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De brontekst bevat de volledige Spectral linter configuratie van ADR 2.1.0, maar een regel `nlgov:semver` of `semver` voor semantic versioning controle is daarin niet aanwezig. De standaard verwijst naar /core/semver als design rule, maar er is geen bijbehorende Spectral regel in de gepubliceerde configuratie.*
+  - *De bron vermeldt de Signing module alleen als een apart extensie-document en geeft geen details over JAdES, RSASSA-PSS of PS256.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De brontekst bevat geen informatie over Spectral regels, GitHub-versies van linters, of `nlgov:semver`.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van Spectral linter regels of `nlgov:semver` in de brontekst.*
+  - *De brontekst beschrijft het beheermodel voor de ADR. De Signing module wordt niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron gaat over de Geospatial module, niet over een Signing module.*
 </details>
 
-### `ls-api-0067` — SKILL.md:271 *(§ Spectral Linter)*
+### `ls-api-0047` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
 
-> De Spectral regel `nlgov:problem-schema-members` controleert verplichte velden in problem+json schema conform RFC 9457.
+> Signing module: signatures worden geplaatst in `Payload-Signature` en `Message-Signature` HTTP headers.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter (GitHub-versie)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Signing module (draft)
 
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
-  - *RFC 9457 bevat geen enkele verwijzing naar Spectral, linters, of de nlgov:problem-schema-members regel. Dit is een implementatiedetail van de Nederlandse API Design Rules tooling, niet van de RFC zelf.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
-### `ls-api-0068` — reference.md:50 *(§ Implementatievoorbeelden)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen inhoud over `Payload-Signature` of `Message-Signature` HTTP headers.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel voor de ADR. HTTP headers voor signing worden niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt geen Signing module of HTTP signature headers.*
+</details>
+
+### `ls-api-0048` — SKILL.md:148 *(§ Signing Module (JAdES) — draft)*
+
+> Signing module: OpenAPI representatie gebruikt `format: jws-compact-detached`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Signing module (draft)
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen vermelding van `format: jws-compact-detached`.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel voor de ADR. OpenAPI-representaties van signing worden niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron gaat niet over Signing module of jws-compact-detached formaten.*
+</details>
+
+### `ls-api-0049` — SKILL.md:154 *(§ Encryption Module (JWE) — draft)*
+
+> De Encryption module (JWE) is bedoeld voor end-to-end versleuteling van request/response payloads wanneer transport-level encryptie niet voldoende is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Encryption module (draft)
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron vermeldt alleen dat 'security controls for signing and encrypting of application level messages are part of separate extensions', zonder inhoudelijke details over JWE of end-to-end encryptie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel voor de ADR. De Encryption module wordt niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt geen Encryption module of JWE.*
+</details>
+
+### `ls-api-0050` — SKILL.md:237 *(§ Spectral Linter)*
+
+> De DON-hosted Spectral ruleset bevat 11 regels; de GitHub-versie bevat 22 regels (11 extra t.o.v. DON).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Spectral linter
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron bevat geen vergelijking tussen een DON-hosted versie (11 regels) en een GitHub-versie (22 regels) van de Spectral ruleset.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel voor de ADR. Spectral ruleset-aantallen worden niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen informatie over Spectral rulesets of het aantal regels daarin.*
+</details>
+
+### `ls-api-0054` — SKILL.md:271 *(§ Spectral Linter)*
+
+> De GitHub-versie van de ruleset bevat `nlgov:problem-schema-members` die verplichte velden in problem+json schema (RFC 9457) controleert.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Spectral linter regels (GitHub-only)
+
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
+  - *De claim gaat over een specifieke Spectral linter ruleset (`nlgov:problem-schema-members`) in een GitHub-repository van de Nederlandse API Design Rules. RFC 9457 bevat geen informatie over Spectral rules, linters, of de Nederlandse API Design Rules GitHub-repo.*
+
+### `ls-api-0055` — reference.md:50 *(§ Implementatievoorbeelden)*
 
 > Referentie-implementaties voor de ADR zijn beschikbaar in ASP.NET en Quarkus.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — implementatievoorbeelden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — implementatievoorbeelden
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De brontekst bevat geen verwijzing naar referentie-implementaties in ASP.NET of Quarkus. Dit onderwerp wordt in deze versie van de ADR spec niet behandeld.*
+  - *De bron bevat geen vermelding van referentie-implementaties in ASP.NET of Quarkus.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De brontekst noemt geen referentie-implementaties in ASP.NET of Quarkus. Wel wordt validatie via API-test.nl en Developer.overheid.nl genoemd, maar dit zijn testtools, geen referentie-implementaties.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van referentie-implementaties in ASP.NET of Quarkus in de brontekst.*
+  - *De brontekst beschrijft het beheermodel voor de ADR. Referentie-implementaties in specifieke frameworks worden niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt geen referentie-implementaties voor ADR in ASP.NET of Quarkus.*
 </details>
 
-## CONTRADICTED — bron spreekt de claim expliciet tegen (1)
-
-### `ls-api-0036` — SKILL.md:111 *(§ Naamgeving)*
-
-> Implementatiedetails zoals framework- of databasenamen MOGEN NIET in URIs worden verborgen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — naamgeving
-
-- **CONTRADICTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > An API SHOULD not expose implementation details of the underlying application, development platforms/frameworks or database systems/persistence models.
-  - *De claim stelt dat implementatiedetails NIET in URIs verborgen mogen worden (MUST NOT), maar de bron zegt dat een API implementatiedetails SHOULD NOT blootstellen — dit is een zwakkere norm dan MUST NOT. Bovendien gaat de regel over het niet blootstellen (niet verbergen) van implementatiedetails, wat de omgekeerde formulering is van de claim.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *URI-ontwerpregels over implementatiedetails worden niet behandeld in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Verbod op implementatiedetails in URIs wordt niet behandeld in deze bron.*
-
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (6)
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (14)
 
 ### `ls-api-0005` — SKILL.md:35 *(§ Versiemodel)*
 
 > De Geospatial module v1.0.x is normatief onderdeel van ADR v2.1.0 en daarmee vastgesteld.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR v2.1.0 — Geospatial module
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > functional /core/geospatial : Apply the geospatial module for geospatial data — The API Design Rules Module: Geospatial version 1.0.x MUST be applied when providing geospatial data or functionality.
-  - *De bron bevestigt dat Geospatial module v1.0.x normatief vereist is (MUST), maar zegt niets over een eigen vaststellingsproces of dat de module daarmee 'vastgesteld' is in de formele zin.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron is het beheermodel ADR v1.0 uit 2021. ADR v2.1.0 en de Geospatial module worden niet vermeld.*
-
-### `ls-api-0023` — SKILL.md:78 *(§ Versiebeheer)*
-
-> Bij major version changes MOET een deprecation schedule gepubliceerd worden.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > functional /core/deprecation-schedule : Include a deprecation schedule when deprecating features or versions — When deprecating features or versions, a deprecation schedule MUST be published.
-  - *De bron vereist een deprecation schedule bij het deprecaten van features of versies in het algemeen, niet specifiek alleen bij major version changes. De claim koppelt het expliciet aan major version changes, wat een beperking is die de bron niet maakt.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen regels over deprecation schedules bij major version changes.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over deprecation schedules bij major version changes.*
-
-### `ls-api-0025` — SKILL.md:83 *(§ Foutafhandeling)*
-
-> Foutresponses MOETEN `application/problem+json` (RFC 9457) gebruiken.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — foutafhandeling
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
-  > The data model for problem details is a JSON [JSON] object; when serialized as a JSON document, it uses the "application/problem+json" media type.
-  - *RFC 9457 definieert application/problem+json als het media type voor problem details en beschrijft het formaat uitgebreid, maar legt geen MUST-verplichting op aan API-implementors om dit te gebruiken. De spec zegt dat foutresponses dit formaat KAN gebruiken ('Problem details can be used with any HTTP status code'), niet dat het verplicht is. De MUST-claim is dus sterker dan wat de RFC zelf voorschrijft — die verplichting komt waarschijnlijk uit de ADR (API Design Rules), niet uit RFC 9457 zelf. De bron ondersteunt het gebruik van application/problem+json maar niet de MUST-modaliteit.*
-
-### `ls-api-0033` — SKILL.md:108 *(§ Naamgeving)*
-
-> Collecties MOETEN in meervoud worden benoemd: `/users`, `/orders`.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — naamgeving
-
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > Collection resources are referred to using plural nouns. [...] The path segment describing the name of the collection resource MUST be written in the plural form. Example collection resources: https://api.example.org/v1/gebouwen https://api.example.org/v1/vergunningen
-  - *Bron bevestigt meervoud voor collecties maar gebruikt Nederlandse voorbeelden (`gebouwen`, `vergunningen`), niet de Engelstalige voorbeelden `/users` en `/orders` uit de claim.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Naamgevingsregels voor collecties zijn geen onderdeel van dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Naamgeving van collecties in meervoud wordt niet behandeld in deze bron.*
-
-### `ls-api-0035` — SKILL.md:110 *(§ Naamgeving)*
-
-> Interfaces MOETEN in het Nederlands worden gedefinieerd tenzij er een officieel Engelstalig begrippenkader bestaat.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — naamgeving
-
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > Resources and the underlying attributes SHOULD be defined in the Dutch language unless there is an official English glossary available.
-  - *De bron zegt SHOULD, niet MUST. De claim stelt MOETEN (MUST). Dit is een verzwakking van de norm.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Taalvereisten voor interface-definities worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Taalvereisten voor interface-definities (Nederlands tenzij officieel Engelstalig begrippenkader) worden niet behandeld in deze bron.*
-
-### `ls-api-0050` — SKILL.md:142 *(§ Geospatial Module (v1.0.3 — vastgesteld))*
-
-> De Geospatial module v1.0.3 is normatief onderdeel van ADR v2.1.0 en is verplicht bij geospatiale data.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Geospatial module
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Geospatial module
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
   > The API Design Rules Module: Geospatial version 1.0.x MUST be applied when providing geospatial data or functionality.
-  - *De bron bevestigt dat de Geospatial module verplicht is bij geospatiale data, maar vermeldt versie `1.0.x` (niet specifiek `v1.0.3`). De versieclaim `v1.0.3` is niet verifieerbaar vanuit deze bron.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > This document is part of the Nederlandse API Strategie. [...] Normative module GEO module v1.0 [...] This is the definitive version of this document.
-  - *De bron bevestigt dat dit document een normatief onderdeel is van de Nederlandse API Strategie en dat het de definitieve versie is (1.0.3). De claim over 'ADR v2.1.0' specifiek en 'verplicht bij geospatiale data' als zodanig wordt niet letterlijk bevestigd; de bron noemt 'GEO module v1.0' als normatief zonder versienummer 1.0.3 in de statustabel.*
+  - *De bron bevestigt dat de Geospatial module v1.0.x normatief onderdeel is van ADR v2.1.0. Dat de module daarmee 'vastgesteld' is in een eigen vaststellingsproces wordt niet vermeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De Geospatial module en versienummers worden niet beschreven in dit beheermodel.*
+  - *De bron beschrijft de ADR v1.0. ADR v2.1.0 en een Geospatial module worden niet vermeld.*
 
-## UNGROUNDED — geen bron ondersteunt de claim (15)
+### `ls-api-0007` — SKILL.md:42 *(§ Repositories)*
 
-### `ls-api-0011` — SKILL.md:55 *(§ URI-ontwerp)*
+> De ADR-Beheermodel repository is gearchiveerd en vervangen door API-Standaarden-Beheermodel.
 
-> Padsegmenten MOETEN kebab-case gebruiken: `/mijn-documenten` (niet `/mijnDocumenten`).
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — repositories
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — URI-ontwerp
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  > Dit beheermodel is verouderd en vervangen door het algemene API Standaarden beheermodel
+  - *De bron bevestigt dat de ADR-Beheermodel repository gearchiveerd is en vervangen is door een algemeen API Standaarden beheermodel. De claim noemt specifiek 'API-Standaarden-Beheermodel' als naam van de vervangende repository — dat exacte detail staat niet in de bron.*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  > Generiek beheermodel voor de verzameling van API standaarden [...] Overzicht van API standaarden Een overzicht van API standaarden waarvoor dit beheer model wordt opgezet: NLGov REST API Design Rules NLGov Profiel voor OAuth 2.0 NLGov OIDC profiel Cloudevents
+  - *De bron bevestigt dat API-Standaarden-Beheermodel bestaat en de ADR beheert, wat de vervanging impliciet ondersteunt. Maar of de ADR-Beheermodel repository expliciet is 'gearchiveerd' staat niet in de brontekst.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat een linter-regel (paths-kebab-case) met severity 'warn', niet 'error', die kebab-case aanbeveelt. Er is geen normatieve MUST-regel voor kebab-case padsegmenten in de designrules-tekst zelf.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  - *De bron maakt geen melding van de ADR-Beheermodel repository of een opvolger. Dit onderwerp wordt niet behandeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron is het beheermodel en bevat geen technische URI-ontwerpregels over kebab-case padsegmenten.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over kebab-case padsegmenten in URIs.*
+  - *De bron is juist de ADR-Beheermodel repository zelf (v1.0). Of deze gearchiveerd is en vervangen door een API-Standaarden-Beheermodel staat er niet in.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  - *De brontekst (GitHub README van API-Design-Rules) vermeldt niets over een gearchiveerde ADR-Beheermodel repository of een vervangend API-Standaarden-Beheermodel. Er staat alleen een link naar https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/ zonder verdere details over archivering.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  - *De brontekst vermeldt het beheermodel alleen als externe referentie ('The Governance of this standard is described by the API-Standaarden beheermodel published by Logius'), maar bevat geen informatie over archivering van de ADR-Beheermodel repository of vervanging door API-Standaarden-Beheermodel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  - *De brontekst vermeldt dat beheermodellen van ADR en OAuth zijn samengevoegd met dit beheermodel en dat 'de kopieën zijn daarom nu gearchiveerd', maar zegt niets specifieks over een 'ADR-Beheermodel repository' die gearchiveerd is en vervangen door 'API-Standaarden-Beheermodel' als repositorynaam.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De brontekst gaat uitsluitend over de API-mod-geospatial repository. Er is geen informatie over ADR-Beheermodel of API-Standaarden-Beheermodel.*
 </details>
 
-### `ls-api-0012` — SKILL.md:56 *(§ URI-ontwerp)*
+### `ls-api-0008` — SKILL.md:44 *(§ Repositories)*
+
+> De API-mod-geospatial module is normatief opgenomen in ADR v2.1.0; vastgestelde versie is v1.0.3.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Geospatial module
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > The API Design Rules Module: Geospatial version 1.0.x MUST be applied when providing geospatial data or functionality.
+  - *De bron bevestigt dat de Geospatial module v1.0.x normatief is opgenomen, maar noemt geen specifiek versienummer v1.0.3. De claim dat de vastgestelde versie v1.0.3 is wordt niet ondersteund.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  > Normative module GEO module v1.0 [...] /core/modules/geospatial : Apply the geospatial module for geospatial data [...] The API Design Rules Module: Geospatial version 1.0.x MUST be applied when providing geospatial data or functionality.
+  - *De bron bevestigt dat de Geospatial module normatief is opgenomen (via /core/modules/geospatial), en verwijst naar versie 1.0.x. De claim dat het specifiek om ADR v2.1.0 gaat en dat de vastgestelde versie v1.0.3 is, wordt niet bevestigd — de bron is een draft zonder versienummer in de titel, en noemt alleen '1.0.x'.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *API-mod-geospatial en ADR v2.1.0 worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  - *De brontekst bevat geen informatie over een API-mod-geospatial module, noch over normatieve opname in ADR v2.1.0 of een versienummer v1.0.3. De README noemt alleen ADR, OAuth en OIDC als standaarden.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  - *De bron (GitHub-landingspagina van ADR-Beheermodel) bevat geen informatie over de geospatial module, ADR v2.1.0 of versienummers.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  - *De brontekst noemt geen modules, geen versienummers, en geen geospatial specificaties.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  - *De brontekst noemt de API-mod-geospatial module niet. Er is geen informatie over normatieve opname in ADR v2.1.0 of een vastgestelde versie v1.0.3.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De bron bevestigt dat API-mod-geospatial bestaat als module, maar vermeldt niets over normatieve opname in ADR v2.1.0 of een vastgestelde versie v1.0.3. Er zijn wel '3 tags' vermeld, maar geen versienummers.*
+</details>
+
+### `ls-api-0009` — SKILL.md:45 *(§ Repositories)*
+
+> De API-mod-transport-security repository is gearchiveerd; de inhoud is ingebed in ADR v2.1.0.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Transport Security module
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > 3.8 Transport Security ... The scope of this section is limited to generic security controls that directly influence the visible parts of an API.
+  - *De bron bevestigt dat Transport Security is ingebed in ADR v2.1.0 als sectie 3.8. Dat de repository gearchiveerd is wordt niet vermeld in de bron.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  > Normative Transport Security module v1.0 [...] 2.11 Transport Security [...] Note: security controls for signing and encrypting of application level messages are part of separate extensions: Signing and Encryption.
+  - *De bron bevestigt dat Transport Security als module bestaat en normatief is opgenomen (sectie 2.11 is geheel gewijd aan Transport Security, en de leeswijzer noemt 'Transport Security module v1.0'). De claim dat de repository gearchiveerd is en de inhoud ingebed is in ADR v2.1.0 wordt niet expliciet bevestigd — de bron is een draft zonder versienummer.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *API-mod-transport-security en ADR v2.1.0 worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  - *De brontekst vermeldt niets over een API-mod-transport-security repository, archivering daarvan, of inbedding in ADR v2.1.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  - *De bron bevat geen informatie over de API-mod-transport-security repository of de inhoud ervan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  - *De brontekst bevat geen informatie over API-mod-transport-security of archivering daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  - *De brontekst noemt de API-mod-transport-security repository niet. Er is geen informatie over archivering of inbedding in ADR v2.1.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De brontekst behandelt de API-mod-transport-security repository niet.*
+</details>
+
+### `ls-api-0010` — SKILL.md:46 *(§ Repositories)*
+
+> De API-mod-signing module (HTTP Message Signing) heeft nog geen vastgestelde versie en is een draft.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Signing module
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Note: security controls for signing and encrypting of application level messages are part of separate extensions: Signing and Encryption.
+  - *De bron bevestigt dat Signing een aparte extensie is, maar zegt niets over de vaststellingsstatus (draft of vastgesteld).*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Een signing module of HTTP Message Signing wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  - *De brontekst bevat geen informatie over een API-mod-signing module of de draftstatus daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  - *De bron vermeldt de Signing module normatief (/core/modules/signing) en verwijst naar 'API Design Rules Module: Signing version 1.0.x', maar bevat geen informatie over de versie-status (draft vs. vastgesteld). De claim dat er nog geen vastgestelde versie is, kan niet worden getoetst aan deze bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  - *De bron bevat geen informatie over de API-mod-signing module of HTTP Message Signing.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  - *De brontekst noemt geen signing module, HTTP Message Signing, of draftstatus van modules.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  - *De brontekst noemt de API-mod-signing module noch HTTP Message Signing. Er is geen informatie over de status (draft of vastgesteld).*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De brontekst behandelt de API-mod-signing repository niet.*
+</details>
+
+### `ls-api-0011` — SKILL.md:47 *(§ Repositories)*
+
+> De API-mod-encryption module (JWE) heeft nog geen vastgestelde versie en is een draft.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Encryption module
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Note: security controls for signing and encrypting of application level messages are part of separate extensions: Signing and Encryption.
+  - *De bron bevestigt dat Encryption een aparte extensie is, maar zegt niets over de vaststellingsstatus (draft of vastgesteld).*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Een encryption module (JWE) wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
+  - *De brontekst bevat geen informatie over een API-mod-encryption module of de draftstatus daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
+  - *De bron vermeldt de Encryption module normatief (/core/modules/encryption) en verwijst naar 'API Design Rules Module: Encryption version 1.0.x', maar bevat geen informatie over de versie-status (draft vs. vastgesteld). De claim dat er nog geen vastgestelde versie is, kan niet worden getoetst aan deze bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
+  - *De bron bevat geen informatie over de API-mod-encryption module of JWE.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
+  - *De brontekst noemt geen encryption module, JWE, of draftstatus van modules.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
+  - *De brontekst noemt de API-mod-encryption module noch JWE. Er is geen informatie over de status (draft of vastgesteld).*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
+  - *De brontekst behandelt de API-mod-encryption repository niet.*
+</details>
+
+### `ls-api-0012` — SKILL.md:55 *(§ URI-ontwerp)*
+
+> URI-padsegmenten MOETEN kebab-case gebruiken: `/mijn-documenten` (niet `/mijnDocumenten`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — URI-ontwerp
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > paths-kebab-case: severity: warn message: " {{property}} is not kebab-case."
+  - *De linter configuratie in de bron suggereert kebab-case voor paden, maar dit is een warn (niet error) en staat in een non-normatieve sectie (Appendix A). Er is geen normatieve MUST-regel voor kebab-case in de kern van de spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De bron beschrijft het beheermodel, niet de inhoudelijke technische regels van de ADR. Kebab-case voor URI-padsegmenten staat er niet in.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron gaat over geospatiale regels; kebab-case voor URI-padsegmenten wordt niet behandeld.*
+
+### `ls-api-0016` — SKILL.md:59 *(§ URI-ontwerp)*
+
+> De major versie MOET in de URI zijn opgenomen: `/v1/resources`; in OAS op serverniveau, niet in individuele paden.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — URI-ontwerp en versiebeheer
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > The URI of an API (base path) MUST include the major version number, prefixed by the letter v ... An example of an openapi.yaml for an API with a base path https://api.example.org/v1
+  - *De bron bevestigt dat de major versie in de URI moet staan. De specificatie dat dit 'op serverniveau, niet in individuele paden' moet worden gedaan wordt geïmpliceerd door het voorbeeld maar niet expliciet als regel gesteld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *Versie-opname in de URI en OAS-serverniveau worden niet behandeld in dit beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Versie in de URI wordt niet behandeld in deze bron.*
+
+### `ls-api-0025` — SKILL.md:99 *(§ Datum en tijd)*
+
+> Datum/tijd-waarden MOETEN het RFC 3339 formaat gebruiken.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — datum en tijd
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
+  > The following profile of ISO 8601 [ISO8601] dates SHOULD be used in new protocols on the Internet.
+  - *RFC 3339 definieert het formaat als SHOULD (aanbevolen), niet als MUST (verplicht). De claim stelt dat het formaat MOET worden gebruikt, maar de bron zegt 'SHOULD be used'. Dit is een verzwakking ten opzichte van de claim, maar de bron bevestigt wel dat RFC 3339 het relevante formaat is voor datum/tijd-waarden op internet. De claim kan dus grotendeels worden onderbouwd door de bron, maar het normatieve niveau (MUST vs SHOULD) klopt niet exact.*
+
+### `ls-api-0031` — SKILL.md:108 *(§ Naamgeving)*
+
+> Collecties MOETEN in meervoud worden aangeduid: `/users`, `/orders`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — naamgeving
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Collection resources are referred to using plural nouns. [...] The path segment describing the name of the collection resource MUST be written in the plural form. Example collection resources: https://api.example.org/v1/gebouwen https://api.example.org/v1/vergunningen
+  - *De bron bevestigt het meervoud-MUST, maar de voorbeelden zijn `/gebouwen` en `/vergunningen`, niet `/users` of `/orders` zoals de claim stelt. De eis zelf is correct, maar de specifieke voorbeeldpaden in de claim worden niet bevestigd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel, niet de inhoudelijke naamgevingsregels van de ADR.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Meervoud voor collecties wordt niet als expliciete regel behandeld. De bron gebruikt wel meervoud in voorbeelden (e.g. /collections/gebouwen) maar formuleert geen MUST-regel hierover.*
+
+### `ls-api-0032` — SKILL.md:110 *(§ Naamgeving)*
+
+> Interfaces MOETEN in het Nederlands worden gedefinieerd tenzij er een officieel Engelstalig begrippenkader bestaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — naamgeving
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > Resources and the underlying attributes SHOULD be defined in the Dutch language unless there is an official English glossary available.
+  - *De bron zegt SHOULD, niet MUST zoals de claim stelt. De claim gebruikt 'MOETEN' (MUST), maar de spec gebruikt SHOULD — dit is een verschil in normativiteit.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel, niet de inhoudelijke naamgevingsregels van de ADR.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Taalkeuze (Nederlands/Engels) voor interface-definities wordt niet behandeld.*
+
+### `ls-api-0033` — SKILL.md:111 *(§ Naamgeving)*
+
+> Een API SHOULD geen framework-, platform- of databasenamen blootleggen in resource-paden (ADR).
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD_NOT  ·  **Scope:** API Design Rules — naamgeving
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > The API SHOULD not expose information about the technical components being used, such as development platforms/frameworks or database systems.
+  - *De bron bevestigt dat platforms/frameworks en databasesystemen niet blootgelegd mogen worden (SHOULD NOT), maar spreekt specifiek over implementatiedetails in het algemeen, niet uitsluitend over 'resource-paden'. De strekking klopt, de locatie-specificiteit (resource-paden) wordt niet expliciet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel, niet de inhoudelijke API-ontwerpregels.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *Het niet blootleggen van framework- of databasenamen in resource-paden wordt niet behandeld.*
+
+### `ls-api-0036` — SKILL.md:117 *(§ OpenAPI Documentatie)*
+
+> Contactinformatie (`info.contact` met `name`, `email`, `url`) wordt sterk aanbevolen voor publieke APIs (ADR `/core/doc-openapi-contact`: SHOULD).
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** API Design Rules — OpenAPI documentatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > OpenAPI definition document SHOULD include the info.contact object for publicly available APIs. Contact information SHOULD NOT be a generic contact address for the whole organisation. [...] Relevant contact information can include an email address and issue tracker.
+  - *De bron bevestigt SHOULD en vermeldt name, url en email als velden in het voorbeeld. De claim stelt dat name, email en url 'sterk aanbevolen' zijn, wat klopt. Echter, de bron zegt alleen dat relevante contactinfo 'can include' email en issue tracker — de drie velden worden alleen als voorbeeld in de JSON getoond, niet expliciet als vereiste velden benoemd in de normatieve tekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel, niet de inhoudelijke ADR-regels over contactinformatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt geen OpenAPI contactinformatie of info.contact velden.*
+
+### `ls-api-0045` — SKILL.md:142 *(§ Geospatial Module (v1.0.3 — vastgesteld))*
+
+> De Geospatial module (v1.0.3, vastgesteld) is verplicht bij geospatiale data en regelt GeoJSON encodering, bounding box filtering en coördinaatsystemen (CRS).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — Geospatial module
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > This document describes the Geospatial module, containing rules for geospatial content and functions in APIs. [...] This is the definitive version of this document.
+  - *De bron bevestigt dat het om versie 1.0.3 (definitief/vastgesteld) gaat en behandelt GeoJSON encodering, bounding box filtering en CRS. De bron zegt echter nergens expliciet dat de module 'verplicht' is bij geospatiale data; de normatieve status impliceert dat, maar de claim van 'verplicht' staat niet letterlijk in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  - *De brontekst beschrijft het beheermodel voor de ADR. De Geospatial module wordt niet besproken.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (6)
+
+### `ls-api-0013` — SKILL.md:56 *(§ URI-ontwerp)*
 
 > Query-parameters MOETEN camelCase gebruiken: `?sortOrder=desc`.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — URI-ontwerp
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — URI-ontwerp
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat geen regel over camelCase query-parameters.*
+  - *De bron bevat geen regel over camelCase voor query-parameters. Dit onderwerp wordt niet normatief behandeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen technische URI-ontwerpregels over camelCase query-parameters.*
+  - *camelCase voor query-parameters wordt niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over camelCase query-parameters.*
+  - *CamelCase voor query-parameters wordt niet behandeld in deze bron.*
 </details>
 
-### `ls-api-0014` — SKILL.md:58 *(§ URI-ontwerp)*
+### `ls-api-0015` — SKILL.md:58 *(§ URI-ontwerp)*
 
-> URIs mogen geen bestandsextensies bevatten; gebruik de Accept-header voor content negotiation.
+> URIs mogen geen bestandsextensies bevatten; gebruik Accept-header voor content negotiation.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — URI-ontwerp
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** API Design Rules — URI-ontwerp
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat geen regel over het verbod op bestandsextensies in URIs of het gebruik van de Accept-header voor content negotiation.*
+  - *De bron bevat geen regel over bestandsextensies in URIs of het gebruik van Accept-header voor content negotiation in dit verband.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen regels over bestandsextensies in URIs of gebruik van Accept-headers.*
+  - *Bestandsextensies in URIs en content negotiation via Accept-header worden niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over bestandsextensies in URIs of het gebruik van de Accept-header voor content negotiation in deze context.*
+  - *Bestandsextensies in URIs en content negotiation via Accept-header worden niet behandeld.*
 </details>
 
-### `ls-api-0028` — SKILL.md:100 *(§ Datum en tijd)*
+### `ls-api-0023` — SKILL.md:83 *(§ Foutafhandeling)*
+
+> Foutresponses MOETEN het mediatype `application/problem+json` (RFC 9457) gebruiken.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — foutafhandeling
+
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
+  - *De bron is RFC 9457 zelf, die het application/problem+json formaat definieert. De claim gaat over een verplichting in de Nederlandse API Design Rules om dit mediatype te gebruiken. RFC 9457 legt geen verplichting op aan API Design Rules of vergelijkbare nationale standaarden — dat is een externe beleidskeuze. De bron is dus niet de juiste bron om deze claim te verifiëren.*
+
+### `ls-api-0026` — SKILL.md:100 *(§ Datum en tijd)*
 
 > Bij `date-time` velden MOET altijd een timezone worden gespecificeerd (bijv. `2026-04-11T10:30:00+02:00`).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — datum en tijd
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — datum en tijd
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron bevat geen regels over date-time velden of het verplicht opnemen van een timezone.*
+  - *De bron bevat geen regels over date-time velden of timezone specificatie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen technische regels over datum/tijd-velden of timezone-specificatie.*
+  - *date-time velden en timezone-specificatie worden niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over `date-time` velden of timezone-specificatie.*
+  - *Timezone in date-time velden wordt niet behandeld in deze bron.*
 </details>
 
-### `ls-api-0029` — SKILL.md:101 *(§ Datum en tijd)*
+### `ls-api-0027` — SKILL.md:101 *(§ Datum en tijd)*
 
-> Gebruik `format: date` wanneer alleen een datum nodig is (niet `date-time`).
+> Wanneer alleen een datum nodig is, MOET `format: date` worden gebruikt in plaats van `date-time`.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — datum en tijd
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — datum en tijd
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De brontekst bevat geen regels over datum/tijd formatting of gebruik van `format: date` vs `format: date-time`.*
+  - *De bron bevat geen regels over het gebruik van format: date versus format: date-time.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen technische regels over het gebruik van `format: date` versus `date-time`.*
+  - *format: date versus date-time wordt niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over het gebruik van `format: date`.*
+  - *Gebruik van format: date wordt niet behandeld.*
 </details>
 
-### `ls-api-0030` — SKILL.md:102 *(§ Datum en tijd)*
+### `ls-api-0028` — SKILL.md:102 *(§ Datum en tijd)*
 
-> Properties die datum of tijd bevatten MOETEN altijd een `format` specificeren.
+> Voor properties die datum of tijd bevatten MOET altijd een `format` worden gespecificeerd.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — datum en tijd
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — datum en tijd
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De brontekst bevat geen regels over verplicht specificeren van `format` voor datum/tijd properties.*
+  - *De bron bevat geen regels of vermeldingen over het specificeren van een `format` voor datum/tijd-properties.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron is het ADR Beheermodel (governance/beheer document), niet de technische ADR-specificatie zelf. Technische regels over datum/tijd-properties worden hier niet beschreven.*
+  - *Format-specificatie voor datum/tijd properties wordt niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron gaat over de Geospatial module (GeoJSON, CRS, bounding box). Datum/tijd-properties en format-specificaties worden niet behandeld.*
+  - *Format-specificatie voor datum/tijd properties wordt niet behandeld.*
 </details>
 
-### `ls-api-0034` — SKILL.md:109 *(§ Naamgeving)*
+## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (6)
 
-> Individuele resources MOETEN in enkelvoud worden benoemd: `/users/{id}`.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — naamgeving
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron zegt dat enkelvoudige resources niet in een collectie staan MUST worden benoemd in enkelvoud, maar dit gaat over zelfstandige singular resources, niet over `/users/{id}` als patroon. De claim stelt dat individuele resources binnen een collectie enkelvoud MOETEN gebruiken, wat de bron niet expliciet stelt. De bron bespreekt `/gebouwen/3b9710c4-...` als patroon zonder de naam van het segment enkelvoud te noemen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Naamgevingsregels voor individuele resources zijn geen onderdeel van dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Naamgeving van individuele resources in enkelvoud wordt niet behandeld in deze bron.*
-</details>
-
-### `ls-api-0042` — SKILL.md:126 *(§ Transport Security (TLS))*
+### `ls-api-0039` — SKILL.md:126 *(§ Transport Security (TLS))*
 
 > Alle verbindingen MOETEN TLS gebruiken (wettelijk verplicht). Volg de laatste NCSC-richtlijnen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — Transport Security
 
-*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' beschrijft de gearchiveerde status van API-mod-transport-security en dat inhoud is ingebed in ADR v2.1.0. Maar specifieke TLS/NCSC-verplichtingen worden niet behandeld. Lage confidence: het onderwerp raakt dezelfde module, maar de concrete claim is niet gedocumenteerd.*
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De brontekst is alleen de GitHub-repositorypagina (README/navigatie). De inhoud van transport-security.md is niet meegeleverd, dus de TLS-verplichting kan niet worden geverifieerd.*
-
-### `ls-api-0043` — SKILL.md:132 *(§ Transport Security (TLS))*
-
-> De header `Cache-Control: no-store` is verplicht in alle API-responses om caching van gevoelige data te voorkomen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
-
-*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' beschrijft dat de repo gearchiveerd is en content ingebed in ADR v2.1.0, maar de specifieke Cache-Control-verplichting wordt nergens behandeld. Lage confidence.*
+**Erkend in conflicts.md** *(§ Transport Security module: dubbelzinnige status)*: conflicts.md §'Transport Security module': repo is gearchiveerd, inhoud ingebed als sectie 3.8 in ADR v2.1.0, module v1.0 nog normatief in leeswijzer. NOT_FOUND in gearchiveerde repo is verwacht; claim kan via ADR v2.1.0 worden geverifieerd.
 
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+  - *De aangeleverde brontekst bevat alleen de GitHub-repositorypagina met navigatie, metadata en een korte beschrijving. De inhoud van transport-security.md is niet meegeleverd. Er is geen inhoudelijke tekst over TLS of NCSC-richtlijnen.*
 
-### `ls-api-0044` — SKILL.md:133 *(§ Transport Security (TLS))*
+### `ls-api-0040` — SKILL.md:132 *(§ Transport Security (TLS))*
 
-> De header `Content-Security-Policy: frame-ancestors 'none'` is verplicht in alle API-responses als clickjacking-bescherming.
+> De header `Cache-Control: no-store` is verplicht in alle API-responses.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — Transport Security verplichte headers
 
-*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' behandelt de gearchiveerde repo en inbedding, maar niet de specifieke Content-Security-Policy-verplichting. Lage confidence.*
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
-
-### `ls-api-0045` — SKILL.md:134 *(§ Transport Security (TLS))*
-
-> De header `Content-Type: application/json` is verplicht in alle API-responses.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
-
-*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' raakt dezelfde module-context, maar de verplichting voor Content-Type-header in API-responses is niet als discrepantie gedocumenteerd. Lage confidence.*
+**Erkend in conflicts.md** *(§ Transport Security module: dubbelzinnige status)*: conflicts.md §'Transport Security module': repo is gearchiveerd, inhoud ingebed in ADR v2.1.0 sectie 3.8. NOT_FOUND in gearchiveerde repo is verwacht; verificatie loopt via ADR v2.1.0.
 
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+  - *De aangeleverde brontekst bevat geen inhoud van de specificatie. Alleen GitHub UI-tekst en bestandslijsten zijn zichtbaar.*
 
-### `ls-api-0046` — SKILL.md:135 *(§ Transport Security (TLS))*
+### `ls-api-0041` — SKILL.md:133 *(§ Transport Security (TLS))*
 
-> De header `Strict-Transport-Security` is verplicht in alle API-responses om HTTPS te vereisen.
+> De header `Content-Security-Policy: frame-ancestors 'none'` is verplicht in alle API-responses.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — Transport Security verplichte headers
 
-*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' beschrijft de module-status maar niet de specifieke Strict-Transport-Security-verplichting. Lage confidence.*
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
-
-### `ls-api-0047` — SKILL.md:136 *(§ Transport Security (TLS))*
-
-> De header `X-Content-Type-Options: nosniff` is verplicht in alle API-responses om MIME sniffing te voorkomen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
-
-*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' raakt de module-context, maar de X-Content-Type-Options-verplichting is niet specifiek gedocumenteerd als discrepantie. Lage confidence.*
+**Erkend in conflicts.md** *(§ Transport Security module: dubbelzinnige status)*: conflicts.md §'Transport Security module': repo is gearchiveerd, inhoud ingebed in ADR v2.1.0 sectie 3.8. NOT_FOUND in gearchiveerde repo is verwacht; verificatie loopt via ADR v2.1.0.
 
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+  - *De aangeleverde brontekst bevat geen inhoud van de specificatie. Alleen GitHub UI-tekst en bestandslijsten zijn zichtbaar.*
 
-### `ls-api-0048` — SKILL.md:137 *(§ Transport Security (TLS))*
+### `ls-api-0042` — SKILL.md:135 *(§ Transport Security (TLS))*
 
-> De header `X-Frame-Options: DENY` is verplicht in alle API-responses als clickjacking-bescherming.
+> De header `Strict-Transport-Security` is verplicht in alle API-responses.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — Transport Security verplichte headers
 
-*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' behandelt de gearchiveerde repo en inbedding, maar niet de specifieke X-Frame-Options-verplichting. Lage confidence.*
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
-
-### `ls-api-0049` — SKILL.md:138 *(§ Transport Security (TLS))*
-
-> De header `Access-Control-Allow-Origin` is verplicht in alle API-responses voor het CORS-beleid.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — Transport Security, security headers
-
-*Mogelijk relevant in conflicts.md (§ Transport Security module: dubbelzinnige status): conflicts.md § 'Transport Security module' raakt de module-context, maar de Access-Control-Allow-Origin-verplichting voor CORS is niet als discrepantie gedocumenteerd. Lage confidence.*
+**Erkend in conflicts.md** *(§ Transport Security module: dubbelzinnige status)*: conflicts.md §'Transport Security module': repo is gearchiveerd, inhoud ingebed in ADR v2.1.0 sectie 3.8. NOT_FOUND in gearchiveerde repo is verwacht; verificatie loopt via ADR v2.1.0.
 
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De inhoud van transport-security.md is niet meegeleverd in de brontekst.*
+  - *De aangeleverde brontekst bevat geen inhoud van de specificatie. Alleen GitHub UI-tekst en bestandslijsten zijn zichtbaar.*
 
-## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (2)
+### `ls-api-0043` — SKILL.md:136 *(§ Transport Security (TLS))*
 
-### `ls-api-0008` — SKILL.md:41 *(§ Repositories)*
+> De header `X-Content-Type-Options: nosniff` is verplicht in alle API-responses.
 
-> ADR v2.1.0 is de vastgestelde versie, gepubliceerd op https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/.
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — Transport Security verplichte headers
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — hoofdspecificatie
+**Erkend in conflicts.md** *(§ Transport Security module: dubbelzinnige status)*: conflicts.md §'Transport Security module': repo is gearchiveerd, inhoud ingebed in ADR v2.1.0 sectie 3.8. NOT_FOUND in gearchiveerde repo is verwacht; verificatie loopt via ADR v2.1.0.
 
-**Erkend in conflicts.md** *(§ ADR werkversie-nummering op draft-pagina)*: conflicts.md § 'ADR werkversie-nummering op draft-pagina': de draft-pagina (logius-standaarden.github.io/API-Design-Rules) toont nog versienummer '2.1.0' terwijl v2.1.0 ook de DEF-versie is. 'Het versienummer in ReSpec is simpelweg nog niet opgehoogd.' CONTRADICTED-verdict op GitHub Pages is dus gedocumenteerde keuze.
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > NLGov REST API Design Rules 2.1.0 Logius Standard Definitive version August 27, 2025 This version: https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
-  > Releases 8 v2.1.0 Latest Sep 29, 2025
-  - *De bron bevestigt dat v2.1.0 de meest recente release is. De publicatie-URL https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/ wordt niet expliciet vermeld in de brontekst.*
-- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
-  > Previous version: https://gitdocumentatie.logius.nl/publicatie/api/adr/2.0.2/
-  - *De bron vermeldt v2.0.2 als de vorige versie en is zelf een draft zonder versienummer in de header dat overeenkomt met v2.1.0. Er is geen bevestiging dat v2.1.0 de vastgestelde versie is; de meest recente gepubliceerde versie die wordt genoemd is 2.0.2.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
-  > Formele standaard: NLGov API Design Rules (ADR) 2.1.0 — Gepubliceerde versie: 2.1.0
-  - *De bron bevestigt dat ADR 2.1.0 de gepubliceerde versie is, maar de specifieke publicatie-URL https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/ wordt niet vermeld in de bron.*
-<details><summary>13x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron is het beheermodel uit 2021 en vermeldt alleen ADR v1.0 als vastgestelde versie. ADR v2.1.0 wordt niet vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron gaat over de Geospatial module v1.0.3, niet over ADR v2.1.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
-  - *De bron bevat geen informatie over ADR versienummers of publicatie-URLs. Het is een GitHub repo-pagina van het beheermodel, niet de hoofdspecificatie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
-  - *De bron vermeldt de NLGov REST API Design Rules als onderdeel van de API standaarden, maar noemt geen versienummer (v2.1.0) of publicatie-URL. Versie-metadata staat zelden in een beheermodel-README.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
-  - *De brontekst bevat geen informatie over ADR v2.1.0 of de hoofdspecificatie. De bron gaat uitsluitend over de geospatial module.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-geospatial](https://logius-standaarden.github.io/API-mod-geospatial)
-  - *De brontekst vermeldt de ADR hoofdspecificatie alleen als verwijzing in de tabel (normative, 'API Design Rules (ADR v2.0)'), maar bevat geen informatie over versie 2.1.0 of de bijbehorende publicatie-URL.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De brontekst is de README van de Transport Security module repository en bevat geen informatie over ADR v2.1.0 of de publicatie-URL.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-signing](https://github.com/logius-standaarden/API-mod-signing)
-  - *De bron vermeldt geen versienummers van de ADR hoofdspecificatie. Er wordt alleen gelinkt naar 'Formele standaard', 'Gepubliceerde versie' en 'Werkversie' zonder specifieke versienummers.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-signing](https://logius-standaarden.github.io/API-mod-signing)
-  - *De bron beschrijft de ADR Signing module (draft), niet de hoofdspecificatie ADR v2.1.0. Versienummers of publicatie-URLs van de hoofdspecificatie komen niet voor.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption)
-  - *De brontekst vermeldt de ADR hoofdspecificatie wel als link ('NLGov API Design Rules (ADR)') maar geeft geen versienummer of publicatiedatum. De claim over v2.1.0 kan niet worden bevestigd of ontkracht.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-encryption](https://logius-standaarden.github.io/API-mod-encryption)
-  - *De bron is de API-mod-encryption specificatie en bevat geen informatie over de ADR hoofdspecificatie of versienummers daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse)
-  - *De brontekst bevat geen informatie over ADR versies, publicaties of de URL gitdocumentatie.logius.nl. De repository gaat uitsluitend over een impactanalyse-tool voor de spectral linter.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api)
-  - *De brontekst bevat geen informatie over ADR v2.1.0 of publicatie-URLs. De bron gaat over een ReSpec template repository voor zaakgericht-werken-api.*
-</details>
+  - *De aangeleverde brontekst bevat geen inhoud van de specificatie. Alleen GitHub UI-tekst en bestandslijsten zijn zichtbaar.*
 
-### `ls-api-0009` — SKILL.md:44 *(§ Repositories)*
+### `ls-api-0044` — SKILL.md:137 *(§ Transport Security (TLS))*
 
-> Geospatial module v1.0.3 is vastgesteld en gepubliceerd op https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/.
+> De header `X-Frame-Options: DENY` is verplicht in alle API-responses.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Geospatial module
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — Transport Security verplichte headers
 
-**Erkend in conflicts.md** *(§ Details API-mod-geospatial)*: conflicts.md § 'Details API-mod-geospatial': 'De tag 1.0.2 bestaat op GitHub, maar de gepubliceerde versie op gitdocumentatie is 1.0.3. Er is geen tag 1.0.3 in de repository.' CONTRADICTED-verdict op GitHub Pages (draft toont 1.0.2) is gedocumenteerde discrepantie; gitdocumentatie.logius.nl is leidend.
+**Erkend in conflicts.md** *(§ Transport Security module: dubbelzinnige status)*: conflicts.md §'Transport Security module': repo is gearchiveerd, inhoud ingebed in ADR v2.1.0 sectie 3.8. NOT_FOUND in gearchiveerde repo is verwacht; verificatie loopt via ADR v2.1.0.
 
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > API Design Rules Module: Geospatial 1.0.3 Logius Guide Definitive version May 22, 2025 This version: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/
-- **CONTRADICTED** (medium) — [https://logius-standaarden.github.io/API-mod-geospatial](https://logius-standaarden.github.io/API-mod-geospatial)
-  > Previous version: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.1/
-  - *De bron noemt versie 1.0.1 als de vorige versie en het huidige document is een draft (geen vastgestelde versie). Versie 1.0.3 wordt nergens vermeld. De claim dat 1.0.3 vastgesteld is, wordt tegengesproken doordat de bron de huidige versie als draft aanduidt en de meest recente gepubliceerde versie 1.0.1 was. Echter: de bron vermeldt 1.0.3 expliciet niet, dus dit is ook deels NOT_FOUND; CONTRADICTED omdat de draft-status en de genoemde vorige versie 1.0.1 de claim van een vastgestelde 1.0.3 ondermijnen.*
-<details><summary>15x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron noemt de Geospatial module maar niet het specifieke versienummer 1.0.3 of de specifieke publicatie-URL.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Geospatial module v1.0.3 en de bijbehorende publicatie-URL worden niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
-  - *De brontekst bevat geen informatie over een Geospatial module of versie v1.0.3.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
-  - *De bron verwijst naar de Geospatial module via '[ADR-GEO] API Design Rules Module: Geospatial . ... March 07, 2024. URL: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/' maar noemt geen specifiek versienummer 1.0.3.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
-  - *De bron bevat geen informatie over de Geospatial module of versienummers daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
-  - *De bron noemt geen Geospatial module, geen versienummer v1.0.3 en geen publicatie-URL. De normatieve modules van het Kennisplatform API's worden wel kort aangehaald maar zonder detail.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
-  - *De bron vermeldt geen Geospatial module, versienummer v1.0.3 of de bijbehorende publicatie-URL.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
-  - *De brontekst vermeldt wel de publicatieversie-URL (https://gitdocumentatie.logius.nl/publicatie/api/mod-geo) en werkversie-URL, maar noemt geen specifiek versienummer zoals v1.0.3. Het versiebeheer of de vastgestelde versie wordt niet vermeld.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De brontekst bevat geen informatie over een Geospatial module.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-signing](https://github.com/logius-standaarden/API-mod-signing)
-  - *De bron behandelt de Signing module, niet de Geospatial module. Er is geen informatie over mod-geo v1.0.3.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-signing](https://logius-standaarden.github.io/API-mod-signing)
-  - *De bron noemt de GEO module v1.0 in de tabel van de Nederlandse API Strategie, maar geeft geen versienummer 1.0.3 of publicatie-URL voor die module.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption)
-  - *De brontekst bevat geen informatie over de Geospatial module of enig versienummer daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-encryption](https://logius-standaarden.github.io/API-mod-encryption)
-  - *De bron vermeldt in de abstracttabel wel 'GEO module v1.0' als onderdeel van de Nederlandse API Strategie, maar geeft geen informatie over versie 1.0.3 of de publicatie-URL daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse)
-  - *De brontekst bevat geen informatie over de Geospatial module of enige versie daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api)
-  - *De brontekst bevat geen informatie over een Geospatial module of versienummers daarvan.*
-</details>
+  - *De aangeleverde brontekst bevat geen inhoud van de specificatie. Alleen GitHub UI-tekst en bestandslijsten zijn zichtbaar.*
 
-## GROUNDED — minstens één bron ondersteunt de claim (31)
+## GROUNDED — minstens één bron ondersteunt de claim (20)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `ls-api-0001` — SKILL.md:26 *(§ API Design Rules (NL GOV))*
+### `ls-api-0001` — SKILL.md:24 *(§ API Design Rules (NL GOV))*
 
 > De API Design Rules zijn verplicht onder het 'pas-toe-of-leg-uit' regime van het Forum Standaardisatie.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules (ADR) — NL GOV
 
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  > Lijst status Verplicht ('Pas toe leg uit') [...] De standaard NLGov REST API Design Rules moet worden toegepast bij het aanbieden van REST API's ten behoeve van het ontsluiten van overheidsinformatie en/of functionaliteit.
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
   > This version of the design rules has been submitted to Forum Standaardisatie for inclusion on the Comply or Explain list of mandatory standards in the Dutch Public Sector.
-  - *De bron zegt dat de standaard is ingediend ('submitted') voor opname op de lijst, niet dat het al verplicht is onder het pas-toe-of-leg-uit regime. De claim stelt het als vaststaand feit.*
+  - *De bron zegt dat de standaard is 'ingediend voor opname' op de lijst, niet dat deze er al verplicht op staat. De claim stelt dat de ADR 'verplicht' is onder het pas-toe-of-leg-uit regime, maar de bron bevestigt alleen de indiening.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
   > De status van de ADR-standaard is 'Verplicht (pas toe leg uit)'. Dit houdt kort gezegd in dat Nederlandse overheden en instellingen uit de (semi) publieke sector verplicht zijn deze standaard toe te passen op het moment dat zij REST API's gaan gebruiken voor het ontsluiten van overheidsinformatie en/of functionaliteit.
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron gaat over de Geospatial module van de ADR en vermeldt niets over het 'pas-toe-of-leg-uit' regime van het Forum Standaardisatie.*
+- **NOT_FOUND** (low) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst vermeldt slechts de navigatiestructuur en paginatitels van de Forum Standaardisatie website, zonder een specifieke lijst van standaarden die onder het 'pas toe of leg uit'-regime vallen. De API Design Rules worden nergens expliciet genoemd. De tekst bevestigt wél dat er een 'pas toe of leg uit'-lijst bestaat, maar welke standaarden daarop staan is niet uit deze brontekst op te maken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron beschrijft de technische inhoud van de Geospatial Module (ADR mod-geo). Forum Standaardisatie en het 'pas-toe-of-leg-uit' regime worden niet behandeld.*
 
 ### `ls-api-0002` — SKILL.md:32 *(§ Versiemodel)*
 
-> De vastgestelde versie (DEF) van de ADR is gepubliceerd op `gitdocumentatie.logius.nl`.
+> De vastgestelde ADR-versie (DEF) wordt gepubliceerd op `gitdocumentatie.logius.nl`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — versiemodel
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — versiemodel
 
-- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > This version: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/ ... This is the definitive version of this document.
-  - *De bron bevestigt dat vastgestelde (definitieve) versies op gitdocumentatie.logius.nl worden gepubliceerd, maar specifiek voor de Geospatial module, niet de ADR-hoofdspecificatie. De claim is algemeen over de ADR.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
+  > This version: https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0/
+  - *De vastgestelde versie wordt gepubliceerd op gitdocumentatie.logius.nl, zoals de bron zelf laat zien.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
+  > Versie 1.0 van de ADR is gepubliceerd op: https://gitdocumentatie.logius.nl/publicatie/api/adr/1.0 De laatste versie van de ADR is gepubliceerd op: https://gitdocumentatie.logius.nl/publicatie/api/adr/
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  > This version: https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3/
+  - *De bron bevestigt dat de definitieve (vastgestelde) versie wordt gepubliceerd op gitdocumentatie.logius.nl, maar dan voor de Geospatial Module, niet voor de ADR zelf. De claim gaat over ADR in het algemeen.*
 
 ### `ls-api-0003` — SKILL.md:33 *(§ Versiemodel)*
 
-> De werkversie (draft) van de ADR is gepubliceerd op `logius-standaarden.github.io`.
+> De ADR werkversie (draft) wordt gepubliceerd op `logius-standaarden.github.io`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — versiemodel
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — versiemodel
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
   > Latest editor's draft: https://logius-standaarden.github.io/API-Design-Rules/
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
   > De laatste concept versie van de standard is gepubliceerd op: https://logius-standaarden.github.io/API-Design-Rules/
-- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
   > Latest editor's draft: https://logius-standaarden.github.io/API-mod-geospatial/
-  - *Bevestigd voor de Geospatial module; de claim is algemeen over de ADR-werkversie, maar het patroon klopt.*
+  - *De bron bevestigt dat de editor's draft op logius-standaarden.github.io staat, maar dit geldt voor de Geospatial Module, niet expliciet voor de ADR zelf.*
 
 ### `ls-api-0006` — SKILL.md:35 *(§ Versiemodel)*
 
-> Transport Security is in ADR v2.1.0 ingebed als sectie 3.8 met eigen regels (`/core/transport/*`).
+> De inhoud van Transport Security is in ADR v2.1.0 ingebed als sectie 3.8 met eigen regels (`/core/transport/*`).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR v2.1.0 — Transport Security
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Transport Security module
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > 3.8 Transport Security [...] technical /core/transport/tls [...] technical /core/transport/security-headers [...] technical /core/transport/cors
+  > 3.8 Transport Security ... technical /core/transport/tls ... technical /core/transport/security-headers ... technical /core/transport/cors
+  - *Sectie 3.8 met eigen /core/transport/* regels is duidelijk aanwezig in de bron.*
 
-### `ls-api-0007` — SKILL.md:45 *(§ Repositories)*
-
-> De API-mod-transport-security GitHub-repository is gearchiveerd.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Transport Security module
-
-- **SUPPORTED** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  > This repository was archived by the owner on Aug 29, 2025. It is now read-only.
-<details><summary>16x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron vermeldt niets over archivering van de API-mod-transport-security GitHub-repository.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron vermeldt de API-mod-transport-security repository of archivering daarvan niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron vermeldt de Transport Security module of de bijbehorende repository niet.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
-  - *De brontekst bevat geen informatie over een API-mod-transport-security repository of de archiefstatus ervan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
-  - *De brontekst vermeldt de Transport Security module als normatief onderdeel en verwijst naar een apart document, maar bevat geen informatie over de archiefstatus van de GitHub-repository.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
-  - *De bron gaat over het ADR-Beheermodel repository, niet over de API-mod-transport-security repository. Geen informatie over archivering van die specifieke repo.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
-  - *De brontekst is de README/overzichtspagina van het API-Standaarden-Beheermodel repository. Er wordt geen melding gemaakt van de API-mod-transport-security GitHub-repository of de archiefstatus ervan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
-  - *De bron vermeldt geen GitHub-repository voor een Transport Security module, noch informatie over archivering daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
-  - *De brontekst gaat over de API-mod-geospatial repository, niet over API-mod-transport-security. Geen informatie over archivering van transport-security repo.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-geospatial](https://logius-standaarden.github.io/API-mod-geospatial)
-  - *De brontekst gaat over de Geospatial module en vermeldt niets over een Transport Security module of de status van een bijbehorende GitHub-repository.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-signing](https://github.com/logius-standaarden/API-mod-signing)
-  - *De bron gaat over de API-mod-signing repository, niet over API-mod-transport-security. Er is geen informatie over archivering van transport-security.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-signing](https://logius-standaarden.github.io/API-mod-signing)
-  - *De bron gaat over de API-mod-signing specificatie en maakt geen melding van een transport-security repository of de archiveringsstatus daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption)
-  - *De brontekst gaat over de API-mod-encryption repository, niet over de API-mod-transport-security repository. Er is geen informatie over archivering van transport-security.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-encryption](https://logius-standaarden.github.io/API-mod-encryption)
-  - *De bron behandelt alleen de Encryption module (JWE). Er is geen informatie over de Transport Security module of de archiefstatus van een gerelateerde GitHub-repository.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse)
-  - *De brontekst gaat over de api-linter-impactanalyse repository en bevat geen informatie over de API-mod-transport-security GitHub-repository of de archiefstatus daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api)
-  - *De brontekst gaat over de zaakgericht-werken-api repository (een ReSpec template). Er is geen informatie over de API-mod-transport-security repository of archiveringsstatus daarvan.*
-</details>
-
-### `ls-api-0010` — SKILL.md:42 *(§ Repositories)*
-
-> ADR-Beheermodel v1.0 is gearchiveerd en vervangen door het API-Standaarden-Beheermodel.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — beheermodel
-
-- **SUPPORTED** (high) — [https://github.com/logius-standaarden/ADR-Beheermodel](https://github.com/logius-standaarden/ADR-Beheermodel)
-  > Dit beheermodel is verouderd en vervangen door het algemene API Standaarden beheermodel
-  - *De bron bevestigt expliciet dat het ADR-Beheermodel vervangen is door het API Standaarden beheermodel. De archivering wordt ook bevestigd: 'This repository was archived by the owner on Jul 15, 2025. It is now read-only.' De versieaanduiding 'v1.0' staat niet letterlijk in de brontekst, maar de releases sectie toont '1.0 (rerelease) Latest Jan 7, 2022', wat v1.0 ondersteunt.*
-- **PARTIALLY_SUPPORTED** (low) — [https://github.com/logius-standaarden/API-Standaarden-Beheermodel](https://github.com/logius-standaarden/API-Standaarden-Beheermodel)
-  > "Generiek beheermodel voor de verzameling van API standaarden" en "Generated from Logius-standaarden/Logius-Beheermodel"
-  - *De bron bevestigt dat het API-Standaarden-Beheermodel bestaat als opvolger/generiek kader, gegenereerd vanuit het Logius-Beheermodel. Dat impliceert dat er een voorganger was, maar de bron benoemt het ADR-Beheermodel v1.0 noch de archiefstatus ervan expliciet. PARTIALLY_SUPPORTED omdat de vervanging indirect blijkt maar de archiefstatus en versieaanduiding ontbreken.*
-- **SUPPORTED** (high) — [https://logius-standaarden.github.io/API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel)
-  > Met het indienen van versie 2.0 van de ADR standaard zijn tevens de beheermodelen van ADR en OAuth (die hadden een apart beheermodel) samengevoegd met dit beheermodel. Ook deze samenvoeging is goedgekeurd en de kopieën zijn daarom nu gearchiveerd.
-  - *De bron bevestigt expliciet dat het aparte ADR-beheermodel is samengevoegd met het API-Standaarden-Beheermodel en gearchiveerd. De claim over 'v1.0' als specifiek versienummer wordt niet vermeld, maar dat is een klein detail dat de kern van de claim niet weerspreekt.*
-<details><summary>14x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  - *De bron vermeldt niets over het ADR-Beheermodel v1.0 of archivering ervan.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron is het beheermodel zelf en vermeldt niets over archivering of vervanging ervan door een API-Standaarden-Beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron vermeldt het ADR-Beheermodel of het API-Standaarden-Beheermodel niet.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-Design-Rules](https://github.com/logius-standaarden/API-Design-Rules)
-  - *De brontekst vermeldt wel een beheermodel-URL (https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/) maar zegt niets over archiefstatus van ADR-Beheermodel v1.0 of vervanging door een API-Standaarden-Beheermodel.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-Design-Rules](https://logius-standaarden.github.io/API-Design-Rules)
-  - *De bron vermeldt dat het beheermodel van de standaard wordt beschreven door 'het API-Standaarden beheermodel gepubliceerd door Logius', maar bevat geen informatie over archivering van een ADR-Beheermodel v1.0 of vervanging ervan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-geospatial](https://github.com/logius-standaarden/API-mod-geospatial)
-  - *De brontekst bevat geen informatie over het ADR-Beheermodel of het API-Standaarden-Beheermodel.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-geospatial](https://logius-standaarden.github.io/API-mod-geospatial)
-  - *De brontekst bevat geen informatie over het ADR-Beheermodel of een vervangend API-Standaarden-Beheermodel.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-transport-security](https://github.com/logius-standaarden/API-mod-transport-security)
-  - *De brontekst bevat geen informatie over het ADR-Beheermodel.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-signing](https://github.com/logius-standaarden/API-mod-signing)
-  - *De bron vermeldt wel het beheermodel via de URL https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/, maar geeft geen informatie over archivering van ADR-Beheermodel v1.0 of vervanging door een API-Standaarden-Beheermodel.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-signing](https://logius-standaarden.github.io/API-mod-signing)
-  - *Het ADR-Beheermodel of de archiveringsstatus daarvan wordt in deze bron niet besproken.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/API-mod-encryption](https://github.com/logius-standaarden/API-mod-encryption)
-  - *De brontekst verwijst naar het beheermodel via een URL ('https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/') maar zegt niets over archivering van ADR-Beheermodel v1.0 of een opvolger.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/API-mod-encryption](https://logius-standaarden.github.io/API-mod-encryption)
-  - *De bron bevat geen informatie over het ADR-Beheermodel of een opvolger daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/api-linter-impactanalyse](https://github.com/logius-standaarden/api-linter-impactanalyse)
-  - *De brontekst bevat geen informatie over het ADR-Beheermodel of het API-Standaarden-Beheermodel.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/zaakgericht-werken-api](https://github.com/logius-standaarden/zaakgericht-werken-api)
-  - *De brontekst bevat geen informatie over het ADR-Beheermodel of een API-Standaarden-Beheermodel.*
-</details>
-
-### `ls-api-0013` — SKILL.md:57 *(§ URI-ontwerp)*
+### `ls-api-0014` — SKILL.md:57 *(§ URI-ontwerp)*
 
 > URIs mogen geen trailing slashes bevatten: `/api/v1/users` (niet `/api/v1/users/`).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — URI-ontwerp
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** API Design Rules — URI-ontwerp
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > technical /core/no-trailing-slash : Leave off trailing slashes from URIs — A URI MUST never contain a trailing slash. When requesting a resource including a trailing slash, this MUST result in a 404 (not found) error response and not a redirect.
+  > A URI MUST never contain a trailing slash. When requesting a resource including a trailing slash, this MUST result in a 404 (not found) error response and not a redirect.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen regels over trailing slashes in URIs.*
+  - *Trailing slashes in URIs worden niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over trailing slashes in URIs.*
+  - *Trailing slashes in URIs worden niet behandeld in deze bron.*
 
-### `ls-api-0015` — SKILL.md:59 *(§ URI-ontwerp)*
-
-> De major versie MOET in de URI staan (`/v1/resources`); in de OAS moet dit op serverniveau worden gespecificeerd, niet in individuele paden.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — URI-ontwerp en versiebeheer
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > technical /core/uri-version : Include the major version number in the URI — The URI of an API (base path) MUST include the major version number, prefixed by the letter v [...] An example of an openapi.yaml for an API with a base path https://api.example.org/v1 [...] servers: - description: test environment url: https://api.test.example.org/v1
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen technische regels over versiebeheer in URIs of OAS-serverniveau specificatie.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over het opnemen van de major versie in de URI of OAS-configuratie op serverniveau.*
-
-### `ls-api-0016` — SKILL.md:60 *(§ URI-ontwerp)*
+### `ls-api-0017` — SKILL.md:60 *(§ URI-ontwerp)*
 
 > Operaties als sub-resources: het laatste padsegment mag starten met `_` (bijv. `/_search`).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** ADR — URI-ontwerp
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** API Design Rules — URI-ontwerp
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > In exceptional cases [...] Use the imperative mood of a verb, maybe even prefix it with a underscore to distinguish these resources from regular resources. For example: /search or /_search .
+  > Use the imperative mood of a verb, maybe even prefix it with a underscore to distinguish these resources from regular resources. For example: /search or /_search.
 - **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > In case of a global query /api/v1/_search , results should be placed in the relevant geometric context
-  - *De bron gebruikt het patroon `/_search` als voorbeeld en de bijbehorende regel /geo/geometric-context, wat consistent is met de claim dat het laatste padsegment mag starten met `_`.*
+  > /geo/geometric-context : Place results of a global spatial query in the relevant geometric context In case of a global query /api/v1/_search
+  - *De bron gebruikt het patroon `_search` als voorbeeld van een sub-resource met underscore-prefix, wat de claim ondersteunt. De regel zelf is echter niet expliciet als MAY geformuleerd.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen regels over operaties als sub-resources of het gebruik van `_` als prefix.*
+  - *Sub-resources met underscore-prefix worden niet behandeld in dit beheermodel.*
 
-### `ls-api-0017` — SKILL.md:61 *(§ URI-ontwerp)*
+### `ls-api-0018` — SKILL.md:61 *(§ URI-ontwerp)*
 
-> Gevoelige informatie MAG NIET in URIs worden opgenomen omdat URIs niet door TLS beschermd zijn.
+> Gevoelige informatie MAG NIET in URIs worden opgenomen (niet beschermd door TLS).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — URI-ontwerp
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** API Design Rules — URI-ontwerp
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > functional /core/transport/no-sensitive-uris : No sensitive information in URIs — Even when using TLS connections, information in URIs is not secured. URIs can be cached and logged outside of the servers controlled by clients and servers. [...] MUST NOT contain any sensitive information.
+  > Do not put any sensitive information in URIs ... URIs can be cached and logged outside of the servers controlled by clients and servers ... MUST NOT contain any sensitive information. This includes client secrets used for authentication, privacy sensitive information suchs as BSNs
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen regels over gevoelige informatie in URIs en TLS-bescherming.*
+  - *Gevoelige informatie in URIs wordt niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over het opnemen van gevoelige informatie in URIs of TLS-bescherming.*
+  - *Gevoelige informatie in URIs wordt niet behandeld in deze bron.*
 
-### `ls-api-0018` — SKILL.md:67 *(§ HTTP-methoden)*
+### `ls-api-0019` — SKILL.md:67 *(§ HTTP-methoden)*
 
-> De GET-methode is veilig en idempotent en mag de resource nooit wijzigen.
+> De HTTP GET-methode is veilig en idempotent en mag een resource NOOIT wijzigen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — HTTP-methoden
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** API Design Rules — HTTP-methoden
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > Method Safe Idempotent GET Yes Yes [...] Request methods are considered safe if their defined semantics are essentially read-only; i.e., the client does not request, and does not expect, any state change on the origin server as a result of applying a safe method to a target resource.
+  > Method Safe Idempotent GET Yes Yes ... GET Read Retrieve a resource representation for the given URI. Data is only retrieved and never modified.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen technische regels over HTTP-methoden zoals GET.*
+  - *HTTP GET-methode en veiligheid/idempotentie worden niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen expliciete regels over de veiligheid of idempotentie van de GET-methode.*
+  - *HTTP GET veiligheid en idempotentie worden niet behandeld in deze bron.*
 
-### `ls-api-0019` — SKILL.md:69 *(§ HTTP-methoden)*
+### `ls-api-0020` — SKILL.md:76 *(§ Versiebeheer)*
 
-> De PUT-methode is idempotent en wordt gebruikt voor het aanmaken of volledig vervangen van een resource.
+> De volledige versie MOET worden opgenomen in de `API-Version` response header: bijv. `1.2.3`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — HTTP-methoden
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — versiebeheer
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > PUT Create/update Create a resource with the given URI or replace (full update) a resource when the resource already exists. [...] Method Safe Idempotent [...] PUT No Yes
+  > The version number MUST be returned in an HTTP response header named API-Version (case-insensitive) and SHOULD not be prefixed. An example of an API version response header: API-Version: 1.0.2
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen technische regels over de PUT-methode.*
+  - *API-Version response header wordt niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over de PUT-methode.*
+  - *De API-Version response header wordt niet behandeld in deze bron.*
 
-### `ls-api-0020` — SKILL.md:75 *(§ Versiebeheer)*
+### `ls-api-0021` — SKILL.md:77 *(§ Versiebeheer)*
 
-> De major versie MOET in het URI-pad staan: `/v1`, `/v2`.
+> Semantic versioning (major.minor.patch) MOET worden gebruikt in `info.version` van de OpenAPI spec.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — versiebeheer
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > technical /core/uri-version : Include the major version number in the URI — The URI of an API (base path) MUST include the major version number, prefixed by the letter v .
+  > Version numbering MUST follow the Semantic Versioning [SemVer] model to prevent breaking changes when releasing new API versions. Release versions are formatted using the major.minor.patch template
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen technische versiebeheerregels over major versie in het URI-pad.*
+  - *Semantic versioning in info.version van OpenAPI spec wordt niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen expliciete regel dat de major versie in het URI-pad moet staan.*
+  - *Semantic versioning in info.version van OpenAPI wordt niet behandeld.*
 
-### `ls-api-0021` — SKILL.md:76 *(§ Versiebeheer)*
+### `ls-api-0022` — SKILL.md:78 *(§ Versiebeheer)*
 
-> De volledige versie MOET in de `API-Version` response header worden opgenomen: `1.2.3`.
+> Bij major version changes MOET een deprecation schedule worden gepubliceerd.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — versiebeheer
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > technical /core/version-header : Return the full version number in a response header — The version number MUST be returned in an HTTP response header named API-Version (case-insensitive) [...] An example of an API version response header: API-Version: 1.0.2
+  > When deprecating features or versions, a deprecation schedule MUST be published.
+  - *De bron stelt dit breder dan alleen bij major version changes (ook bij het deprecaten van features), maar de kern van de claim wordt ondersteund.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron vermeldt de `API-Version` response header niet.*
+  - *Deprecation schedules bij major version changes worden niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over de `API-Version` response header.*
+  - *Deprecation schedule bij major version changes wordt niet behandeld.*
 
-### `ls-api-0022` — SKILL.md:77 *(§ Versiebeheer)*
-
-> Semantic versioning (major.minor.patch) MOET worden gebruikt in `info.version`.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > technical /core/semver : Adhere to the Semantic Versioning model when releasing API changes — Version numbering MUST follow the Semantic Versioning [SemVer] model [...] Release versions are formatted using the major.minor.patch template
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron vermeldt semantic versioning in `info.version` niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over semantic versioning of `info.version`.*
-
-### `ls-api-0024` — SKILL.md:79 *(§ Versiebeheer)*
-
-> Er MOET een vaste transitieperiode tussen major versies worden gehanteerd.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — versiebeheer
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > functional /core/transition-period : Schedule a fixed transition period for a new major API version — When releasing a new major API version, the old version MUST remain available for a limited and fixed deprecation period.
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen regels over een transitieperiode tussen major versies.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over transitieperiodes tussen major versies.*
-
-### `ls-api-0026` — SKILL.md:95 *(§ Foutafhandeling)*
+### `ls-api-0024` — SKILL.md:95 *(§ Foutafhandeling)*
 
 > Foutmeldingen MOGEN GEEN technische details bevatten zoals stack traces of interne hints.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** ADR — foutafhandeling
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** API Design Rules — foutafhandeling
 
 - **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > In case of an error, the server SHOULD NOT pass technical details (e.g. call stacks or other internal hints) to the client. The error message SHOULD be generic to avoid revealing additional details and expose internal information which can be used with malicious intent.
-  - *De bron gebruikt SHOULD NOT, niet MUST NOT. De claim gebruikt MOGEN NIET (MUST NOT). Dit is een potentieel verschil in normatieve sterkte, maar de strekking is gelijk en de bron ondersteunt de claim in de geest.*
+  > In case of an error, the server SHOULD NOT pass technical details (e.g. call stacks or other internal hints) to the client. The error message SHOULD be generic to avoid revealing additional details
+  - *De bron gebruikt SHOULD NOT, niet MUST NOT. De claim gebruikt MOGEN GEEN (MUST NOT). Dit is een subtiel verschil in modaliteit maar de strekking is gelijk.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De bron bevat geen regels over de inhoud van foutmeldingen of het weglaten van technische details.*
+  - *Inhoudelijke regels over foutmeldingen en stack traces worden niet behandeld in dit beheermodel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron bevat geen regels over foutmeldingen of het uitsluiten van technische details daarin.*
+  - *Foutmeldingen en het vermijden van technische details worden niet behandeld.*
 
-### `ls-api-0027` — SKILL.md:99 *(§ Datum en tijd)*
+### `ls-api-0030` — SKILL.md:107 *(§ Naamgeving)*
 
-> Datum/tijd waarden MOETEN RFC 3339 formaat gebruiken.
+> Resources MOETEN als zelfstandige naamwoorden worden benoemd, niet als werkwoorden.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — datum en tijd
-
-- **SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
-  > The following profile of ISO 8601 [ISO8601] dates SHOULD be used in new protocols on the Internet. [...] date-time = full-date "T" full-time
-  - *RFC 3339 definieert het formaat dat de claim beschrijft. De bron zegt echter SHOULD (aanbevolen) voor gebruik in nieuwe protocollen, niet MUST. De claim stelt MOETEN (MUST). De bron definieert het RFC 3339 formaat zelf volledig, maar legt het gebruik als SHOULD op, niet MUST. Toch is de claim dat datum/tijd waarden RFC 3339 formaat MOETEN gebruiken plausibel als een API-standaard RFC 3339 als verplicht aanwijst — de bron bevestigt het formaat zelf volledig. Omdat de claim gaat over een ADR-regel die RFC 3339 verplicht stelt (niet over RFC 3339 zelf die dat verplicht stelt), en de bron het formaat volledig beschrijft, is SUPPORTED hier de juiste keuze: de bron definieert het formaat waaraan voldaan moet worden.*
-
-### `ls-api-0032` — SKILL.md:107 *(§ Naamgeving)*
-
-> Resources MOETEN als zelfstandige naamwoorden worden benoemd (niet werkwoorden).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — naamgeving
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — naamgeving
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > Resources are referred to using nouns (instead of verbs) that represent entities meaningful to the API consumer.
+  > Resources are referred to using nouns (instead of verbs) that represent entities meaningful to the API consumer. [...] This is different than RPC-style APIs, where verbs are often used to perform certain actions
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Naamgevingsregels voor resources zijn geen onderdeel van dit beheermodel.*
+  - *De brontekst beschrijft het beheermodel, niet de inhoudelijke naamgevingsregels van de ADR.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Naamgevingsregels voor resources (zelfstandige naamwoorden vs. werkwoorden) komen niet voor in deze bron.*
+  - *Naamgeving van resources als zelfstandige naamwoorden wordt niet behandeld.*
 
-### `ls-api-0037` — SKILL.md:115 *(§ OpenAPI Documentatie)*
+### `ls-api-0034` — SKILL.md:115 *(§ OpenAPI Documentatie)*
 
-> Een OpenAPI 3.0+ specificatie is VERPLICHT.
+> Een OpenAPI 3.0+ specificatie is verplicht.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — OpenAPI documentatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — OpenAPI documentatie
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
   > API documentation MUST be provided in the form of an OpenAPI definition document which conforms to the OpenAPI Specification (from v3 onwards).
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De verplichting van een OpenAPI 3.0+ specificatie staat niet in dit beheermodel.*
+  - *De brontekst beschrijft het beheermodel, niet de inhoudelijke vereisten van de ADR.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *OpenAPI 3.0+ verplichting wordt niet behandeld in deze Geospatial module bron.*
+  - *De verplichting van een OpenAPI 3.0+ specificatie wordt niet behandeld in deze bron.*
 
-### `ls-api-0038` — SKILL.md:116 *(§ OpenAPI Documentatie)*
+### `ls-api-0035` — SKILL.md:116 *(§ OpenAPI Documentatie)*
 
-> De OpenAPI JSON-spec MOET gepubliceerd worden op standaardlocatie `/openapi.json` (VERPLICHT); YAML op `/openapi.yaml` is OPTIONEEL.
+> De OpenAPI spec in JSON MOET op de standaardlocatie `/openapi.json` worden gepubliceerd (VERPLICHT); YAML (`/openapi.yaml`) is OPTIONEEL.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — OpenAPI documentatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — OpenAPI documentatie
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > The standard location for the OAS document is a URI called openapi.json or openapi.yaml within the base path of the API. [...] At least the JSON format MUST be supported. [...] the same OAS document MAY be provided in YAML format: https://api.example.org/v1/openapi.yaml
+  > The standard location for the OAS document is a URI called openapi.json or openapi.yaml within the base path of the API. [...] At least the JSON format MUST be supported. [...] Optionally, the same OAS document MAY be provided in YAML format
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Publicatielocaties voor OpenAPI-specificaties worden niet beschreven in dit beheermodel.*
+  - *De brontekst beschrijft het beheermodel, niet de inhoudelijke vereisten over OpenAPI-locaties.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Publicatielocatie van OpenAPI specificatie wordt niet behandeld in deze bron.*
+  - *De bron gaat over de Geospatial module. Niets over OpenAPI spec locaties (/openapi.json, /openapi.yaml) staat in deze bron.*
 
-### `ls-api-0039` — SKILL.md:117 *(§ OpenAPI Documentatie)*
+### `ls-api-0037` — SKILL.md:117 *(§ OpenAPI Documentatie)*
 
-> Contactinformatie (`info.contact` met `name`, `email`, `url`) wordt sterk aanbevolen voor publieke APIs (ADR `/core/doc-openapi-contact`: SHOULD).
+> De Spectral linter dwingt contactvelden af als error voor publieke APIs.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** ADR — OpenAPI documentatie, publieke APIs
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Spectral linter
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > OpenAPI definition document SHOULD include the info.contact object for publicly available APIs. Contact information SHOULD NOT be a generic contact address for the whole organisation. [...] { "name": "Gebouwen API beheerder", "url": "...", "email": "teamgebouwen@ministerie.nl" }
+  > info-contact: error [...] info-contact-fields-exist: severity: error given: - "$.info.contact" then: function: schema functionOptions: schema: required: - email - name - url message: "Missing fields in `info.contact` field. Must specify email, name and url."
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Aanbevelingen voor contactinformatie in OpenAPI-specs worden niet behandeld in dit beheermodel.*
+  - *De brontekst bevat geen informatie over Spectral linter gedrag of error-niveaus.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Contactinformatie in OpenAPI (info.contact) wordt niet behandeld in deze bron.*
+  - *De bron bevat geen informatie over Spectral linter regels of contactvelden.*
 
-### `ls-api-0040` — SKILL.md:117 *(§ OpenAPI Documentatie)*
+### `ls-api-0038` — SKILL.md:118 *(§ OpenAPI Documentatie)*
 
-> De Spectral linter dwingt contactinformatie-velden af als error voor publieke APIs.
+> CORS MOET worden ondersteund voor documentatie-toegang.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter, OpenAPI documentatie
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > #/core/doc-openapi-contact # This rule exists in the base oas spectral linter set info-contact: error info-contact-fields-exist: severity: error given: - "$.info.contact" then: function: schema functionOptions: schema: required: - email - name - url
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Spectral linter-gedrag voor contactinformatie wordt niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Spectral linter afdwinging van contactinformatie-velden wordt niet behandeld in deze bron.*
-
-### `ls-api-0041` — SKILL.md:118 *(§ OpenAPI Documentatie)*
-
-> CORS MOET ondersteund worden voor documentatie-toegang.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ADR — OpenAPI documentatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** API Design Rules — OpenAPI documentatie
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
   > Clients (such as Swagger UI or ReDoc) MUST be able to retrieve the document without having to authenticate. Furthermore, the CORS policy for this URI MUST allow external domains to read the documentation from a browser environment.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *CORS-vereisten worden niet behandeld in dit beheermodel.*
+  - *De brontekst beschrijft het beheermodel, niet de inhoudelijke CORS-vereisten.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *CORS-vereisten voor documentatietoegang worden niet behandeld in deze bron.*
+  - *CORS wordt niet behandeld in deze Geospatial module bron.*
 
-### `ls-api-0051` — SKILL.md:142 *(§ Geospatial Module (v1.0.3 — vastgesteld))*
-
-> De Geospatial module regelt GeoJSON encodering, bounding box filtering en coördinaatsystemen (CRS).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Geospatial module
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  > The Geospatial Module provides rules for the structuring of geospatial payloads and for functions in APIs to handle geospatial data. [...] how to encode geometries in APIs how to supply a spatial filter in the call (request) how to return results of a spatial search
-  - *De bron bevestigt dat de Geospatial module GeoJSON encodering, bounding box filtering (bbox query parameter) en coördinaatsystemen (CRS, heel hoofdstuk 3) regelt.*
-
-### `ls-api-0059` — SKILL.md:241 *(§ Spectral Linter)*
+### `ls-api-0051` — SKILL.md:241 *(§ Spectral Linter)*
 
 > De publieke DON-hosted ruleset is beschikbaar op `https://static.developer.overheid.nl/adr/ruleset.yaml`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Spectral linter
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
   > curl -L https://static.developer.overheid.nl/adr/ruleset.yaml > .spectral.yml
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De URL van de DON-hosted Spectral ruleset wordt niet vermeld in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De DON-hosted Spectral ruleset URL wordt niet vermeld in deze bron.*
+  - *De brontekst beschrijft het beheermodel voor de ADR. De URL van de DON-hosted ruleset wordt niet vermeld.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen verwijzing naar static.developer.overheid.nl of Spectral rulesets.*
 
-### `ls-api-0060` — SKILL.md:257 *(§ Spectral Linter)*
+### `ls-api-0052` — SKILL.md:257 *(§ Spectral Linter)*
 
-> Spectral regel `include-major-version-in-uri` / `nlgov:include-major-version-in-uri` controleert de aanwezigheid van de major versie in de server URL.
+> Spectral regel `include-major-version-in-uri` / `nlgov:include-major-version-in-uri` controleert of de major versie in het URI-pad aanwezig is.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter, URI-ontwerp
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > #/core/uri-version include-major-version-in-uri: severity: error given: - "$.servers[*]" then: function: pattern functionOptions: match: "\/v[\d+]" field: url message: "/core/uri-version: Include the major version number in the URI"
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Specifieke Spectral-regelnamen worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Spectral regel include-major-version-in-uri wordt niet behandeld in deze bron.*
-
-### `ls-api-0061` — SKILL.md:258 *(§ Spectral Linter)*
-
-> Spectral regel `paths-no-trailing-slash` / `nlgov:paths-no-trailing-slash` controleert dat paden geen trailing slashes hebben.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Spectral linter regels
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > #/core/no-trailing-slash paths-no-trailing-slash: severity: error given: - "$.paths" then: function: pattern functionOptions: notMatch: ".+ \/$" field: "@key" message: "/core/no-trailing-slash: Leave off trailing slashes from URIs"
+  > include-major-version-in-uri: severity: error given: - "$.servers[*]" then: function: pattern functionOptions: match: "\/v[\d+]" field: url message: "/core/uri-version: Include the major version number in the URI"
+  - *De claim noemt ook `nlgov:include-major-version-in-uri` als alternatieve naam; de bron gebruikt alleen `include-major-version-in-uri`. Het bestaan van de regel wordt bevestigd.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Specifieke Spectral-regelnamen worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Spectral regel paths-no-trailing-slash wordt niet behandeld in deze bron.*
+  - *De brontekst beschrijft het beheermodel voor de ADR. Specifieke Spectral regelnames worden niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron behandelt geen Spectral linter regels over URI versioning.*
 
-### `ls-api-0062` — SKILL.md:259 *(§ Spectral Linter)*
+### `ls-api-0053` — SKILL.md:262 *(§ Spectral Linter)*
 
-> Spectral regel `paths-kebab-case` / `nlgov:paths-kebab-case` controleert dat padsegmenten kebab-case gebruiken.
+> Spectral regel `use-problem-schema` / `nlgov:use-problem-schema` controleert gebruik van problem+json voor foutresponses.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules — Spectral linter regels
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > paths-kebab-case: severity: warn message: " {{property}} is not kebab-case." given: $.paths[?(@property && !@property.match(/ \/openapi\.json/))]~
+  > use-problem-schema: severity: warn message: "The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457." given: $..[responses][?(@property && @property.match(/(4|5)\d\d/))].content
+  - *De claim noemt ook `nlgov:use-problem-schema`; de bron gebruikt alleen `use-problem-schema`. De kern van de claim wordt bevestigd.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Specifieke Spectral-regelnamen worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *Spectral regel paths-kebab-case wordt niet behandeld in deze bron.*
-
-### `ls-api-0063` — SKILL.md:261 *(§ Spectral Linter)*
-
-> Spectral regel `missing-version-header` / `nlgov:missing-version-header` controleert de aanwezigheid van de version header in 2xx/3xx responses.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > #/core/version-header missing-version-header: severity: error given: $..[responses][?(@property && @property.match(/(2|3)\d\d/))][headers] then: function: or functionOptions: properties: - API-Version - Api-Version - Api-version - api-version - API-version message: "Return the full version number in a response header"
-  - *De regel heet `missing-version-header` (zonder `nlgov:`-prefix) en controleert 2xx/3xx responses op aanwezigheid van de version header.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *Specifieke Spectral-regelnamen worden niet beschreven in dit beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van Spectral linter regels of `missing-version-header` in de brontekst.*
-
-### `ls-api-0064` — SKILL.md:262 *(§ Spectral Linter)*
-
-> Spectral regel `use-problem-schema` / `nlgov:use-problem-schema` controleert het gebruik van problem+json voor foutresponses.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ADR — Spectral linter
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0)
-  > use-problem-schema: severity: warn message: "The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457." given: $..[responses][?(@property && @property.match(/(4|5)\d\d/))].content then: function: schema functionOptions: schema: anyOf: - required: [ "application/problem+json" ] - required: [ "application/problem+xml" ]
-  - *De regel heet `use-problem-schema` (zonder `nlgov:`-prefix) in de gepubliceerde versie.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0](https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/1.0)
-  - *De brontekst gaat over het beheermodel van de ADR-standaard. Er is geen vermelding van Spectral, linters, of specifieke regels zoals `use-problem-schema`.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
-  - *De bron beschrijft de API Design Rules Module Geospatial. Er is geen vermelding van Spectral linter regels of `use-problem-schema` in de brontekst.*
+  - *De brontekst beschrijft het beheermodel voor de ADR. Specifieke Spectral regelnames worden niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.3)
+  - *De bron bevat geen Spectral regels over problem+json foutresponses.*
 
 </details>

--- a/skills/ls-bomos/audit.md
+++ b/skills/ls-bomos/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-bomos — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,326 +7,106 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 20 | 56% |
-| CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 3 | 8% |
-| UNGROUNDED | 10 | 28% |
+| UNSUPPORTED_ASSERTION | 3 | 9% |
+| CONTRADICTED | 1 | 3% |
+| PARTIALLY_GROUNDED | 13 | 37% |
+| UNGROUNDED | 0 | 0% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
-| KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 3 | 8% |
+| KNOWN_DISCREPANCY | 1 | 3% |
+| GROUNDED | 17 | 49% |
 
-*Geverifieerd met sonnet, 20 calls, $1.3351.*
+*Geverifieerd met sonnet, 20 calls, $1.9940.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (20)
-
-### `ls-bomos-0001` — SKILL.md:32 *(§ Versiemodel)*
-
-> BOMOS staat niet op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS - Beheer- en Ontwikkelmodel voor Open Standaarden
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v3.0.2') en geen inhoudelijke tekst over BOMOS of de pas-toe-of-leg-uit-lijst.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v3.1.0') en geen inhoudelijke tekst. Niet te verifiëren.*
-
-### `ls-bomos-0002` — SKILL.md:32 *(§ Versiemodel)*
-
-> BOMOS is een raamwerk voor het beheren van open standaarden, geen interoperabiliteitsstandaard.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS - Beheer- en Ontwikkelmodel voor Open Standaarden
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0003` — SKILL.md:27 *(§ Versiemodel)*
-
-> BOMOS kent twee publicatiekanalen: een vastgestelde versie (DEF) op gitdocumentatie.logius.nl en een werkversie (draft) op logius-standaarden.github.io.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS versiemodel
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0009` — SKILL.md:58 *(§ Wijzigingsbeheer Workflow)*
-
-> De RFC-procedure (Request for Change) is het kernproces voor wijzigingsbeheer in BOMOS.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS wijzigingsbeheer
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (3)
 
 ### `ls-bomos-0010` — SKILL.md:80 *(§ Wijzigingsbeheer Workflow)*
 
-> Het RFC-proces verloopt via de stappen: RFC indienen → Community review → Expert beoordeling → Autorisator besluit → Implementatie → Publicatie nieuwe versie.
+> Het RFC-proces binnen BOMOS verloopt via de stappen: RFC indienen → Community review → Expert beoordeling → Autorisator besluit → Implementatie → Publicatie nieuwe versie.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS RFC-procedure
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De specifieke RFC-processtappen zoals beschreven in de claim worden nergens in de bron vermeld.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De bron beschrijft stappen in het wijzigingsproces (verzamelen wensen, voorbereiden veranderingsvoorstellen, beoordeling en besluitvorming) maar niet in de exacte volgorde of terminologie zoals in de claim: 'RFC indienen → Community review → Expert beoordeling → Autorisator besluit → Implementatie → Publicatie nieuwe versie'.*
 
-### `ls-bomos-0013` — reference.md:7 *(§ Het BOMOS Activiteitenmodel)*
+### `ls-bomos-0031` — reference.md:107 *(§ Pressure Cooker Model)*
 
-> Het BOMOS activiteitenmodel beschrijft vijf hoofdlagen: Strategie, Tactiek, Operationeel, Implementatieondersteuning en Communicatie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS activiteitenmodel
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0014` — reference.md:13 *(§ 1. Strategie)*
-
-> De strategielaag van BOMOS bevat drie activiteiten: Governance, Visie en Financiering. De verantwoordelijke rollen zijn Eigenaar en Financier.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS strategielaag
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0015` — reference.md:23 *(§ 2. Tactiek)*
-
-> De tactieklaag van BOMOS bevat zeven activiteiten: Architectuur, Specificatiebeheer, Wijzigingsbeheer, Adoptiestrategie, Kwaliteitsbeleid, Rechtenmanagement en Community. De verantwoordelijke rol is Autorisator.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS tactieklaag
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0016` — reference.md:37 *(§ 3. Operationeel)*
-
-> De operationele laag van BOMOS bevat zes activiteiten: Initiatie, Wensen en eisen verzamelen, Ontwikkeling, Uitvoering, Documentatie en Klachtenafhandeling. De verantwoordelijke rollen zijn Functioneel Beheerder en Technisch Beheerder.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS operationele laag
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0017` — reference.md:50 *(§ 4. Implementatieondersteuning)*
-
-> De implementatieondersteuningslaag van BOMOS bevat vijf activiteiten: Helpdesk, Opleidingen, Open source modules, Pilots en Validatie en certificatie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS implementatieondersteuning
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0023` — reference.md:60 *(§ 5. Communicatie)*
-
-> De communicatielaag van BOMOS bevat twee activiteiten: Promotie en Publicatie. De verantwoordelijke rol is Distributeur.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS communicatielaag
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0024` — reference.md:67 *(§ Rollen en Verantwoordelijkheden)*
-
-> BOMOS definieert acht rollen: Eigenaar, Financier, Autorisator, Functioneel Beheerder, Technisch Beheerder, Distributeur, Expert en Gebruiker.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS rollenmodel
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0025` — reference.md:80 *(§ Rollen en Verantwoordelijkheden)*
-
-> Een persoon kan meerdere BOMOS-rollen vervullen, en een rol kan door meerdere personen worden ingevuld.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS rollenmodel
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0026` — reference.md:86 *(§ Levensfasen van een Standaard)*
-
-> BOMOS onderscheidt vijf levensfasen van een standaard: Creatie/Ontwikkeling, Introductie, Implementatie/Groei, Volwassenheid en Uitfasering.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS levensfasen
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0030` — reference.md:107 *(§ Pressure Cooker Model)*
-
-> Het BOMOS Pressure Cooker Model heeft een totale doorlooptijd van circa 2 maanden van initiatie tot governance.
+> Het Pressure Cooker Model is geschikt voor standaarden waar urgentie en breed draagvlak samenkomen.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Pressure Cooker Model
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron vermeldt de pressure cooker alleen als een methode om 'sneller en goedkoper standaarden te ontwikkelen', maar zegt niets over toepassingscriteria zoals urgentie en breed draagvlak.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De bron beschrijft het pressure cooker model als efficiënt middel, maar koppelt het niet expliciet aan 'urgentie en breed draagvlak' als voorwaarden voor geschiktheid. De kwaliteit wordt gerelateerd aan de werkgroepleden, niet aan urgentie/draagvlak als vereiste combinatie.*
 
-### `ls-bomos-0032` — reference.md:101 *(§ Pressure Cooker Model)*
+### `ls-bomos-0034` — reference.md:121 *(§ Linked Data Module)*
 
-> Het Pressure Cooker Model bestaat uit vier stappen: intensieve workshop (1 week), expert-verfijning (2 weken), community review (2 weken), en afronding en governance.
+> De BOMOS Linked Data module behandelt URI-strategie, versiebeheer van ontologieën, en publicatie als Linked Data.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Pressure Cooker Model
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0033` — reference.md:113 *(§ Geonovum)*
-
-> Geonovum ontving in 2014 het predicaat 'uitstekend beheer' voor de manier waarop zij hun standaarden conform BOMOS beheren.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS praktijkvoorbeelden - Geonovum
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0034` — reference.md:117 *(§ TOOI - Thesaurus en Ontologie voor OverheidsInformatie)*
-
-> TOOI (Thesaurus en Ontologie voor OverheidsInformatie) gebruikt BOMOS als basis voor hun beheerplan en beschrijft per BOMOS-activiteit hoe deze wordt ingevuld.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS praktijkvoorbeelden - TOOI
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0035` — reference.md:121 *(§ Linked Data Module)*
-
-> De Linked Data module behandelt URI-strategie, versiebeheer van ontologieën, en publicatie als Linked Data.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Linked Data Module
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Linked Data module
 
 - **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
-  - *De brontekst is de GitHub-pagina van BOMOS-LinkedData en beschrijft de module slechts als 'aanvullende module met BOMOS aspecten die specifiek over linked data gaan'. Inhoudelijke onderwerpen zoals URI-strategie, versiebeheer van ontologieën en publicatie als Linked Data worden niet concreet vermeld in de aangeleverde brontekst.*
+  - *De brontekst beschrijft alleen de repository-pagina van BOMOS-LinkedData op GitHub (README, bestandslijst, metadata). De inhoud van de module zelf (URI-strategie, versiebeheer van ontologieën, publicatie als Linked Data) is niet aanwezig in de aangeleverde tekst. De titel suggereert dat de module over linked data gaat, maar de specifieke onderwerpsclaims kunnen niet worden bevestigd op basis van de aangeleverde brontekst.*
 
-### `ls-bomos-0036` — reference.md:127 *(§ Open Source Module)*
+## CONTRADICTED — bron spreekt de claim expliciet tegen (1)
 
-> De Open Source module beschrijft governance voor open source componenten die bij standaarden horen, waaronder licentiekeuze, contributor agreements en beheer van referentie-implementaties.
+### `ls-bomos-0007` — SKILL.md:47 *(§ Repositories)*
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Open Source Module
+> BOMOS-Aanvullende-Modules is gearchiveerd en heeft geen actieve publicatie.
 
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
-  - *De brontekst beschrijft alleen globaal het doel van BOMOS-OpenSource ('open source code open beheerd kan worden') maar gaat niet in op specifieke onderwerpen als licentiekeuze, contributor agreements of beheer van referentie-implementaties.*
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS aanvullende modules
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (3)
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules)
+  > This repository was archived by the owner on May 1, 2025. It is now read-only.
+  - *De bron bevestigt expliciet dat de repository gearchiveerd is en read-only. Geen actieve publicatie is daarmee bevestigd.*
+- **CONTRADICTED** (medium) — [https://logius-standaarden.github.io/BOMOS-LinkedData](https://logius-standaarden.github.io/BOMOS-LinkedData)
+  > Deze versie: https://logius-standaarden.github.io/BOMOS-LinkedData/ Laatst gepubliceerde versie: https://gitdocumentatie.logius.nl/publicatie/bomos/linkeddata/ ... Status van dit document: Dit is een werkversie die op elk moment kan worden gewijzigd, verwijderd of vervangen door andere documenten.
+  - *De bron toont een actieve werkversie van een BOMOS aanvullende module (Linked Data), gedateerd 09 maart 2026. Dit weerspreekt de claim dat BOMOS aanvullende modules gearchiveerd zijn zonder actieve publicatie. Wel is dit een werkversie (niet formeel vastgesteld), maar van archivering is geen sprake. De claim spreekt over 'BOMOS-Aanvullende-Modules' generiek; deze bron dekt slechts één module (Linked Data), dus het verdict is gebaseerd op wat de bron laat zien.*
+- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/BOMOS-Stelsels](https://logius-standaarden.github.io/BOMOS-Stelsels)
+  > Werkversie 09 maart 2026 ... Status van dit document: Dit is een werkversie die op elk moment kan worden gewijzigd, verwijderd of vervangen door andere documenten.
+  - *De bron is een actieve werkversie gedateerd 09 maart 2026 met een live URL en redacteurs. Er is geen sprake van archivering; de module is actief gepubliceerd en wordt bijgehouden (zie documentbeheer: laatste wijziging 15/06/2025).*
+<details><summary>5x NOT_FOUND (klap uit)</summary>
 
-### `ls-bomos-0004` — SKILL.md:40 *(§ Kerndocumenten (met vastgestelde versies))*
-
-> BOMOS-Fundament v3.0.2 is gepubliceerd op gitdocumentatie.logius.nl/publicatie/bomos/fundament/ onder licentie CC-BY-4.0.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-Fundament repository
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament)
-  > LICENSE CC-BY-4.0 license ... Beheermodel voor het Beheer- en Ontwikkelmodel Open Standaarden (BOMOS) ... BOMOS Fundament beschrijft de basis en achtergronden van BOMOS.
-  - *De bron bevestigt de CC-BY-4.0 licentie voor de BOMOS-Fundament repository. De gepubliceerde URL in de claim (gitdocumentatie.logius.nl/publicatie/bomos/fundament/) wordt niet genoemd; de bron vermeldt 'logius-standaarden.github.io/BOMOS-Fundament/' als URL. Het versienummer v3.0.2 komt niet voor in de brontekst.*
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/BOMOS-Fundament](https://logius-standaarden.github.io/BOMOS-Fundament)
-  - *Bron status: unsupported*
-<details><summary>4x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping)
-  - *De brontekst gaat over de BOMOS-Verdieping repository. Er is geen informatie over BOMOS-Fundament v3.0.2 of de publicatie-URL gitdocumentatie.logius.nl/publicatie/bomos/fundament/ in de bron. De CC-BY-4.0 licentie wordt wel vermeld, maar niet in relatie tot BOMOS-Fundament of een versienummer.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Verdieping](https://logius-standaarden.github.io/BOMOS-Verdieping)
-  - *De brontekst gaat over BOMOS-Verdieping, niet over BOMOS-Fundament. Er is geen informatie over het Fundament v3.0.2 in deze bron.*
-</details>
-
-### `ls-bomos-0005` — SKILL.md:41 *(§ Kerndocumenten (met vastgestelde versies))*
-
-> BOMOS-Verdieping v3.1.0 is gepubliceerd op gitdocumentatie.logius.nl/publicatie/bomos/verdieping/ onder licentie CC-BY-4.0.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-Verdieping repository
-
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/BOMOS-Fundament](https://logius-standaarden.github.io/BOMOS-Fundament)
-  - *Bron status: unsupported*
-- **PARTIALLY_SUPPORTED** (low) — [https://github.com/logius-standaarden/BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping)
-  > CC-BY-4.0 license [...] De gepubliceerde (vastgestelde) versie staat online: Vastgestelde versie 07 juni 2022 De ontwikkelversie van dit document staat online: Dynamische pagina (actueel)
-  - *De bron bevestigt dat BOMOS-Verdieping onder CC-BY-4.0 licentie valt. De specifieke versie v3.1.0 en de URL gitdocumentatie.logius.nl/publicatie/bomos/verdieping/ worden niet expliciet vermeld. De publicatie-URL in de bron verwijst naar logius-standaarden.github.io/BOMOS-Verdieping/, niet naar gitdocumentatie.logius.nl.*
-- **PARTIALLY_SUPPORTED** (high) — [https://logius-standaarden.github.io/BOMOS-Verdieping](https://logius-standaarden.github.io/BOMOS-Verdieping)
-  > Deze versie: https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/3.1.0/ [...] Dit document valt onder de volgende licentie: Creative Commons Attribution 4.0 International Public License
-  - *De bron bevestigt versie 3.1.0 en de CC-BY-4.0 licentie. De URL 'gitdocumentatie.logius.nl/publicatie/bomos/verdieping/' wordt genoemd als 'Laatst gepubliceerde versie', wat de claim ondersteunt. De afkorting 'CC-BY-4.0' staat niet letterlijk in de bron maar 'Creative Commons Attribution 4.0 International Public License' is equivalent. Volledig SUPPORTED zou ook verdedigbaar zijn, maar de claim specificeert een korte URL zonder versienummer als publicatielocatie terwijl de bron die URL als 'Laatst gepubliceerde versie' aanduidt, niet als primaire URL van v3.1.0.*
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament)
-  - *De bron gaat over de BOMOS-Fundament repository. BOMOS-Verdieping wordt wel genoemd als apart document, maar de claim over versienummer v3.1.0, de specifieke URL en de licentie voor BOMOS-Verdieping worden niet behandeld in deze brontekst. OUT_OF_SCOPE zou ook passend zijn, maar de bron noemt Verdieping zijdelings zonder er verdere details over te geven.*
-</details>
-
-### `ls-bomos-0007` — SKILL.md:49 *(§ Aanvullende modules en documenten (alleen werkversies))*
-
-> BOMOS-OpenSource repository is gearchiveerd en de draft-versie is bevroren.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-OpenSource module
-
-- **PARTIALLY_SUPPORTED** (high) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
-  > This repository was archived by the owner on Aug 28, 2025. It is now read-only.
-  - *De bron bevestigt dat de repository gearchiveerd is. De claim dat de 'draft-versie is bevroren' wordt niet expliciet vermeld; archivering impliceert read-only maar de bron spreekt niet van een draft-versie of bevriezing daarvan.*
-<details><summary>14x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules)
-  - *De brontekst gaat over de BOMOS-Aanvullende-Modules repository, niet over een aparte BOMOS-OpenSource repository. Er is geen informatie over archivering of bevriezing van een draft-versie van BOMOS-OpenSource.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
-  - *De brontekst vermeldt niets over een BOMOS-OpenSource repository, archivering of bevroren draft-versie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-LinkedData](https://logius-standaarden.github.io/BOMOS-LinkedData)
-  - *De brontekst gaat over BOMOS LinkedData, niet over een BOMOS-OpenSource module of repository. Geen enkele vermelding van archivering of bevroren drafts.*
+  - *De brontekst gaat over de BOMOS-LinkedData repository en noemt BOMOS-Aanvullende-Modules niet.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
+  - *De brontekst gaat over BOMOS-OpenSource, niet over een module genaamd 'BOMOS-Aanvullende-Modules'. Of die specifieke module gearchiveerd is en geen actieve publicatie heeft, blijkt niet uit deze bron.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-OpenSource](https://logius-standaarden.github.io/BOMOS-OpenSource)
-  - *De brontekst bevat geen informatie over de archiefstatus van de BOMOS-OpenSource repository of het bevriezen van een draft-versie.*
+  - *De bron gaat over BOMOSS (BOMOS voor Open Source Software) en vermeldt niets over 'BOMOS-Aanvullende-Modules' of de archiefstatus daarvan.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels)
-  - *De brontekst vermeldt BOMOS-OpenSource niet. Er is geen informatie over archivering of bevriezing van die repository.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Stelsels](https://logius-standaarden.github.io/BOMOS-Stelsels)
-  - *De brontekst bevat geen informatie over een BOMOS-OpenSource repository, archivering daarvan, of het bevriezen van een draft-versie.*
+  - *De brontekst is de README van BOMOS-Stelsels. Er wordt geen melding gemaakt van een repository genaamd 'BOMOS-Aanvullende-Modules' of de status daarvan (gearchiveerd of niet). De vermelde BOMOS-documenten zijn: Fundament, Verdieping, Stelsels, Linked Data en Beheermodel.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Beheermodel](https://github.com/logius-standaarden/BOMOS-Beheermodel)
-  - *De brontekst maakt geen melding van de BOMOS-OpenSource repository of archivering/bevriezing daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Beheermodel](https://logius-standaarden.github.io/BOMOS-Beheermodel)
-  - *De brontekst bevat geen informatie over een 'BOMOS-OpenSource' repository, archiveringsstatus of bevroren draft-versie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
-  - *De brontekst gaat over de BOMOS-voorbeeld-beheermodel repository. Er is geen informatie over een BOMOS-OpenSource repository of de archiefstatus/bevriezing daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel](https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel)
-  - *De brontekst maakt geen melding van de BOMOS-OpenSource repository, archivering daarvan, of het bevriezen van een draft-versie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Community](https://github.com/logius-standaarden/BOMOS-Community)
-  - *De brontekst bevat geen informatie over de BOMOS-OpenSource repository, de archiefstatus ervan, of de status van een draft-versie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Community](https://logius-standaarden.github.io/BOMOS-Community)
-  - *De brontekst behandelt de BOMOS Community en events. Er is geen informatie over de BOMOS-OpenSource repository of de archiveringstatus en bevriezing van een draft-versie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Logius-Beheermodel](https://github.com/logius-standaarden/Logius-Beheermodel)
-  - *De brontekst bevat geen informatie over de BOMOS-OpenSource repository, de archiefstatus ervan, of een bevroren draft-versie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Logius-Beheermodel](https://logius-standaarden.github.io/Logius-Beheermodel)
-  - *De aangeleverde brontekst bevat geen informatie over de BOMOS-OpenSource repository of de status daarvan.*
+  - *De brontekst is de README van de BOMOS-Beheermodel repository. Er worden wel aanvullende modules genoemd (BOMOS Stelsels, BOMOS Linked Data), maar er staat niets over archivering of het ontbreken van een actieve publicatie van aanvullende modules.*
 </details>
 
-## UNGROUNDED — geen bron ondersteunt de claim (10)
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (13)
+
+### `ls-bomos-0001` — SKILL.md:32 *(§ Versiemodel)*
+
+> BOMOS is geen interoperabiliteitsstandaard en staat niet op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS - Beheer- en Ontwikkelmodel voor Open Standaarden
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Overigens, als de beheerorganisatie conform BOMOS werkt, dan wil dat niet automatisch zeggen dat de standaard daarmee ook voldoet aan de criteria voor de pas-toe of leg-uit lijst van standaarden van de overheid. Echter het is wel te prefereren dat aangemelde standaarden conform BOMOS werken
+  - *De bron bevestigt dat BOMOS-conformiteit niet automatisch leidt tot plaatsing op de pas-toe-of-leg-uit-lijst, maar zegt niet expliciet dat BOMOS zelf niet op die lijst staat. De claim dat BOMOS 'geen interoperabiliteitsstandaard' is wordt ook niet letterlijk bevestigd; BOMOS wordt een 'standaard voor standaarden' genoemd.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De bron noemt de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie meerdere keren in de context van andere standaarden, maar zegt nergens expliciet dat BOMOS zelf niet op die lijst staat of geen interoperabiliteitsstandaard is.*
+
+### `ls-bomos-0009` — SKILL.md:58 *(§ Wijzigingsbeheer Workflow)*
+
+> De RFC-procedure (Request for Change) is het kernproces voor wijzigingsbeheer binnen BOMOS.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS wijzigingsbeheer
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Op een moment dat de indiener dit aangeeft dient de wens of eis opgenomen te worden als request for change of wijzigingsverzoek.
+  - *De bron noemt het RFC/wijzigingsverzoek-concept maar beschrijft het niet expliciet als 'het kernproces voor wijzigingsbeheer binnen BOMOS'. De procedure wordt beschreven als onderdeel van het operationele beheerproces, maar de centrale/kern-status wordt niet zo benoemd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *De bron beschrijft het wijzigingsproces via wensen en eisen, maintenance requests, etc., maar noemt de term 'RFC-procedure' of 'Request for Change' niet als kernproces.*
 
 ### `ls-bomos-0012` — SKILL.md:181 *(§ BOMOS Conformiteit Checklist)*
 
@@ -334,204 +114,407 @@
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS conformiteit
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > De beheerorganisatie werkt conform BOMOS als er een beheerdocument is gepubliceerd waarin de invulling van alle onderdelen uit het BOMOS Activiteitendiagram (het Beheer- en Ontwikkelmodel) zijn beschreven.
+  - *De bron stelt dat alle onderdelen beschreven moeten zijn, maar zegt niet expliciet dat 'niet invullen' ook als bewuste beschrijving volstaat. De claim is specifieker dan de bron op dit punt.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De bron beschrijft het BOMOS-model uitgebreid maar formuleert nergens een conformiteitseis zoals beschreven in de claim, namelijk dat elke activiteit bewust beschreven moet zijn, ook met 'deze activiteit vullen wij (nog) niet in'.*
 
-### `ls-bomos-0018` — reference.md:48 *(§ 4. Implementatieondersteuning)*
+### `ls-bomos-0014` — reference.md:13 *(§ Het BOMOS Activiteitenmodel)*
 
-> Bij implementatieondersteuning is het cruciaal om een balans te vinden tussen activiteiten van de beheerorganisatie en die van commerciële partijen.
+> De strategielaag van BOMOS bevat de activiteiten Governance, Visie, en Financiering, met de rollen Houder en Financier.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** BOMOS implementatieondersteuning
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS strategielaag
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Strategie: Richtinggevende activiteiten gerelateerd aan de strategische (lange) termijn: Governance [...] Visie [...] Financiën [...] Activiteit Primair verantwoordelijke rol: Strategie - Eigenaar, financier
+  - *De bron bevestigt Governance, Visie en Financiën als strategieactiviteiten, en Financier als rol. Maar de claim noemt 'Houder'; de bron gebruikt de term 'Eigenaar', niet 'Houder'. Dat is een terminologisch verschil.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Houder: Governance, Visie, Rechtenbeleid, Adoptie en erkenning (beleid) [...] Financier: Financiën
+  - *De bron bevestigt Governance en Visie als activiteiten in de strategielaag, en de rollen Houder en Financier. Maar 'Financiering' als activiteitsnaam wordt in de bron aangeduid als 'Financiën' (sectie 2.2). De claim noemt 'Financiering', de bron noemt 'Financiën'.*
 
-### `ls-bomos-0019` — reference.md:50 *(§ 4. Implementatieondersteuning)*
+### `ls-bomos-0015` — reference.md:23 *(§ Het BOMOS Activiteitenmodel)*
 
-> Een helpdesk is een minimale ondersteuning voor implementatievragen die altijd nodig is (laagdrempelig).
+> De tactieklaag van BOMOS bevat de activiteiten Architectuur, Specificatiebeheer, Wijzigingsbeheer, Adoptiestrategie, Kwaliteitsbeleid, Rechtenmanagement, en Community, met de rol Autorisator.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS implementatieondersteuning - Helpdesk
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS tactieklaag
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Tactiek: Activiteiten die op middellang termijn voor stabiliteit zorgen: Adoptie & erkenning [...] Architectuur [...] Community [...] Kwaliteitsbeleid benchmarking [...] Rechtenbeleid [...] Autorisator
+  - *De bron bevestigt Architectuur, Community, Kwaliteitsbeleid, Rechtenbeleid, Adoptie & erkenning en de rol Autorisator. Maar 'Specificatiebeheer' en 'Wijzigingsbeheer' als aparte activiteiten worden niet vermeld. De claim noemt meer activiteiten dan de bron beschrijft.*
+- **NOT_FOUND** (low) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De bron beschrijft tactische activiteiten (Community, Architectuur, Adoptie & Erkenning, Kwaliteitsbeleid) en noemt de rol Autorisator, maar de volledige lijst uit de claim (Specificatiebeheer, Wijzigingsbeheer, Rechtenmanagement) wordt niet als zodanig als tactische laag-activiteiten benoemd in deze brontekst.*
 
-### `ls-bomos-0020` — reference.md:51 *(§ 4. Implementatieondersteuning)*
+### `ls-bomos-0016` — reference.md:37 *(§ Het BOMOS Activiteitenmodel)*
 
-> Opleidingen bij standaardenbeheer mogen niet concurreren met de markt; ze worden alleen aangeboden waar de markt niet voorziet.
+> De operationele laag van BOMOS bevat de activiteiten Initiatie, Wensen en eisen verzamelen, Ontwikkeling, Uitvoering, Documentatie, en Klachtenafhandeling, met de rollen Functioneel Beheerder en Technisch Beheerder.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS operationele laag
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Operationeel: De uitvoerende activiteiten die leiden tot nieuwe versies van standaarden, waaronder: Initiatie [...] Wensen en eisen [...] Ontwikkeling [...] Uitvoeren [...] Documentatie [...] Functioneel beheerder, Technisch beheerder
+  - *De bron bevestigt Initiatie, Wensen en eisen, Ontwikkeling, Uitvoeren, Documentatie en de rollen Functioneel Beheerder en Technisch Beheerder. Maar 'Klachtenafhandeling' staat in de bron onder de Communicatielaag, niet onder Operationeel.*
+- **NOT_FOUND** (low) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De bron behandelt operationele activiteiten zoals wensen/eisen verzamelen, wijzigingsvoorstellen, besluitvorming, en noemt rollen Functioneel Beheerder en Technisch Beheerder, maar de volledige en exacte opsomming van de operationele laag zoals in de claim wordt niet als zodanig gepresenteerd in deze brontekst.*
+
+### `ls-bomos-0017` — reference.md:50 *(§ Het BOMOS Activiteitenmodel)*
+
+> De implementatieondersteuningslaag van BOMOS bevat de activiteiten Helpdesk, Opleidingen, Open source modules, Pilots, en Validatie en certificatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS implementatieondersteuning
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Implementatie-ondersteuning, ondersteunende activiteiten gericht op het bevorderen van implementaties van de standaard, waaronder: Opleiding [...] Helpdesk [...] Module-ontwikkeling [...] Pilot [...] Validatie & Certificatie
+  - *De bron bevestigt Helpdesk, Opleiding, Module-ontwikkeling (niet 'Open source modules'), Pilots en Validatie & Certificatie. De claim gebruikt 'Open source modules' waar de bron 'Module-ontwikkeling' zegt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Een helpdesk functionaliteit is minimaal voor een beheerorganisatie. [...] Met het bieden van opleidingen [...] open source modules te ontwikkelen. [...] Laag drempeliger is het om pilots te organiseren. [...] Vooral een lichtere vorm van certificatie, validatie is een goede vorm van implementatie-ondersteuning.
+  - *De bron bevestigt helpdesk, opleidingen, open source modules, pilots en validatie/certificatie als vormen van implementatieondersteuning. Echter ze worden niet expliciet als een formele lijst van vijf activiteiten van een 'implementatieondersteuningslaag' gepresenteerd.*
+
+### `ls-bomos-0019` — reference.md:51 *(§ Het BOMOS Activiteitenmodel)*
+
+> Opleidingen binnen BOMOS-implementatieondersteuning mogen niet concurreren met de markt; ze worden alleen aangeboden waar de markt niet voorziet.
 
 **Type:** normative_requirement  ·  **Modaliteit:** SHOULD_NOT  ·  **Scope:** BOMOS implementatieondersteuning - Opleidingen
 
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Met het bieden van opleidingen kom je als beheerorganisatie al sneller in het vaarwater van anderen. Toch kan het in een beginstadium wel essentieel zijn om het aan te bieden, vooral ook om de kwaliteit van de implementaties te verhogen, en implementaties laagdrempeliger maken.
+  - *De bron stelt dat opleidingen aanbieden je 'in het vaarwater van anderen' brengt en dat het alleen in beginstadium essentieel kan zijn. Dit ondersteunt de gedachte dat concurrentie vermeden moet worden, maar de expliciete formulering 'alleen waar de markt niet voorziet' staat niet letterlijk in de bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+  - *De bron beschrijft opleidingen als activiteit maar stelt nergens dat ze niet mogen concurreren met de markt of alleen aangeboden mogen worden waar de markt niet voorziet.*
+
+### `ls-bomos-0021` — reference.md:60 *(§ Het BOMOS Activiteitenmodel)*
+
+> De communicatielaag van BOMOS bevat de activiteiten Promotie en Publicatie, met de rol Distributeur.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS communicatielaag
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Communicatie, ondersteunende activiteiten gericht op het creëren van draagvlak voor de standaard, waaronder: Promotie [...] Publicatie [...] Klachtenafhandeling [...] Distributeur
+  - *De bron bevestigt Promotie, Publicatie en de rol Distributeur. Maar de claim vermeldt alleen Promotie en Publicatie; de bron noemt ook Klachtenafhandeling als communicatieactiviteit, wat de claim weglaat. Geen tegenspraak, wel onvolledigheid in de claim.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Distributeur: Promotie, Publicatie
+  - *De tabel met rollen en BOMOS-activiteiten bevestigt dat de Distributeur de activiteiten Promotie en Publicatie heeft. Echter de claim stelt dit als onderdeel van een 'communicatielaag' — de bron vermeldt wel een hoofdstuk Communicatie (6) maar koppelt Promotie/Publicatie in de tabel primair aan de rol Distributeur, niet expliciet als 'communicatielaag'. Deels ondersteund.*
+
+### `ls-bomos-0023` — reference.md:80 *(§ Rollen en Verantwoordelijkheden)*
+
+> Binnen BOMOS kan een persoon meerdere rollen vervullen, en een rol kan door meerdere personen worden ingevuld.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS rollenmodel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Van bovenstaande rollen kunnen de financier-rol, de expert-rol, de gebruikers-rol en de eindgebruikers-rol meervoudig worden ingevuld: meer dan één persoon of organisatie kan de rol van financier, expert, gebruiker of eindgebruiker vervullen. De overige rollen zijn enkelvoudig
+  - *De bron stelt dat sommige rollen meervoudig zijn en andere enkelvoudig. De claim dat 'een persoon meerdere rollen kan vervullen' wordt niet expliciet bevestigd; wel dat meerdere personen dezelfde rol kunnen invullen (meervoudig). De claim combineert twee dingen die de bron niet volledig zo stelt.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron beschrijft de rollen en hun activiteiten, maar bevat geen expliciete uitspraak dat één persoon meerdere rollen kan vervullen of dat één rol door meerdere personen kan worden ingevuld.*
 
-### `ls-bomos-0021` — reference.md:52 *(§ 4. Implementatieondersteuning)*
+### `ls-bomos-0027` — reference.md:96 *(§ Conformiteit)*
 
-> Open source modules worden alleen ingezet bij geconstateerde implementatieproblemen.
+> Het BOMOS beheerdocument hoeft niet voor elk onderdeel uitgebreid te zijn; bij sommige activiteiten volstaat een bewuste keuze om deze (nog) niet in te vullen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** BOMOS conformiteit
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > De invulling van de ontwikkel- en beheeronderwerpen zijn situationeel afhankelijk [...] Het is dus zeker niet zo dat elk onderwerp moet worden geïmplementeerd.
+  - *De bron bevestigt dat niet elk onderwerp geïmplementeerd hoeft te worden, maar zegt niet expliciet dat een bewuste keuze om iets 'niet in te vullen' volstaat als beschrijving in het beheerdocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De bron bevat geen uitspraken over minimale vereisten voor BOMOS-conformiteit of dat bij sommige activiteiten een bewuste keuze om ze niet in te vullen volstaat.*
+
+### `ls-bomos-0033` — reference.md:117 *(§ Praktijkvoorbeelden)*
+
+> TOOI (Thesaurus en Ontologie voor OverheidsInformatie) gebruikt BOMOS als basis voor hun beheerplan en beschrijft per BOMOS-activiteit hoe deze wordt ingevuld.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS praktijkvoorbeelden - TOOI
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Het beheerplan TOOI is opgezet volgens de principes uit BOMOS. De invulling van de 5 thema's uit BOMOS (Strategie, Tactiek, Operationeel, Implementatieondersteuning en Communicatie) zijn uitgebreid beschreven op de website.
+  - *De bron bevestigt dat TOOI BOMOS als basis gebruikt en de thema's beschrijft, maar spreekt van 'thema's' beschreven op de website, niet expliciet van 'per BOMOS-activiteit'. De strekking klopt grotendeels maar de precisering 'per activiteit' staat er niet letterlijk.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *TOOI (Thesaurus en Ontologie voor OverheidsInformatie) wordt in de aangeleverde brontekst niet vermeld.*
+
+### `ls-bomos-0035` — reference.md:127 *(§ Open Source Module)*
+
+> De BOMOS Open Source module beschrijft governance voor open source componenten, inclusief licentiekeuze, contributor agreements, en beheer van referentie-implementaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Open Source module
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
+  > Deze handreiking probeert een kader te geven waarmee open source code open beheerd kan worden. Het Beheer- en ontwikkelmodel Open Standaarden is ontwikkeld als een handreiking voor het beheer van standaarden. Deze handreiking beoogt ondersteuning aan het beheer van open source code te geven vanuit de BOMOS bril.
+  - *De bron bevestigt dat de module governance voor open source code beschrijft. Licentiekeuze, contributor agreements en beheer van referentie-implementaties worden echter niet expliciet als onderwerpen genoemd in de brontekst; die details zijn niet te verifiëren op basis van de aangeleverde README-tekst alleen.*
+
+## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (1)
+
+### `ls-bomos-0008` — SKILL.md:49 *(§ Repositories)*
+
+> BOMOS-OpenSource is gearchiveerd en heeft een bevroren draft publicatie, gepubliceerd onder de W3C Software and Document License.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-OpenSource module
+
+**Erkend in conflicts.md** *(§ Licentie-status GitHub-repositories)*: conflicts.md beschrijft expliciet: 'BOMOS-OpenSource | W3C Software License | CC0-1.0 (ReSpec) | Afwijkend'. De discrepantie tussen de GitHub LICENSE (W3C Software License) en de gepubliceerde licentie is gedocumenteerd. Archivering wordt niet vermeld, maar de licentieconflicten zijn de kern van de CONTRADICTED-verdicts.
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
+  > This repository was archived by the owner on Aug 28, 2025. It is now read-only.
+  - *De bron bevestigt dat BOMOS-OpenSource gearchiveerd is. De claim over 'bevroren draft publicatie' is niet verifieerbaar uit de brontekst. De licentie is vermeld als 'View license' maar de W3C Software and Document License wordt nergens expliciet bij naam genoemd; de repo verwijst naar een LICENSE bestand zonder de inhoud te tonen.*
+- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/BOMOS-OpenSource](https://logius-standaarden.github.io/BOMOS-OpenSource)
+  > Dit document valt onder de volgende licentie: Creative Commons 0 Public Domain Dedication
+  - *De claim stelt dat het document gepubliceerd is onder de W3C Software and Document License, maar de bron vermeldt expliciet Creative Commons 0 Public Domain Dedication als licentie. Bovendien is het document een actieve werkversie ('Werkversie 25 augustus 2025'), niet een bevroren draft. Over archivering wordt niets vermeld.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://raw.githubusercontent.com/logius-standaarden/BOMOS-OpenSource/main/LICENSE](https://raw.githubusercontent.com/logius-standaarden/BOMOS-OpenSource/main/LICENSE)
+  > The W3C SOFTWARE NOTICE AND LICENSE (W3C) https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document ... Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted
+  - *De bron bevestigt dat het werk gepubliceerd is onder de W3C Software and Document License. De claim dat BOMOS-OpenSource 'gearchiveerd is en een bevroren draft publicatie heeft' wordt niet ondersteund noch weersproken door deze licentietekst — die informatie staat niet in de LICENSE-file zelf.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://raw.githubusercontent.com/logius-standaarden/BOMOS-OpenSource/master/LICENSE](https://raw.githubusercontent.com/logius-standaarden/BOMOS-OpenSource/master/LICENSE)
+  > The W3C SOFTWARE NOTICE AND LICENSE (W3C) https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document [...] Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted
+  - *De bron bevestigt dat de W3C Software and Document License van toepassing is op dit werk, wat het licentiedeel van de claim ondersteunt. De claim dat het werk 'gearchiveerd' is en een 'bevroren draft publicatie' heeft, wordt niet bevestigd noch tegengesproken door deze licensetekst — dat is publicatie-metadata die niet in een LICENSE-bestand staat.*
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules)
+  - *De brontekst gaat over BOMOS-Aanvullende-Modules, niet over een aparte BOMOS-OpenSource repository. Er is geen informatie over een W3C Software and Document License of een bevroren draft publicatie voor een OpenSource module.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
+  - *De brontekst gaat over de BOMOS-LinkedData repository en noemt BOMOS-OpenSource niet.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-LinkedData](https://logius-standaarden.github.io/BOMOS-LinkedData)
+  - *De bron gaat uitsluitend over de BOMOS Linked Data module. BOMOS-OpenSource, archiveringsstatus daarvan, of een W3C Software and Document License worden nergens in de tekst vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels)
+  - *De brontekst bevat geen verwijzing naar een 'BOMOS-OpenSource' module, de archiefstatus ervan, of de W3C Software and Document License. Dit valt buiten de scope van de aangeleverde BOMOS-Stelsels README.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (17)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-bomos-0002` — SKILL.md:32 *(§ Versiemodel)*
+
+> BOMOS is een raamwerk voor het beheren van open standaarden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS - Beheer- en Ontwikkelmodel voor Open Standaarden
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > BOMOS (Beheer- en OntwikkelModel voor Open Standaarden) is een hulpmiddel van en voor de standaardisatiewereld.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Het doel van deze publicatie is organisaties te helpen bij het opzetten van het beheer van standaarden en de verbetering daarvan.
+  - *De bron beschrijft BOMOS consistent als een Beheer- en OntwikkelModel voor Open Standaarden, een raamwerk gericht op het beheren van open standaarden.*
+
+### `ls-bomos-0003` — SKILL.md:29 *(§ Versiemodel)*
+
+> BOMOS kent twee publicatiekanalen: een vastgestelde versie (DEF) gepubliceerd op gitdocumentatie.logius.nl, en een werkversie (draft) gepubliceerd op logius-standaarden.github.io.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS versiemodel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Deze versie: https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/3.0.2/ [...] Laatste werkversie: https://logius-standaarden.github.io/BOMOS-Fundament/
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Deze versie: https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/3.1.0/ [...] Laatste werkversie: https://logius-standaarden.github.io/BOMOS-Verdieping/
+  - *De bron toont beide publicatiekanalen in de header: gitdocumentatie.logius.nl voor de vastgestelde versie en logius-standaarden.github.io voor de werkversie.*
+
+### `ls-bomos-0004` — SKILL.md:40 *(§ Repositories)*
+
+> BOMOS-Fundament v3.0.2 is de vastgestelde versie, gepubliceerd op gitdocumentatie.logius.nl/publicatie/bomos/fundament/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-Fundament
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > BOMOS, het fundament 3.0.2 Logius Handreiking Vastgestelde versie 02 november 2023 Deze versie: https://gitdocumentatie.logius.nl/publicatie/bomos/fundament/3.0.2/
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/logius-standaarden/BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament)
+  > Vastgestelde versie 07 juni 2022
+  - *De bron bevestigt dat er een vastgestelde versie bestaat (gepubliceerd op 07 juni 2022), maar vermeldt geen versienummer v3.0.2 en noemt de URL gitdocumentatie.logius.nl/publicatie/bomos/fundament/ niet. De gepubliceerde versie-URL ontbreekt in de aangeleverde tekst.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/BOMOS-Fundament](https://logius-standaarden.github.io/BOMOS-Fundament)
+  - *Bron status: unsupported*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De bron (BOMOS Verdieping) verwijst naar het Fundament als apart document maar noemt geen specifiek versienummer v3.0.2 voor het Fundament.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping)
+  - *De brontekst vermeldt versienummers noch een publicatie-URL voor BOMOS-Fundament. Alleen de naam 'BOMOS Fundament' wordt genoemd als onderdeel van de documentatieset.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Verdieping](https://logius-standaarden.github.io/BOMOS-Verdieping)
+  - *De bron is BOMOS-Verdieping en bevat geen informatie over de BOMOS-Fundament versie of publicatielocatie. Dit document gaat uitsluitend over BOMOS Deel 2: De Verdieping.*
+</details>
+
+### `ls-bomos-0005` — SKILL.md:41 *(§ Repositories)*
+
+> BOMOS-Verdieping v3.1.0 is de vastgestelde versie, gepubliceerd op gitdocumentatie.logius.nl/publicatie/bomos/verdieping/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-Verdieping
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > BOMOS Deel 2: de verdieping 3.1.0 Logius Handreiking Vastgestelde versie 19 september 2025 Deze versie: https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/3.1.0/
+  - *De brontekst bevestigt expliciet dat v3.1.0 de vastgestelde versie is, gepubliceerd op gitdocumentatie.logius.nl.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/BOMOS-Fundament](https://logius-standaarden.github.io/BOMOS-Fundament)
+  - *Bron status: unsupported*
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/BOMOS-Verdieping](https://logius-standaarden.github.io/BOMOS-Verdieping)
+  > BOMOS Deel 2: de verdieping 3.1.0 Logius Handreiking Vastgestelde versie 19 september 2025 Deze versie: https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/3.1.0/ Laatst gepubliceerde versie: https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/
+  - *De bron bevestigt zowel versienummer 3.1.0 als de publicatielocatie op gitdocumentatie.logius.nl/publicatie/bomos/verdieping/.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *De bron gaat over BOMOS-Fundament. De versie van BOMOS-Verdieping (v3.1.0) wordt nergens in deze tekst vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament)
+  - *De bron vermeldt BOMOS-Verdieping als apart document maar geeft geen versienummer (v3.1.0) en geen URL voor de vastgestelde versie. Deze claim gaat over een apart repository en valt buiten wat deze brontekst behandelt.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping)
+  - *De brontekst noemt geen versienummer voor BOMOS-Verdieping en geen publicatie-URL op gitdocumentatie.logius.nl. Wel staat er een link naar een 'Vastgestelde versie 07 juni 2022' maar zonder versienummer v3.1.0.*
+</details>
+
+### `ls-bomos-0006` — SKILL.md:40 *(§ Repositories)*
+
+> BOMOS-Fundament en BOMOS-Verdieping zijn gepubliceerd onder de CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS kerndocumenten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Dit document valt onder de volgende licentie: Creative Commons Attribution 4.0 International Public License
+  - *Geldt voor het Fundament-document. De bron bevestigt de CC-BY-4.0 licentie voor dit document; de Verdieping wordt niet behandeld in deze bron.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Dit document valt onder de volgende licentie: Creative Commons Attribution 4.0 International Public License
+  - *CC BY 4.0 is de gangbare aanduiding voor Creative Commons Attribution 4.0 International Public License. De bron bevestigt dit voor de Verdieping; de claim spreekt over beide kerndocumenten, maar de bron dekt alleen de Verdieping.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament)
+  > CC-BY-4.0 license
+  - *De bron bevestigt de CC-BY-4.0 licentie voor BOMOS-Fundament. BOMOS-Verdieping wordt wel vermeld als apart document, maar de licentie daarvan is niet bevestigd in deze brontekst. De claim stelt dat beide documenten onder CC-BY-4.0 vallen; voor Verdieping ontbreekt bevestiging.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/BOMOS-Fundament](https://logius-standaarden.github.io/BOMOS-Fundament)
+  - *Bron status: unsupported*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping)
+  > CC-BY-4.0 license (vermeld onder 'License' in de repository-metadata van BOMOS-Verdieping)
+  - *De bron bevestigt CC-BY-4.0 voor BOMOS-Verdieping. De bron vermeldt niets over de licentie van BOMOS-Fundament, dus de claim dat beide documenten onder CC-BY-4.0 vallen is slechts gedeeltelijk onderbouwd.*
+- **PARTIALLY_SUPPORTED** (high) — [https://logius-standaarden.github.io/BOMOS-Verdieping](https://logius-standaarden.github.io/BOMOS-Verdieping)
+  > Dit document valt onder de volgende licentie: Creative Commons Attribution 4.0 International Public License
+  - *De bron bevestigt CC-BY-4.0 voor BOMOS-Verdieping. De claim stelt dat ook BOMOS-Fundament onder deze licentie valt, maar de bron bevat geen informatie over de licentie van het Fundament.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://raw.githubusercontent.com/logius-standaarden/BOMOS-Fundament/main/LICENSE](https://raw.githubusercontent.com/logius-standaarden/BOMOS-Fundament/main/LICENSE)
+  > Attribution 4.0 International [...] Creative Commons Attribution 4.0 International Public License
+  - *De bron is het LICENSE-bestand van de BOMOS-Fundament repository en bevestigt dat CC-BY-4.0 de licentie is voor dit document. De claim stelt dat zowel BOMOS-Fundament als BOMOS-Verdieping onder CC-BY-4.0 zijn gepubliceerd. De bron bevestigt alleen BOMOS-Fundament; over BOMOS-Verdieping staat niets in deze brontekst.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://raw.githubusercontent.com/logius-standaarden/BOMOS-Fundament/master/LICENSE](https://raw.githubusercontent.com/logius-standaarden/BOMOS-Fundament/master/LICENSE)
+  > Attribution 4.0 International [...] Creative Commons Attribution 4.0 International Public License
+  - *De brontekst is de volledige tekst van de CC-BY-4.0 licentie, afkomstig uit de LICENSE-file van de BOMOS-Fundament repository. Dit bevestigt dat BOMOS-Fundament onder CC-BY-4.0 is gepubliceerd. De claim stelt echter ook dat BOMOS-Verdieping onder dezelfde licentie valt, maar de bron bevat geen informatie over BOMOS-Verdieping — dat valt buiten het bereik van dit document.*
+
+### `ls-bomos-0011` — SKILL.md:84 *(§ Beheermodel Template)*
+
+> Een BOMOS-conform beheermodel bevat minimaal de secties: Strategie, Tactiek, Operationeel, Implementatieondersteuning, en Communicatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS beheermodel template
+
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
+  > ch02_Strategie.md ch03_Tactiek.md ch04_Operationeel.md ch05_Implementatieondersteuning.md ch06_Communicatie.md
+  - *De repository bevat expliciet de bestanden ch02_Strategie.md, ch03_Tactiek.md, ch04_Operationeel.md, ch05_Implementatieondersteuning.md en ch06_Communicatie.md, wat direct overeenkomt met de vijf genoemde secties in de claim.*
+
+### `ls-bomos-0013` — reference.md:7 *(§ Het BOMOS Activiteitenmodel)*
+
+> Het BOMOS activiteitenmodel beschrijft vijf hoofdlagen: Strategie, Tactiek, Operationeel, Implementatieondersteuning, en Communicatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS activiteitenmodel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > De structuur bestaat uit een aantal elementen: Drie hoofdlagen: strategie, tactiek en operationeel. Twee ondersteunende lagen: implementatieondersteuning en communicatie.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Naast de lagen operationeel, tactisch en strategisch worden implementatie ondersteuning en communicatie besproken.
+  - *De bron bevestigt de vijf hoofdlagen expliciet in de introductie en werkt ze uit in aparte hoofdstukken.*
+
+### `ls-bomos-0018` — reference.md:48 *(§ Het BOMOS Activiteitenmodel)*
+
+> Bij implementatieondersteuning is het cruciaal om een balans te vinden tussen activiteiten van de beheerorganisatie en die van commerciële partijen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS implementatieondersteuning
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Module-ontwikkeling en Certificatie zijn riskante activiteiten, waarmee er actief ingegrepen wordt in de markt. De uitvoering daarvan dient zorgvuldig te gebeuren en zoveel mogelijk buiten de eigen organisatie.
+  - *De bron waarschuwt voor riskante ingrepen in de markt maar formuleert dit niet als een must-vereiste over een 'balans'. De strekking overlapt gedeeltelijk maar de claim is specifieker dan wat de bron zegt.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Met name omdat er een balans gevonden moet worden wat de beheer-organisatie invult, en wat overgelaten wordt aan consultancy door commerciële ondernemingen. Als beheerorganisatie is het ongewenst om te concurreren.
+  - *De bron ondersteunt de claim volledig: het belang van een balans tussen de beheerorganisatie en commerciële partijen bij implementatieondersteuning wordt expliciet beschreven.*
+
+### `ls-bomos-0020` — reference.md:52 *(§ Het BOMOS Activiteitenmodel)*
+
+> Open source modules (referentie-implementaties) worden binnen BOMOS alleen ingezet bij geconstateerde implementatieproblemen.
 
 **Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** BOMOS implementatieondersteuning - Open source modules
 
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Module-ontwikkeling is dan ook een activiteit die zeer zorgvuldig aangepakt moet worden, en pas in het vizier moet komen als er een probleem rond implementaties is ontstaan.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+  - *De bron beschrijft module-ontwikkeling en noemt dat de markt gestimuleerd kan worden, maar stelt niet dat open source modules alleen ingezet mogen worden bij geconstateerde implementatieproblemen.*
+
+### `ls-bomos-0022` — reference.md:67 *(§ Rollen en Verantwoordelijkheden)*
+
+> BOMOS definieert de rollen: Houder, Financier, Autorisator, Functioneel Beheerder, Technisch Beheerder, Distributeur, Expert, en Gebruiker.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS rollenmodel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Eigenaar [...] Financier [...] Autorisator [...] Functioneel beheerder [...] Technisch beheerder [...] Distributeur [...] Expert [...] Gebruiker
+  - *De bron beschrijft exact deze rollen, maar gebruikt 'Eigenaar' waar de claim 'Houder' zegt. Dat is een terminologisch verschil dat de claim gedeeltelijk tegenspreekt.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Rol BOMOS activiteit: Houder [...] Financier [...] Autorisator [...] Expert [...] Functioneel beheerder [...] Technisch beheerder [...] Distributeur [...] Gebruiker [...]
+
+### `ls-bomos-0024` — reference.md:86 *(§ Levensfasen van een Standaard)*
+
+> BOMOS onderscheidt vijf levensfasen voor een standaard: Creatie/Ontwikkeling, Introductie, Implementatie/Groei, Volwassenheid, en Uitfasering.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS levensfasen
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Figuur 3 Levensfases van een standaard 1. Creatie / ontwikkeling 2. Introductiefase van de standaard 3. Implementatie / groei van de standaard 4. Volwaardige toepassing / volwassenheid van de standaard 5. Uitfaseren / overgang naar een andere (versie van de) standaard
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron vermeldt nergens een onderverdeling in vijf levensfasen (Creatie/Ontwikkeling, Introductie, Implementatie/Groei, Volwassenheid, Uitfasering). Levenscyclus van standaarden wordt wel kort aangestipt maar de vijf genoemde fasen worden niet als zodanig benoemd.*
 
-### `ls-bomos-0022` — reference.md:54 *(§ 4. Implementatieondersteuning)*
-
-> Validatie en certificatie worden eerst intern toegepast, later publiek gemaakt. Naming & shaming kan worden overwogen als instrument.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** BOMOS implementatieondersteuning - Validatie en certificatie
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-bomos-0027` — reference.md:92 *(§ Levensfasen van een Standaard)*
+### `ls-bomos-0025` — reference.md:92 *(§ Levensfasen van een Standaard)*
 
 > De beheerorganisatie moet de activiteiten uit het activiteitenmodel aanpassen aan de huidige levensfase van de standaard.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS levensfasen
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > Het is dan ook als vuistregel verstandig om bij iedere overgang een controle (op basis van het Beheer- en Ontwikkelmodel) uit te voeren om te bepalen of uw beheerinrichting nog voldoet.
+  - *De bron formuleert dit als 'vuistregel' (aanbeveling), niet als harde must-vereiste. De claim gebruikt MUST, wat strenger is dan wat de bron zegt.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron bespreekt levenscyclus van standaarden en beheeractiviteiten, maar bevat geen expliciete MUST-norm dat activiteiten aangepast moeten worden aan de huidige levensfase.*
 
-### `ls-bomos-0028` — reference.md:96 *(§ Conformiteit)*
+### `ls-bomos-0026` — reference.md:96 *(§ Conformiteit)*
 
-> Een beheerorganisatie werkt conform BOMOS wanneer een beheerdocument is gepubliceerd dat alle componenten uit het BOMOS Activiteitendiagram beschrijft, inclusief een beschrijving van hoe elke activiteit wordt ingevuld.
+> Een beheerorganisatie werkt conform BOMOS wanneer een beheerdocument is gepubliceerd dat alle componenten uit het BOMOS Activiteitendiagram beschrijft.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS conformiteit
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > De beheerorganisatie werkt conform BOMOS als er een beheerdocument is gepubliceerd waarin de invulling van alle onderdelen uit het BOMOS Activiteitendiagram (het Beheer- en Ontwikkelmodel) zijn beschreven.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron beschrijft wel wat een beheerdocument kan inhouden (o.a. Geonovum voorbeeld), maar bevat geen expliciete conformiteitseis dat een beheerorganisatie 'conform BOMOS werkt' wanneer een beheerdocument alle componenten beschrijft.*
 
-### `ls-bomos-0029` — reference.md:96 *(§ Conformiteit)*
+### `ls-bomos-0028` — reference.md:107 *(§ Pressure Cooker Model)*
 
-> Het beheerdocument hoeft niet voor elk onderdeel uitgebreid te zijn; bij sommige activiteiten volstaat een bewuste keuze om deze (nog) niet in te vullen.
+> Het BOMOS Pressure Cooker Model beschrijft een versneld ontwikkelproces met een totale doorlooptijd van circa 2 maanden van initiatie tot governance.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** BOMOS conformiteit
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Pressure Cooker Model
 
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Na een werkgroepweek, met gemiddeld 15 deelnemers van zowel de afvalverwerkers en de leveranciers, waarin de standaarden stuk voor stuk zijn doorlopen, volgt twee weken van uitwerking door een externe begeleider, en vervolgens een twee weken review periode door de werkgroep voordat de standaard is opgeleverd aan de stuurgroep. Geteld vanaf de start van de werkgroep ligt er dan binnen 2 maanden ...
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Het 'Pressure Cooker Model' wordt niet beschreven in BOMOS-Fundament. Het wordt alleen kort in vogelvlucht aangestipt als onderdeel van Deel 2 (De Verdieping), zonder details over doorlooptijd.*
 
-### `ls-bomos-0031` — reference.md:102 *(§ Pressure Cooker Model)*
+### `ls-bomos-0029` — reference.md:102 *(§ Pressure Cooker Model)*
 
-> Het Pressure Cooker Model vereist minimaal 15 deelnemers voor de intensieve workshop van één week.
+> De intensieve workshop in het BOMOS Pressure Cooker Model duurt 1 week en heeft gemiddeld 15 deelnemers.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS Pressure Cooker Model
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Pressure Cooker Model
 
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > Na een werkgroepweek, met gemiddeld 15 deelnemers van zowel de afvalverwerkers en de leveranciers, waarin de standaarden stuk voor stuk zijn doorlopen
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
-  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+  - *De bron noemt het concept van de 'pressure cooker' kort in de context van snellere standaardiseringmethoden, maar geeft geen details over duur (1 week) of gemiddeld aantal deelnemers (15).*
+
+### `ls-bomos-0030` — reference.md:103 *(§ Pressure Cooker Model)*
+
+> In het BOMOS Pressure Cooker Model volgen na de intensieve workshop een expert-verfijningsfase van 2 weken en een community review van 2 weken.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Pressure Cooker Model
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  > volgt twee weken van uitwerking door een externe begeleider, en vervolgens een twee weken review periode door de werkgroep voordat de standaard is opgeleverd aan de stuurgroep.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *De bron noemt de pressure cooker methode maar beschrijft geen fasen, tijdlijnen of een expert-verfijningsfase en community review van elk 2 weken.*
+
+### `ls-bomos-0032` — reference.md:113 *(§ Praktijkvoorbeelden)*
+
+> Geonovum ontving in 2014 het predicaat 'uitstekend beheer' voor de manier waarop zij standaarden conform BOMOS beheren.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS praktijkvoorbeelden - Geonovum
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  > De geo-standaarden zijn opgenomen in de pas-toe-of-leg-uit-lijst van het Forum Standaardisatie, waarvoor wij in 2014 het predicaat uitstekend beheer ontvingen, mede omdat wij de geo-standaarden beheren conform BOMOS.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-## GROUNDED — minstens één bron ondersteunt de claim (3)
-
-<details>
-<summary>Klap uit voor alle GROUNDED claims</summary>
-
-### `ls-bomos-0006` — SKILL.md:47 *(§ Aanvullende modules en documenten (alleen werkversies))*
-
-> BOMOS-Aanvullende-Modules repository is gearchiveerd.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS aanvullende modules
-
-- **SUPPORTED** (high) — [https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules)
-  > This repository was archived by the owner on May 1, 2025. It is now read-only.
-<details><summary>14x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
-  - *De brontekst gaat over de BOMOS-LinkedData repository en vermeldt niets over een BOMOS-Aanvullende-Modules repository of dat deze gearchiveerd is.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-LinkedData](https://logius-standaarden.github.io/BOMOS-LinkedData)
-  - *De brontekst beschrijft de inhoud van de BOMOS LinkedData module maar maakt geen melding van archivering van een repository.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
-  - *De bron gaat uitsluitend over de BOMOS-OpenSource repository. Over een 'BOMOS-Aanvullende-Modules' repository staat niets in deze brontekst.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-OpenSource](https://logius-standaarden.github.io/BOMOS-OpenSource)
-  - *De brontekst bevat geen informatie over de BOMOS-Aanvullende-Modules repository of de archiefstatus ervan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels)
-  - *De brontekst gaat over de BOMOS-Stelsels repository en noemt wel de BOMOS aanvullende modules in de README, maar geeft geen informatie over archivering van een BOMOS-Aanvullende-Modules repository.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Stelsels](https://logius-standaarden.github.io/BOMOS-Stelsels)
-  - *De brontekst beschrijft de inhoud van de BOMOS Stelsels module maar maakt geen melding van archivering van een BOMOS-Aanvullende-Modules repository.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Beheermodel](https://github.com/logius-standaarden/BOMOS-Beheermodel)
-  - *De brontekst vermeldt de BOMOS-Aanvullende-Modules repository niet. Er worden wel aanvullende modules genoemd (Stelsels, Linked Data), maar niets over archivering van een aparte repository.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Beheermodel](https://logius-standaarden.github.io/BOMOS-Beheermodel)
-  - *De brontekst bevat geen informatie over een 'BOMOS-Aanvullende-Modules' repository of de archiveringsstatus daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
-  - *De brontekst gaat over de BOMOS-voorbeeld-beheermodel repository. Er is geen informatie over een BOMOS-Aanvullende-Modules repository of de archiefstatus daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel](https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel)
-  - *De brontekst beschrijft het BOMOS voorbeeld-beheermodel van Logius maar bevat geen informatie over de BOMOS-Aanvullende-Modules repository of de archiveringsstatus daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Community](https://github.com/logius-standaarden/BOMOS-Community)
-  - *De brontekst (BOMOS-Community repository pagina) bevat geen informatie over de BOMOS-Aanvullende-Modules repository of de archiefstatus ervan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Community](https://logius-standaarden.github.io/BOMOS-Community)
-  - *De brontekst gaat uitsluitend over de BOMOS Community (aanmelden, events, bijeenkomsten). Er is geen informatie over de BOMOS-Aanvullende-Modules repository of archiveringsstatus.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Logius-Beheermodel](https://github.com/logius-standaarden/Logius-Beheermodel)
-  - *De brontekst betreft de Logius-Beheermodel template repository. Er is geen informatie over de BOMOS-Aanvullende-Modules repository of de archiefstatus daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Logius-Beheermodel](https://logius-standaarden.github.io/Logius-Beheermodel)
-  - *De aangeleverde brontekst bevat alleen een samenvatting-placeholder en contributors-sectie zonder inhoudelijke informatie over de BOMOS-Aanvullende-Modules repository.*
-</details>
-
-### `ls-bomos-0008` — SKILL.md:49 *(§ Aanvullende modules en documenten (alleen werkversies))*
-
-> BOMOS-OpenSource is gepubliceerd onder licentie CC0-1.0.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-OpenSource module
-
-- **SUPPORTED** (high) — [https://logius-standaarden.github.io/BOMOS-OpenSource](https://logius-standaarden.github.io/BOMOS-OpenSource)
-  > Dit document valt onder de volgende licentie: Creative Commons 0 Public Domain Dedication
-  - *CC0 Public Domain Dedication komt overeen met de CC0-1.0 licentie.*
-<details><summary>14x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules)
-  - *De brontekst bevat geen informatie over licenties. CC0-1.0 wordt nergens vermeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
-  - *De brontekst vermeldt niets over BOMOS-OpenSource of de licentie CC0-1.0. De BOMOS-LinkedData repository zelf gebruikt CC-BY-4.0.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-LinkedData](https://logius-standaarden.github.io/BOMOS-LinkedData)
-  - *De brontekst vermeldt als licentie 'Creative Commons Attribution 4.0 International Public License' voor dit document, maar behandelt BOMOS-OpenSource niet. De CC0-1.0 claim kan niet worden getoetst aan deze bron.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
-  - *De bron vermeldt dat er een LICENSE-bestand aanwezig is ('View license') maar noemt nergens expliciet CC0-1.0. De licentienaam is niet leesbaar in de aangeleverde tekst.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels)
-  - *De brontekst vermeldt BOMOS-OpenSource niet en geeft geen licentie-informatie over die module. De BOMOS-Stelsels repository zelf gebruikt CC-BY-4.0, niet CC0-1.0.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Stelsels](https://logius-standaarden.github.io/BOMOS-Stelsels)
-  - *De brontekst vermeldt als licentie 'Creative Commons Attribution 4.0 International Public License' voor dit document, maar spreekt nergens over een BOMOS-OpenSource module of een CC0-1.0 licentie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Beheermodel](https://github.com/logius-standaarden/BOMOS-Beheermodel)
-  - *De brontekst vermeldt de licentie van de BOMOS-Beheermodel repository (CC-BY-4.0), maar noemt BOMOS-OpenSource noch CC0-1.0.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Beheermodel](https://logius-standaarden.github.io/BOMOS-Beheermodel)
-  - *De brontekst vermeldt alleen de CC BY 4.0 licentie voor BOMOS zelf. Er is geen vermelding van een BOMOS-OpenSource module of CC0-1.0 licentie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
-  - *De brontekst gaat over de BOMOS-voorbeeld-beheermodel repository, die onder CC-BY-4.0 valt. Er is geen informatie over een BOMOS-OpenSource repository of een CC0-1.0 licentie daarvoor.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel](https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel)
-  - *De brontekst noemt de CC0-1.0 licentie niet. Wel wordt een Creative Commons Attribution 4.0 licentie vermeld, maar dit betreft de xxx-standaard en het beheermodel zelf, niet de BOMOS-OpenSource module.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Community](https://github.com/logius-standaarden/BOMOS-Community)
-  - *De brontekst bevat geen informatie over licenties van BOMOS-OpenSource of enige andere repository.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Community](https://logius-standaarden.github.io/BOMOS-Community)
-  - *De brontekst bevat geen informatie over licenties of publicatiedetails van BOMOS-OpenSource.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Logius-Beheermodel](https://github.com/logius-standaarden/Logius-Beheermodel)
-  - *De brontekst vermeldt geen licentie-informatie voor BOMOS-OpenSource. De Logius-Beheermodel repository zelf gebruikt CC-BY-4.0, maar dat betreft een andere repository.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Logius-Beheermodel](https://logius-standaarden.github.io/Logius-Beheermodel)
-  - *De aangeleverde brontekst bevat geen informatie over de licentie van BOMOS-OpenSource.*
-</details>
-
-### `ls-bomos-0011` — SKILL.md:84 *(§ Beheermodel Template)*
-
-> Een BOMOS-conform beheermodel bevat minimaal de secties: Strategie, Tactiek, Operationeel, Implementatieondersteuning en Communicatie.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS beheermodel template
-
-- **SUPPORTED** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
-  > De bestandslijst toont: ch02_Strategie.md, ch03_Tactiek.md, ch04_Operationeel.md, ch05_Implementatieondersteuning.md, ch06_Communicatie.md
-  - *De repository bevat expliciet hoofdstukken voor alle vijf genoemde secties (Strategie, Tactiek, Operationeel, Implementatieondersteuning, Communicatie), wat bevestigt dat een BOMOS-conform beheermodel deze secties bevat.*
+  - *De bron vermeldt Geonovum meerdere keren als voorbeeld, maar bevat geen verwijzing naar een predicaat 'uitstekend beheer' in 2014.*
 
 </details>

--- a/skills/ls-bomos/audit.md
+++ b/skills/ls-bomos/audit.md
@@ -1,0 +1,537 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-bomos — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 20 | 56% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 3 | 8% |
+| UNGROUNDED | 10 | 28% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 3 | 8% |
+
+*Geverifieerd met sonnet, 20 calls, $1.3351.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (20)
+
+### `ls-bomos-0001` — SKILL.md:32 *(§ Versiemodel)*
+
+> BOMOS staat niet op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS - Beheer- en Ontwikkelmodel voor Open Standaarden
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v3.0.2') en geen inhoudelijke tekst over BOMOS of de pas-toe-of-leg-uit-lijst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v3.1.0') en geen inhoudelijke tekst. Niet te verifiëren.*
+
+### `ls-bomos-0002` — SKILL.md:32 *(§ Versiemodel)*
+
+> BOMOS is een raamwerk voor het beheren van open standaarden, geen interoperabiliteitsstandaard.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS - Beheer- en Ontwikkelmodel voor Open Standaarden
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0003` — SKILL.md:27 *(§ Versiemodel)*
+
+> BOMOS kent twee publicatiekanalen: een vastgestelde versie (DEF) op gitdocumentatie.logius.nl en een werkversie (draft) op logius-standaarden.github.io.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS versiemodel
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0009` — SKILL.md:58 *(§ Wijzigingsbeheer Workflow)*
+
+> De RFC-procedure (Request for Change) is het kernproces voor wijzigingsbeheer in BOMOS.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS wijzigingsbeheer
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0010` — SKILL.md:80 *(§ Wijzigingsbeheer Workflow)*
+
+> Het RFC-proces verloopt via de stappen: RFC indienen → Community review → Expert beoordeling → Autorisator besluit → Implementatie → Publicatie nieuwe versie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS RFC-procedure
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0013` — reference.md:7 *(§ Het BOMOS Activiteitenmodel)*
+
+> Het BOMOS activiteitenmodel beschrijft vijf hoofdlagen: Strategie, Tactiek, Operationeel, Implementatieondersteuning en Communicatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS activiteitenmodel
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0014` — reference.md:13 *(§ 1. Strategie)*
+
+> De strategielaag van BOMOS bevat drie activiteiten: Governance, Visie en Financiering. De verantwoordelijke rollen zijn Eigenaar en Financier.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS strategielaag
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0015` — reference.md:23 *(§ 2. Tactiek)*
+
+> De tactieklaag van BOMOS bevat zeven activiteiten: Architectuur, Specificatiebeheer, Wijzigingsbeheer, Adoptiestrategie, Kwaliteitsbeleid, Rechtenmanagement en Community. De verantwoordelijke rol is Autorisator.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS tactieklaag
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0016` — reference.md:37 *(§ 3. Operationeel)*
+
+> De operationele laag van BOMOS bevat zes activiteiten: Initiatie, Wensen en eisen verzamelen, Ontwikkeling, Uitvoering, Documentatie en Klachtenafhandeling. De verantwoordelijke rollen zijn Functioneel Beheerder en Technisch Beheerder.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS operationele laag
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0017` — reference.md:50 *(§ 4. Implementatieondersteuning)*
+
+> De implementatieondersteuningslaag van BOMOS bevat vijf activiteiten: Helpdesk, Opleidingen, Open source modules, Pilots en Validatie en certificatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS implementatieondersteuning
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0023` — reference.md:60 *(§ 5. Communicatie)*
+
+> De communicatielaag van BOMOS bevat twee activiteiten: Promotie en Publicatie. De verantwoordelijke rol is Distributeur.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS communicatielaag
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0024` — reference.md:67 *(§ Rollen en Verantwoordelijkheden)*
+
+> BOMOS definieert acht rollen: Eigenaar, Financier, Autorisator, Functioneel Beheerder, Technisch Beheerder, Distributeur, Expert en Gebruiker.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS rollenmodel
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0025` — reference.md:80 *(§ Rollen en Verantwoordelijkheden)*
+
+> Een persoon kan meerdere BOMOS-rollen vervullen, en een rol kan door meerdere personen worden ingevuld.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS rollenmodel
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0026` — reference.md:86 *(§ Levensfasen van een Standaard)*
+
+> BOMOS onderscheidt vijf levensfasen van een standaard: Creatie/Ontwikkeling, Introductie, Implementatie/Groei, Volwassenheid en Uitfasering.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS levensfasen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0030` — reference.md:107 *(§ Pressure Cooker Model)*
+
+> Het BOMOS Pressure Cooker Model heeft een totale doorlooptijd van circa 2 maanden van initiatie tot governance.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Pressure Cooker Model
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0032` — reference.md:101 *(§ Pressure Cooker Model)*
+
+> Het Pressure Cooker Model bestaat uit vier stappen: intensieve workshop (1 week), expert-verfijning (2 weken), community review (2 weken), en afronding en governance.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Pressure Cooker Model
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0033` — reference.md:113 *(§ Geonovum)*
+
+> Geonovum ontving in 2014 het predicaat 'uitstekend beheer' voor de manier waarop zij hun standaarden conform BOMOS beheren.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS praktijkvoorbeelden - Geonovum
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0034` — reference.md:117 *(§ TOOI - Thesaurus en Ontologie voor OverheidsInformatie)*
+
+> TOOI (Thesaurus en Ontologie voor OverheidsInformatie) gebruikt BOMOS als basis voor hun beheerplan en beschrijft per BOMOS-activiteit hoe deze wordt ingevuld.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS praktijkvoorbeelden - TOOI
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0035` — reference.md:121 *(§ Linked Data Module)*
+
+> De Linked Data module behandelt URI-strategie, versiebeheer van ontologieën, en publicatie als Linked Data.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Linked Data Module
+
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
+  - *De brontekst is de GitHub-pagina van BOMOS-LinkedData en beschrijft de module slechts als 'aanvullende module met BOMOS aspecten die specifiek over linked data gaan'. Inhoudelijke onderwerpen zoals URI-strategie, versiebeheer van ontologieën en publicatie als Linked Data worden niet concreet vermeld in de aangeleverde brontekst.*
+
+### `ls-bomos-0036` — reference.md:127 *(§ Open Source Module)*
+
+> De Open Source module beschrijft governance voor open source componenten die bij standaarden horen, waaronder licentiekeuze, contributor agreements en beheer van referentie-implementaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Open Source Module
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
+  - *De brontekst beschrijft alleen globaal het doel van BOMOS-OpenSource ('open source code open beheerd kan worden') maar gaat niet in op specifieke onderwerpen als licentiekeuze, contributor agreements of beheer van referentie-implementaties.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (3)
+
+### `ls-bomos-0004` — SKILL.md:40 *(§ Kerndocumenten (met vastgestelde versies))*
+
+> BOMOS-Fundament v3.0.2 is gepubliceerd op gitdocumentatie.logius.nl/publicatie/bomos/fundament/ onder licentie CC-BY-4.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-Fundament repository
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament)
+  > LICENSE CC-BY-4.0 license ... Beheermodel voor het Beheer- en Ontwikkelmodel Open Standaarden (BOMOS) ... BOMOS Fundament beschrijft de basis en achtergronden van BOMOS.
+  - *De bron bevestigt de CC-BY-4.0 licentie voor de BOMOS-Fundament repository. De gepubliceerde URL in de claim (gitdocumentatie.logius.nl/publicatie/bomos/fundament/) wordt niet genoemd; de bron vermeldt 'logius-standaarden.github.io/BOMOS-Fundament/' als URL. Het versienummer v3.0.2 komt niet voor in de brontekst.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/BOMOS-Fundament](https://logius-standaarden.github.io/BOMOS-Fundament)
+  - *Bron status: unsupported*
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping)
+  - *De brontekst gaat over de BOMOS-Verdieping repository. Er is geen informatie over BOMOS-Fundament v3.0.2 of de publicatie-URL gitdocumentatie.logius.nl/publicatie/bomos/fundament/ in de bron. De CC-BY-4.0 licentie wordt wel vermeld, maar niet in relatie tot BOMOS-Fundament of een versienummer.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Verdieping](https://logius-standaarden.github.io/BOMOS-Verdieping)
+  - *De brontekst gaat over BOMOS-Verdieping, niet over BOMOS-Fundament. Er is geen informatie over het Fundament v3.0.2 in deze bron.*
+</details>
+
+### `ls-bomos-0005` — SKILL.md:41 *(§ Kerndocumenten (met vastgestelde versies))*
+
+> BOMOS-Verdieping v3.1.0 is gepubliceerd op gitdocumentatie.logius.nl/publicatie/bomos/verdieping/ onder licentie CC-BY-4.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-Verdieping repository
+
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/BOMOS-Fundament](https://logius-standaarden.github.io/BOMOS-Fundament)
+  - *Bron status: unsupported*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/logius-standaarden/BOMOS-Verdieping](https://github.com/logius-standaarden/BOMOS-Verdieping)
+  > CC-BY-4.0 license [...] De gepubliceerde (vastgestelde) versie staat online: Vastgestelde versie 07 juni 2022 De ontwikkelversie van dit document staat online: Dynamische pagina (actueel)
+  - *De bron bevestigt dat BOMOS-Verdieping onder CC-BY-4.0 licentie valt. De specifieke versie v3.1.0 en de URL gitdocumentatie.logius.nl/publicatie/bomos/verdieping/ worden niet expliciet vermeld. De publicatie-URL in de bron verwijst naar logius-standaarden.github.io/BOMOS-Verdieping/, niet naar gitdocumentatie.logius.nl.*
+- **PARTIALLY_SUPPORTED** (high) — [https://logius-standaarden.github.io/BOMOS-Verdieping](https://logius-standaarden.github.io/BOMOS-Verdieping)
+  > Deze versie: https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping/3.1.0/ [...] Dit document valt onder de volgende licentie: Creative Commons Attribution 4.0 International Public License
+  - *De bron bevestigt versie 3.1.0 en de CC-BY-4.0 licentie. De URL 'gitdocumentatie.logius.nl/publicatie/bomos/verdieping/' wordt genoemd als 'Laatst gepubliceerde versie', wat de claim ondersteunt. De afkorting 'CC-BY-4.0' staat niet letterlijk in de bron maar 'Creative Commons Attribution 4.0 International Public License' is equivalent. Volledig SUPPORTED zou ook verdedigbaar zijn, maar de claim specificeert een korte URL zonder versienummer als publicatielocatie terwijl de bron die URL als 'Laatst gepubliceerde versie' aanduidt, niet als primaire URL van v3.1.0.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Fundament](https://github.com/logius-standaarden/BOMOS-Fundament)
+  - *De bron gaat over de BOMOS-Fundament repository. BOMOS-Verdieping wordt wel genoemd als apart document, maar de claim over versienummer v3.1.0, de specifieke URL en de licentie voor BOMOS-Verdieping worden niet behandeld in deze brontekst. OUT_OF_SCOPE zou ook passend zijn, maar de bron noemt Verdieping zijdelings zonder er verdere details over te geven.*
+</details>
+
+### `ls-bomos-0007` — SKILL.md:49 *(§ Aanvullende modules en documenten (alleen werkversies))*
+
+> BOMOS-OpenSource repository is gearchiveerd en de draft-versie is bevroren.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-OpenSource module
+
+- **PARTIALLY_SUPPORTED** (high) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
+  > This repository was archived by the owner on Aug 28, 2025. It is now read-only.
+  - *De bron bevestigt dat de repository gearchiveerd is. De claim dat de 'draft-versie is bevroren' wordt niet expliciet vermeld; archivering impliceert read-only maar de bron spreekt niet van een draft-versie of bevriezing daarvan.*
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules)
+  - *De brontekst gaat over de BOMOS-Aanvullende-Modules repository, niet over een aparte BOMOS-OpenSource repository. Er is geen informatie over archivering of bevriezing van een draft-versie van BOMOS-OpenSource.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
+  - *De brontekst vermeldt niets over een BOMOS-OpenSource repository, archivering of bevroren draft-versie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-LinkedData](https://logius-standaarden.github.io/BOMOS-LinkedData)
+  - *De brontekst gaat over BOMOS LinkedData, niet over een BOMOS-OpenSource module of repository. Geen enkele vermelding van archivering of bevroren drafts.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-OpenSource](https://logius-standaarden.github.io/BOMOS-OpenSource)
+  - *De brontekst bevat geen informatie over de archiefstatus van de BOMOS-OpenSource repository of het bevriezen van een draft-versie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels)
+  - *De brontekst vermeldt BOMOS-OpenSource niet. Er is geen informatie over archivering of bevriezing van die repository.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Stelsels](https://logius-standaarden.github.io/BOMOS-Stelsels)
+  - *De brontekst bevat geen informatie over een BOMOS-OpenSource repository, archivering daarvan, of het bevriezen van een draft-versie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Beheermodel](https://github.com/logius-standaarden/BOMOS-Beheermodel)
+  - *De brontekst maakt geen melding van de BOMOS-OpenSource repository of archivering/bevriezing daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Beheermodel](https://logius-standaarden.github.io/BOMOS-Beheermodel)
+  - *De brontekst bevat geen informatie over een 'BOMOS-OpenSource' repository, archiveringsstatus of bevroren draft-versie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
+  - *De brontekst gaat over de BOMOS-voorbeeld-beheermodel repository. Er is geen informatie over een BOMOS-OpenSource repository of de archiefstatus/bevriezing daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel](https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel)
+  - *De brontekst maakt geen melding van de BOMOS-OpenSource repository, archivering daarvan, of het bevriezen van een draft-versie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Community](https://github.com/logius-standaarden/BOMOS-Community)
+  - *De brontekst bevat geen informatie over de BOMOS-OpenSource repository, de archiefstatus ervan, of de status van een draft-versie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Community](https://logius-standaarden.github.io/BOMOS-Community)
+  - *De brontekst behandelt de BOMOS Community en events. Er is geen informatie over de BOMOS-OpenSource repository of de archiveringstatus en bevriezing van een draft-versie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Logius-Beheermodel](https://github.com/logius-standaarden/Logius-Beheermodel)
+  - *De brontekst bevat geen informatie over de BOMOS-OpenSource repository, de archiefstatus ervan, of een bevroren draft-versie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Logius-Beheermodel](https://logius-standaarden.github.io/Logius-Beheermodel)
+  - *De aangeleverde brontekst bevat geen informatie over de BOMOS-OpenSource repository of de status daarvan.*
+</details>
+
+## UNGROUNDED — geen bron ondersteunt de claim (10)
+
+### `ls-bomos-0012` — SKILL.md:181 *(§ BOMOS Conformiteit Checklist)*
+
+> Een organisatie werkt conform BOMOS wanneer voor elke activiteit een bewuste beschrijving is opgenomen, ook als die beschrijving is: 'deze activiteit vullen wij (nog) niet in.'
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS conformiteit
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0018` — reference.md:48 *(§ 4. Implementatieondersteuning)*
+
+> Bij implementatieondersteuning is het cruciaal om een balans te vinden tussen activiteiten van de beheerorganisatie en die van commerciële partijen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** BOMOS implementatieondersteuning
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0019` — reference.md:50 *(§ 4. Implementatieondersteuning)*
+
+> Een helpdesk is een minimale ondersteuning voor implementatievragen die altijd nodig is (laagdrempelig).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS implementatieondersteuning - Helpdesk
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0020` — reference.md:51 *(§ 4. Implementatieondersteuning)*
+
+> Opleidingen bij standaardenbeheer mogen niet concurreren met de markt; ze worden alleen aangeboden waar de markt niet voorziet.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD_NOT  ·  **Scope:** BOMOS implementatieondersteuning - Opleidingen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0021` — reference.md:52 *(§ 4. Implementatieondersteuning)*
+
+> Open source modules worden alleen ingezet bij geconstateerde implementatieproblemen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** BOMOS implementatieondersteuning - Open source modules
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0022` — reference.md:54 *(§ 4. Implementatieondersteuning)*
+
+> Validatie en certificatie worden eerst intern toegepast, later publiek gemaakt. Naming & shaming kan worden overwogen als instrument.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** BOMOS implementatieondersteuning - Validatie en certificatie
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0027` — reference.md:92 *(§ Levensfasen van een Standaard)*
+
+> De beheerorganisatie moet de activiteiten uit het activiteitenmodel aanpassen aan de huidige levensfase van de standaard.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS levensfasen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0028` — reference.md:96 *(§ Conformiteit)*
+
+> Een beheerorganisatie werkt conform BOMOS wanneer een beheerdocument is gepubliceerd dat alle componenten uit het BOMOS Activiteitendiagram beschrijft, inclusief een beschrijving van hoe elke activiteit wordt ingevuld.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS conformiteit
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0029` — reference.md:96 *(§ Conformiteit)*
+
+> Het beheerdocument hoeft niet voor elk onderdeel uitgebreid te zijn; bij sommige activiteiten volstaat een bewuste keuze om deze (nog) niet in te vullen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** BOMOS conformiteit
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-bomos-0031` — reference.md:102 *(§ Pressure Cooker Model)*
+
+> Het Pressure Cooker Model vereist minimaal 15 deelnemers voor de intensieve workshop van één week.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS Pressure Cooker Model
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/fundament](https://gitdocumentatie.logius.nl/publicatie/bomos/fundament)
+  - *Brontekst is leeg/onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping](https://gitdocumentatie.logius.nl/publicatie/bomos/verdieping)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+## GROUNDED — minstens één bron ondersteunt de claim (3)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-bomos-0006` — SKILL.md:47 *(§ Aanvullende modules en documenten (alleen werkversies))*
+
+> BOMOS-Aanvullende-Modules repository is gearchiveerd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS aanvullende modules
+
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules)
+  > This repository was archived by the owner on May 1, 2025. It is now read-only.
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
+  - *De brontekst gaat over de BOMOS-LinkedData repository en vermeldt niets over een BOMOS-Aanvullende-Modules repository of dat deze gearchiveerd is.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-LinkedData](https://logius-standaarden.github.io/BOMOS-LinkedData)
+  - *De brontekst beschrijft de inhoud van de BOMOS LinkedData module maar maakt geen melding van archivering van een repository.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
+  - *De bron gaat uitsluitend over de BOMOS-OpenSource repository. Over een 'BOMOS-Aanvullende-Modules' repository staat niets in deze brontekst.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-OpenSource](https://logius-standaarden.github.io/BOMOS-OpenSource)
+  - *De brontekst bevat geen informatie over de BOMOS-Aanvullende-Modules repository of de archiefstatus ervan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels)
+  - *De brontekst gaat over de BOMOS-Stelsels repository en noemt wel de BOMOS aanvullende modules in de README, maar geeft geen informatie over archivering van een BOMOS-Aanvullende-Modules repository.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Stelsels](https://logius-standaarden.github.io/BOMOS-Stelsels)
+  - *De brontekst beschrijft de inhoud van de BOMOS Stelsels module maar maakt geen melding van archivering van een BOMOS-Aanvullende-Modules repository.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Beheermodel](https://github.com/logius-standaarden/BOMOS-Beheermodel)
+  - *De brontekst vermeldt de BOMOS-Aanvullende-Modules repository niet. Er worden wel aanvullende modules genoemd (Stelsels, Linked Data), maar niets over archivering van een aparte repository.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Beheermodel](https://logius-standaarden.github.io/BOMOS-Beheermodel)
+  - *De brontekst bevat geen informatie over een 'BOMOS-Aanvullende-Modules' repository of de archiveringsstatus daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
+  - *De brontekst gaat over de BOMOS-voorbeeld-beheermodel repository. Er is geen informatie over een BOMOS-Aanvullende-Modules repository of de archiefstatus daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel](https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel)
+  - *De brontekst beschrijft het BOMOS voorbeeld-beheermodel van Logius maar bevat geen informatie over de BOMOS-Aanvullende-Modules repository of de archiveringsstatus daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Community](https://github.com/logius-standaarden/BOMOS-Community)
+  - *De brontekst (BOMOS-Community repository pagina) bevat geen informatie over de BOMOS-Aanvullende-Modules repository of de archiefstatus ervan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Community](https://logius-standaarden.github.io/BOMOS-Community)
+  - *De brontekst gaat uitsluitend over de BOMOS Community (aanmelden, events, bijeenkomsten). Er is geen informatie over de BOMOS-Aanvullende-Modules repository of archiveringsstatus.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Logius-Beheermodel](https://github.com/logius-standaarden/Logius-Beheermodel)
+  - *De brontekst betreft de Logius-Beheermodel template repository. Er is geen informatie over de BOMOS-Aanvullende-Modules repository of de archiefstatus daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Logius-Beheermodel](https://logius-standaarden.github.io/Logius-Beheermodel)
+  - *De aangeleverde brontekst bevat alleen een samenvatting-placeholder en contributors-sectie zonder inhoudelijke informatie over de BOMOS-Aanvullende-Modules repository.*
+</details>
+
+### `ls-bomos-0008` — SKILL.md:49 *(§ Aanvullende modules en documenten (alleen werkversies))*
+
+> BOMOS-OpenSource is gepubliceerd onder licentie CC0-1.0.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS-OpenSource module
+
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/BOMOS-OpenSource](https://logius-standaarden.github.io/BOMOS-OpenSource)
+  > Dit document valt onder de volgende licentie: Creative Commons 0 Public Domain Dedication
+  - *CC0 Public Domain Dedication komt overeen met de CC0-1.0 licentie.*
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules](https://github.com/logius-standaarden/BOMOS-Aanvullende-Modules)
+  - *De brontekst bevat geen informatie over licenties. CC0-1.0 wordt nergens vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-LinkedData](https://github.com/logius-standaarden/BOMOS-LinkedData)
+  - *De brontekst vermeldt niets over BOMOS-OpenSource of de licentie CC0-1.0. De BOMOS-LinkedData repository zelf gebruikt CC-BY-4.0.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-LinkedData](https://logius-standaarden.github.io/BOMOS-LinkedData)
+  - *De brontekst vermeldt als licentie 'Creative Commons Attribution 4.0 International Public License' voor dit document, maar behandelt BOMOS-OpenSource niet. De CC0-1.0 claim kan niet worden getoetst aan deze bron.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/BOMOS-OpenSource](https://github.com/logius-standaarden/BOMOS-OpenSource)
+  - *De bron vermeldt dat er een LICENSE-bestand aanwezig is ('View license') maar noemt nergens expliciet CC0-1.0. De licentienaam is niet leesbaar in de aangeleverde tekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Stelsels](https://github.com/logius-standaarden/BOMOS-Stelsels)
+  - *De brontekst vermeldt BOMOS-OpenSource niet en geeft geen licentie-informatie over die module. De BOMOS-Stelsels repository zelf gebruikt CC-BY-4.0, niet CC0-1.0.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Stelsels](https://logius-standaarden.github.io/BOMOS-Stelsels)
+  - *De brontekst vermeldt als licentie 'Creative Commons Attribution 4.0 International Public License' voor dit document, maar spreekt nergens over een BOMOS-OpenSource module of een CC0-1.0 licentie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Beheermodel](https://github.com/logius-standaarden/BOMOS-Beheermodel)
+  - *De brontekst vermeldt de licentie van de BOMOS-Beheermodel repository (CC-BY-4.0), maar noemt BOMOS-OpenSource noch CC0-1.0.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Beheermodel](https://logius-standaarden.github.io/BOMOS-Beheermodel)
+  - *De brontekst vermeldt alleen de CC BY 4.0 licentie voor BOMOS zelf. Er is geen vermelding van een BOMOS-OpenSource module of CC0-1.0 licentie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
+  - *De brontekst gaat over de BOMOS-voorbeeld-beheermodel repository, die onder CC-BY-4.0 valt. Er is geen informatie over een BOMOS-OpenSource repository of een CC0-1.0 licentie daarvoor.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel](https://logius-standaarden.github.io/BOMOS-voorbeeld-beheermodel)
+  - *De brontekst noemt de CC0-1.0 licentie niet. Wel wordt een Creative Commons Attribution 4.0 licentie vermeld, maar dit betreft de xxx-standaard en het beheermodel zelf, niet de BOMOS-OpenSource module.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/BOMOS-Community](https://github.com/logius-standaarden/BOMOS-Community)
+  - *De brontekst bevat geen informatie over licenties van BOMOS-OpenSource of enige andere repository.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/BOMOS-Community](https://logius-standaarden.github.io/BOMOS-Community)
+  - *De brontekst bevat geen informatie over licenties of publicatiedetails van BOMOS-OpenSource.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Logius-Beheermodel](https://github.com/logius-standaarden/Logius-Beheermodel)
+  - *De brontekst vermeldt geen licentie-informatie voor BOMOS-OpenSource. De Logius-Beheermodel repository zelf gebruikt CC-BY-4.0, maar dat betreft een andere repository.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Logius-Beheermodel](https://logius-standaarden.github.io/Logius-Beheermodel)
+  - *De aangeleverde brontekst bevat geen informatie over de licentie van BOMOS-OpenSource.*
+</details>
+
+### `ls-bomos-0011` — SKILL.md:84 *(§ Beheermodel Template)*
+
+> Een BOMOS-conform beheermodel bevat minimaal de secties: Strategie, Tactiek, Operationeel, Implementatieondersteuning en Communicatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** BOMOS beheermodel template
+
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel](https://github.com/logius-standaarden/BOMOS-voorbeeld-beheermodel)
+  > De bestandslijst toont: ch02_Strategie.md, ch03_Tactiek.md, ch04_Operationeel.md, ch05_Implementatieondersteuning.md, ch06_Communicatie.md
+  - *De repository bevat expliciet hoofdstukken voor alle vijf genoemde secties (Strategie, Tactiek, Operationeel, Implementatieondersteuning, Communicatie), wat bevestigt dat een BOMOS-conform beheermodel deze secties bevat.*
+
+</details>

--- a/skills/ls-dk/audit.md
+++ b/skills/ls-dk/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-dk — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,2406 +7,1489 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 9 | 18% |
-| CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 11 | 22% |
-| UNGROUNDED | 5 | 10% |
+| UNSUPPORTED_ASSERTION | 7 | 13% |
+| CONTRADICTED | 3 | 5% |
+| PARTIALLY_GROUNDED | 10 | 18% |
+| UNGROUNDED | 1 | 2% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
-| KNOWN_DISCREPANCY | 3 | 6% |
-| GROUNDED | 22 | 44% |
+| KNOWN_DISCREPANCY | 2 | 4% |
+| GROUNDED | 32 | 58% |
 
-*Geverifieerd met sonnet, 44 calls, $5.0213.*
+*Geverifieerd met sonnet, 27 calls, $3.6773.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (9)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (7)
 
-### `ls-dk-0003` — SKILL.md:41 *(§ Repositories)*
+### `ls-dk-0006` — SKILL.md:43 *(§ Repositories)*
 
-> Digikoppeling-Koppelvlakstandaard-REST-API is vastgesteld als v4.0.0.
+> Digikoppeling-Koppelvlakstandaard-WUS is vastgesteld als v3.8.1.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
 
-<details><summary>27x NOT_FOUND (klap uit)</summary>
+<details><summary>8x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+  - *De bron verwijst naar de Digikoppeling Koppelvlakstandaard WUS maar noemt geen versienummer v3.8.1.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding. Geen inhoud over versienummers van de REST-API koppelvlakstandaard.*
+  - *De bron behandelt de REST-API koppelvlakstandaard; het versienummer van de WUS-standaard wordt niet vermeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst gaat over ebMS2, niet over de REST-API koppelvlakstandaard. Versienummer v4.0.0 wordt niet vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Versie-informatie over de REST-API koppelvlakstandaard staat niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron noemt REST-API als voorbeeld van een koppelvlakspecificatie maar geeft geen versienummers van specifieke standaarden.*
+  - *De bron vermeldt geen versienummer voor de WUS koppelvlakstandaard.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  - *De brontekst bevat geen versie-informatie over de WUS koppelvlakstandaard.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
-  - *De bron vermeldt de REST-API koppelvlakstandaard als bestaand document maar noemt geen versienummer.*
+  - *De bron vermeldt de WUS koppelvlakstandaard als gerelateerd document maar geeft geen versienummer.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De brontekst toont alleen de GitHub repository-pagina met releases (de latest is '1.1.1 release' van Dec 9, 2022) en vermeldt geen versienummer v4.0.0. De getoonde releaseinfo suggereert eerder v1.1.1 als laatste release, maar de brontekst bevat geen volledige releaselijst. Geen vermelding van v4.0.0.*
+  - *De bron betreft uitsluitend de REST-API koppelvlakstandaard repository. Informatie over de WUS koppelvlakstandaard staat niet in deze bron.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron is de werkversie van de REST-API koppelvlakstandaard maar noemt geen versienummer v4.0.0. De status is 'werkversie 25 maart 2026', geen vastgestelde versie.*
+  - *De brontekst bevat geen informatie over versienummers van de WUS koppelvlakstandaard.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over de REST-API koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De bron vermeldt in de documentbeheer-tabel versie 3.3.2 als meest recente ebMS2-versie en noemt het REST-API koppelvlak alleen terloops (versie 3.3.1: 'Vermelding REST-API koppelvlak'), maar geeft geen versienummer v4.0.0 voor de REST-API standaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over de REST-API koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst vermeldt het bestaan van een REST-API koppelvlak maar geeft geen versienummer. Er staat alleen: 'Naast de Koppelvlakstandaard WUS zijn er ook de ebMS2- en REST-API-standaarden.' Geen versie-informatie aanwezig.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over de REST-API koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron vermeldt geen versienummer van de REST-API koppelvlakstandaard. Er is slechts een noot dat Digikoppeling ook een REST API profiel kent.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over de REST-API koppelvlakstandaard of diens versienummer.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron behandelt beveiligingsstandaarden en verwijst niet naar de REST-API koppelvlakstandaard of enig versienummer daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over de REST-API koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De bron vermeldt de REST-API koppelvlakstandaard slechts zijdelings ('Vermelding REST-API koppelvlak' in documentbeheer), maar geeft geen versienummer v4.0.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
-  - *De brontekst bevat geen informatie over de REST-API koppelvlakstandaard of versienummers.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
-  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Koppelvlakstandaard-REST-API wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
-  - *De brontekst bevat geen informatie over versienummers van de REST-API koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
-  - *De REST API koppelvlakstandaard wordt wel genoemd als voorbeeld van een toevoeging aan Digikoppeling, maar geen versienummer wordt vermeld in deze bron.*
+  - *De bron gaat over ebMS2, niet over de WUS koppelvlakstandaard.*
 </details>
 
-### `ls-dk-0007` — SKILL.md:45 *(§ Repositories)*
-
-> Digikoppeling-Beveiligingsstandaarden-en-voorschriften is vastgesteld als v3.0.0.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling beveiligingsstandaarden
-
-<details><summary>27x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst verwijst naar Digikoppeling Beveiligingsstandaarden en voorschriften als referentie maar noemt geen versienummer v3.0.0.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Versie-informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften staat niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Beveiligingsstandaarden wordt kort aangehaald als toegevoegd document maar zonder versienummer v3.0.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
-  - *De bron vermeldt de Beveiligingsstandaarden en voorschriften als bestaand document maar noemt geen versienummer.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron betreft de REST-API repository; er is geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften of versienummers daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron verwijst naar Digikoppeling Beveiligingsstandaarden en voorschriften als referentie [DK-beveiliging] maar noemt geen versienummer v3.0.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De bron verwijst naar 'Digikoppeling Beveiligingsstandaarden en voorschriften' als normatieve referentie maar noemt geen versienummer v3.0.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst verwijst naar 'Digikoppeling Beveiligingsstandaarden en voorschriften' als normatieve referentie maar geeft geen versienummer van dat document.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron vermeldt Digikoppeling-Beveiligingsstandaarden-en-voorschriften alleen als normatieve referentie [DK-beveiliging] zonder versienummer.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron is de GitHub-repositorypagina voor Digikoppeling-Beveiligingsstandaarden-en-voorschriften. Er worden 5 releases vermeld (meest recent: '1.4 (rerelease)' van jan 2022), maar v3.0.0 wordt nergens in de aangeleverde brontekst vermeld. De versie-claim kan niet worden bevestigd noch ontkracht op basis van deze tekst.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron is het beveiligingsstandaarden-document zelf. Het documentbeheer toont versies 1.0 t/m 2.0.1; versie 3.0.0 wordt nergens vermeld. De meest recente versie in het documentbeheer is 2.0.1 (24/06/2025).*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over Beveiligingsstandaarden-en-voorschriften.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De bron bevat geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften of versienummer v3.0.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
-  - *De brontekst bevat geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften of versienummers.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
-  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Beveiligingsstandaarden-en-voorschriften wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
-  - *De brontekst bevat geen informatie over versienummers van Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
-  - *Digikoppeling Beveiligingsstandaarden en voorschriften wordt in de documentbeheer-tabel vermeld als toegevoegd in versie 1.4 (april 2016) van het beheermodel, maar een versienummer van het document zelf (v3.0.0) staat niet in de bron.*
-</details>
-
-### `ls-dk-0009` — SKILL.md:47 *(§ Repositories)*
-
-> OIN-Stelsel is vastgesteld als v3.0.0.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-Stelsel
-
-<details><summary>27x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *OIN-Stelsel als document met versienummer v3.0.0 wordt niet vermeld. OIN wordt wel beschreven als identificatiemechanisme maar zonder verwijzing naar een stelsel-document.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Versie-informatie over het OIN-Stelsel staat niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *OIN-Stelsel wordt vermeld in de impactmatrix maar zonder versienummer v3.0.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
-  - *Het OIN-Stelsel als afzonderlijk document met versienummer wordt in de bron niet vermeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron betreft de REST-API repository; er is geen informatie over het OIN-Stelsel of versienummers daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *OIN-Stelsel wordt niet als document of versie genoemd in de bron. Het OIN wordt functioneel beschreven maar zonder verwijzing naar een OIN-Stelsel standaard met versienummer.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over het OIN-Stelsel.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *OIN-Stelsel als apart document met versienummer v3.0.0 wordt niet vermeld. De bron noemt OIN (Organisatie Identificatie Nummer) functioneel maar niet als versioned standaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over het OIN-Stelsel.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst bevat geen informatie over het OIN-Stelsel of een versienummer daarvan. OIN wordt wel kort genoemd in de context van adressering maar zonder verwijzing naar een vastgesteld OIN-Stelsel document.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over het OIN-Stelsel.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
-  - *OIN-Stelsel wordt niet als document met versienummer vermeld in de bron. OIN wordt wel gebruikt als concept (authenticatie op basis van OIN), maar zonder verwijzing naar een OIN-Stelsel document.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over het OIN-Stelsel of diens versienummer.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *Het OIN-Stelsel wordt niet als zelfstandig document of versie vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over het OIN-Stelsel.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De bron verwijst naar het OIN-stelsel en OIN-beleid, maar geeft geen versienummer v3.0.0 voor het OIN-Stelsel document.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
-  - *De brontekst is de GitHub-pagina van de OIN-Stelsel repository zelf, maar bevat geen versienummer (zoals v3.0.0). De gepubliceerde URL wordt wel vermeld (gitdocumentatie.logius.nl/publicatie/dk/oin/), maar versie-metadata staat niet in de repository-overzichtspagina.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
-  - *De bron is het OIN-Stelsel document zelf (werkversie 13 maart 2026), maar een vastgesteld versienummer 'v3.0.0' wordt nergens in de brontekst vermeld. De status is expliciet 'werkversie', niet een vastgestelde versie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
-  - *De brontekst bevat geen informatie over versienummers van het OIN-Stelsel.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
-  - *OIN en het OIN-stelsel worden meerdere keren vermeld in de impactmatrix en elders, maar een vastgesteld versienummer zoals v3.0.0 voor het OIN-Stelsel document staat niet in de bron.*
-</details>
-
-### `ls-dk-0023` — reference.md:39 *(§ REST-API)*
-
-> De REST-API koppelvlakstandaard is gebaseerd op de API Design Rules (ADR) van het Kennisplatform API's, vastgesteld door het Forum Standaardisatie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
-
-<details><summary>17x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst gaat over ebMS2; API Design Rules en het Kennisplatform API's worden niet vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De relatie tussen de REST-API koppelvlakstandaard en de API Design Rules van het Kennisplatform wordt niet behandeld in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De relatie tussen REST-API koppelvlakstandaard en ADR van het Kennisplatform API's wordt niet beschreven in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *API Design Rules en het Kennisplatform API's worden niet genoemd in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *API Design Rules en het Kennisplatform API's worden niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen REST-API koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *REST-API koppelvlakstandaard en API Design Rules worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *API Design Rules en het Kennisplatform API's worden niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *De bron noemt de REST API koppelvlakstandaard maar verwijst niet naar de API Design Rules (ADR) van het Kennisplatform API's als grondslag.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0024` — reference.md:40 *(§ REST-API)*
-
-> Het service contract voor REST-API is een OpenAPI Specification (OAS) 3.x.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
-
-<details><summary>17x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *OpenAPI Specification wordt niet vermeld in de brontekst; de bron gaat over ebMS2.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *OpenAPI Specification als service contract voor REST-API wordt niet behandeld in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *OpenAPI Specification als service contract voor REST-API wordt niet vermeld in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *OpenAPI Specification als service contract voor REST-API wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *OpenAPI Specification wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen REST-API of OAS.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *OpenAPI Specification voor REST-API wordt niet behandeld in deze WUS Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *OpenAPI Specification als service contract voor REST-API wordt niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *OpenAPI Specification (OAS) wordt niet genoemd in de brontekst.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0026` — reference.md:58 *(§ WUS (SOAP))*
-
-> WUS profiel 2W-be-S gebruikt WS-Security en XML Digital Signature (XMLDSIG) voor digitale ondertekening en garandeert integriteit en onweerlegbaarheid.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS 2W-be-S profiel
-
-<details><summary>17x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *WUS-profielen worden niet behandeld in de brontekst; de bron gaat over ebMS2.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *WUS profiel 2W-be-S en WS-Security/XMLDSIG worden niet behandeld in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *WS-Security en XMLDSIG voor het 2W-be-S profiel worden niet besproken in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *WUS profiel 2W-be-S en WS-Security/XMLDSIG worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *WUS profiel 2W-be-S en WS-Security/XMLDSIG worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen WUS profielen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Het WUS profiel 2W-be-S en WS-Security/XMLDSIG voor ondertekening worden niet specifiek behandeld in deze Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *WS-Security, XMLDSIG en het 2W-be-S profiel worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *Het specifieke WUS profiel '2W-be-S' en WS-Security / XMLDSIG worden niet bij naam behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0027` — reference.md:59 *(§ WUS (SOAP))*
-
-> WUS profiel 2W-be-SE gebruikt WS-Security en XML Encryption voor ondertekening en versleuteling en garandeert integriteit, onweerlegbaarheid en vertrouwelijkheid.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS 2W-be-SE profiel
-
-<details><summary>15x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *Deze bron behandelt de ebMS2 koppelvlakstandaard, niet de WUS koppelvlakstandaard. Claims over WUS profielen zijn buiten scope van deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet de WUS koppelvlakstandaard. WUS-profielen (2W-be-SE, WS-Security, XML Encryption) worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron is het Digikoppeling Beheermodel en bevat geen technische specificaties van WUS-profielen zoals 2W-be-SE, WS-Security of XML Encryption.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *WUS profiel 2W-be-SE en XML Encryption worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *WUS profiel 2W-be-SE en XML Encryption worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen WUS profielen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Het WUS profiel 2W-be-SE en XML Encryption worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *WS-Security, XML Encryption en het 2W-be-SE profiel worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *Het specifieke WUS profiel '2W-be-SE' en XML Encryption worden niet bij naam behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0036` — reference.md:116 *(§ Grote Berichten)*
-
-> Er is geen bovengrens gedefinieerd voor de bestandsgrootte bij Grote Berichten.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
-
-<details><summary>17x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *Bovengrens voor bestandsgrootte bij Grote Berichten wordt niet behandeld in deze bron. Er is wel een opmerking over payload-groottes bij ebMS in sectie 6.5, maar die gaat niet over Grote Berichten als apart koppelvlak.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron definieert een ondergrens van 20 MiB (VW001) maar vermeldt nergens expliciet dat er geen bovengrens is voor bestandsgrootte.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Geen informatie over een bovengrens (of afwezigheid daarvan) voor bestandsgrootte bij Grote Berichten.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *De bron gaat uitsluitend over PKIoverheid-certificaten en hun gebruik binnen Digikoppeling. Grote Berichten worden nergens behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Bovengrens voor bestandsgrootte bij Grote Berichten wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *Dit document gaat over ebMS2 best practices, niet over Grote Berichten. Geen vermelding van bestandsgroottes of Grote Berichten.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Bovengrens bestandsgrootte bij Grote Berichten wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *De brontekst beschrijft wat grote berichten zijn en hoe ze werken, maar noemt nergens een bovengrens (of het ontbreken daarvan) voor bestandsgrootte.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *De bron noemt alleen de ondergrens van 20 MiB voor grote berichten. Er wordt geen uitspraak gedaan over een bovengrens.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0049` — reference.md:157 *(§ Berichtniveau-beveiliging)*
-
-> Berichtniveau-versleuteling gebruikt AES-128 of AES-256 voor de payload en asymmetrische RSA voor de sessiesleutel.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling berichtniveau-beveiliging encryptie
-
-<details><summary>16x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De bron vermeldt XML-versleuteling (xmlenc-core) voor End-to-End Security, maar specificeert geen algoritmen zoals AES-128/AES-256 of RSA voor sessiesleutels. Die details staan in het beveiligingsvoorschriftendocument waarnaar verwezen wordt.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron beschrijft bestandsoverdracht via HTTP/TLS, niet berichtniveau-versleuteling met AES of RSA. Dit valt buiten het scope van de Grote Berichten standaard.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *AES-128/256 en RSA voor berichtniveau-versleuteling worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Berichtniveau-versleuteling met AES-128/AES-256 of RSA voor sessiesleutels wordt niet beschreven in deze bron. De bron vermeldt asymmetrische encryptie in algemene termen maar niet de specifieke algoritmen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *AES-128/256 en RSA voor berichtniveau-versleuteling worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *AES of RSA voor payload-encryptie wordt niet vermeld. In 3.4.15 staat expliciet: 'Geen gebruik van Signing of (payload) Encryption. (Alleen op HTTP nivo wordt informatie beveiligd)' — dit is eerder een indicatie dat payload-encryptie buiten scope valt voor de beschreven profielen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Berichtniveau-versleuteling met AES en RSA wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *AES-128, AES-256 of RSA voor sessiesleutels worden niet vermeld in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *AES-128, AES-256 en RSA voor sessiesleutels worden niet vermeld. De bron noemt het versleutelen van berichten als functionaliteit maar zonder algoritmische details.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (11)
-
-### `ls-dk-0012` — SKILL.md:83 *(§ Profielkeuze)*
-
-> Bij berichten via een niet-vertrouwde intermediair moet de signed (-S) of signed+encrypted (-SE/-E) variant worden gekozen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling profielkeuze beveiliging
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > End-to-End Security: op basis van Reliable Messaging of Best Effort wordt een bericht beveiligd tussen de uiteindelijke Consumer en de uiteindelijke Provider, ook wanneer er zich intermediairs bevinden in het pad tussen die twee.
-  - *De bron beschrijft dat End-to-End Security (signed/encrypted variant) wordt gebruikt wanneer er intermediairs zijn, wat de claim ondersteunt voor het ebMS2 domein. De claim stelt dit echter als algemene Digikoppeling-eis; de bron beperkt zich tot ebMS2-profielen.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Het versleutelen van berichtinhoud (berichtenniveau versleuteling) kan worden toegepast indien de intermediair niet vertrouwd wordt.
-  - *De bron bevestigt dat encryptie kan worden toegepast bij niet-vertrouwde intermediairs, maar gebruikt 'kan' (MAY) in plaats van een verplichting (MUST). De claim stelt dat signed/encrypted variant 'moet' worden gekozen; de bron maakt dit optioneel.*
-<details><summary>15x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Profielkeuze op basis van vertrouwde/niet-vertrouwde intermediairs wordt niet behandeld in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron gaat niet in op specifieke profielkeuzes rondom signed/encrypted varianten bij niet-vertrouwde intermediairs.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Profielkeuze bij niet-vertrouwde intermediairs wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen profielkeuze op basis van vertrouwde/niet-vertrouwde intermediairs.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Profielkeuze bij niet-vertrouwde intermediairs wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *De bron behandelt geen profielkeuze voor signed of encrypted varianten bij niet-vertrouwde intermediairs.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *De bron beschrijft dat berichtinhoud kan worden versleuteld bij niet-vertrouwde intermediairs, maar specifieke profielkeuze-vereisten voor signed/encrypted varianten worden niet uitgewerkt in dit document.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0013` — SKILL.md:91 *(§ Profielkenmerken Matrix)*
-
-> REST-API profiel is synchroon en ondersteunt geen berichtniveau signing of encryptie; TLS wordt gebruikt voor transportbeveiliging.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API profiel
-
-- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Noot : REST API Zie het [ Digikoppeling REST API profiel ] voor de ondersteuning van signing en encryptie voor REST API's
-  - *De bron verwijst naar het REST API profiel voor signing en encryptie, maar bevestigt noch ontkent dat het profiel synchroon is of dat TLS de enige transportbeveiliging is. Dat signing/encryptie apart beschreven staan voor REST API suggereert dat het niet inherent aanwezig is, maar de claim als geheel is niet volledig bevestigd.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Een gevolg van het REST principe is wel dat het koppelvlak in principe vooral geschikt is voor bevragingen. [...] Een belangrijk principe van REST is dat de bevraging stateless is.
-  - *De bron bevestigt het synchrone karakter (REST geschikt voor bevragingen). Berichtniveau signing/encryptie en TLS als transportbeveiliging worden niet expliciet voor REST API behandeld in deze bron.*
-<details><summary>15x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst gaat over ebMS2, niet over het REST-API profiel. Synchroniciteit en afwezigheid van berichtniveau signing bij REST worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Eigenschappen van het REST-API profiel (synchroon, signing, encryptie) worden niet behandeld in deze Grote Berichten spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron beschrijft het beheermodel, niet de technische kenmerken van het REST-API profiel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *De bron bespreekt REST API alleen in de context van OIN-gebruik in querystrings; geen uitspraken over synchroniciteit of het ontbreken van berichtniveau signing/encryptie.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen REST-API profiel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *REST-API profiel wordt niet behandeld in deze WUS Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *De bron beschrijft REST-API als koppelvlak voor Grote Berichten maar gaat niet in op synchroniciteit, berichtniveau signing/encryptie of TLS als transportbeveiliging in de context van het REST-API profiel als zodanig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0015` — SKILL.md:105 *(§ Profielkenmerken Matrix)*
-
-> Grote Berichten gebruikt TLS voor transport; payload-encryptie kan aanvullend worden toegepast maar is niet voorgeschreven in het profiel.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** Digikoppeling Grote Berichten
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS. [...] GB007 PUSH / PULL De minimaal ondersteunde TLS encryptie algoritmen en sleutellengtes worden beschreven in het [Digikoppeling Beveiligingsdocument].
-  - *TLS voor transport wordt bevestigd. Payload-encryptie als aanvullende optie wordt niet expliciet behandeld in de bron; de bron verwijst voor beveiligingsdetails naar het Digikoppeling Beveiligingsdocument.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Ten behoeve van Digikoppeling grote berichten dient gebruik gemaakt te worden van OIN gerelateerde certificaten. Alleen verbindingen waarbij zowel de client als de server over een geldig certificaat beschikken zijn toegestaan (TLS).
-  - *De bron bevestigt TLS als vereiste voor transport. Over aanvullende payload-encryptie zegt de bron niets, en de formulering 'niet voorgeschreven in het profiel' is niet bevestigd of ontkracht.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Voor ophalen van het grote bestand maakt de standaard gebruik van HTTPS-downloads. Daardoor zijn reliability en security gelijkwaardig aan WUS en ebMS2.
-  - *HTTPS (TLS) voor transport wordt bevestigd. Payload-encryptie als aanvullende optie wordt niet expliciet behandeld in deze bron.*
-<details><summary>14x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst behandelt Grote Berichten niet. TLS voor transport wordt wel beschreven voor ebMS2 maar niet in de context van Grote Berichten.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Technische details over transportbeveiliging en payload-encryptie voor Grote Berichten ontbreken in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Grote Berichten en payload-encryptie worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Grote Berichten en payload-encryptie worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt het Grote Berichten koppelvlak niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Grote Berichten wordt niet behandeld in deze WUS Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0018` — SKILL.md:365 *(§ Retry Strategie (ebMS2 Reliable Messaging))*
-
-> Bij het profiel osb-rm geldt at-most-once delivery: berichten worden nooit dubbel afgeleverd.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Digikoppeling ebMS2 osb-rm reliable messaging
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Reliable Messaging profile 2, Once-And-Only-Once Reliable Messaging at the End-To-End level only based upon end-to-end retransmission. [...] The ToParty MSH must also filter any duplicate messages based on ebXML MessageId.
-  - *De bron beschrijft 'Once-And-Only-Once' delivery en duplicate eliminatie, wat at-most-once delivery impliceert. De claim stelt expliciet 'berichten worden nooit dubbel afgeleverd', maar de standaard garandeert dit via duplicate eliminatie op MessageId-niveau, niet als absolute garantie. De formulering 'nooit dubbel afgeleverd' is sterker dan wat de bron letterlijk stelt.*
-<details><summary>16x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *At-most-once delivery bij osb-rm wordt niet behandeld in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *At-most-once delivery semantics worden niet beschreven in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *At-most-once delivery en osb-rm worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *At-most-once delivery wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron beschrijft reliable messaging en duplicate-eliminatie, maar de term 'at-most-once delivery' wordt niet gebruikt. De ebMS2 once-and-only-once semantiek wijst eerder op exactly-once dan at-most-once. De specifieke claim over at-most-once wordt niet gestaafd of tegengesproken.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *ebMS2 osb-rm at-most-once delivery wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *At-most-once delivery bij osb-rm wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *Het profiel 'osb-rm' en at-most-once delivery worden niet specifiek behandeld in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0025` — reference.md:51 *(§ WUS (SOAP))*
-
-> WUS staat voor WSDL, UDDI en SOAP. Het service contract is een WSDL en het berichtformaat is SOAP XML.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  > In WSDL 1.1 [...] is een Authoring Style advies opgenomen... De meest gangbare zijn... [en] het berichtformaat is SOAP... messaging (SOAP)
-  - *De bron bevestigt dat WUS gebruik maakt van WSDL en SOAP, maar de expansie 'WUS staat voor WSDL, UDDI en SOAP' als acroniem staat niet expliciet in de bron. UDDI wordt nergens genoemd. De claim over WSDL als service contract en SOAP als berichtformaat wordt wel ondersteund.*
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > De naam WUS staat voor WSDL, UDDI en SOAP, drie belangrijke deelstandaarden. [...] Een WSDL is een formeel xml-document om de gebruikte functionele en technische eigenschappen van de berichtuitwisseling via WUS vast te leggen.
-  - *WUS staat voor WSDL, UDDI en SOAP wordt bevestigd, evenals WSDL als servicecontract. SOAP XML als berichtformaat wordt impliciet bevestigd via de WUS-standaard maar niet expliciet als 'SOAP XML berichtformaat' omschreven.*
-<details><summary>15x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *WUS (WSDL, UDDI, SOAP) wordt niet behandeld in de brontekst; de bron gaat over ebMS2.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *WUS (WSDL, UDDI, SOAP) als koppelvlak wordt niet inhoudelijk behandeld in deze Grote Berichten spec, enkel zijdelings vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De afkorting WUS en de technische details (WSDL, UDDI, SOAP) worden niet uitgelegd in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *WUS (WSDL, UDDI, SOAP) en WSDL als service contract worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *WUS, WSDL, UDDI, SOAP als afkortingen of definities worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen WUS koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *De afkorting WUS en WSDL/UDDI/SOAP-definitie worden niet uitgelegd in deze bron. WUS wordt wel vermeld als koppelvlak maar niet nader gespecificeerd.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0028` — reference.md:60 *(§ WUS (SOAP))*
-
-> WUS gebruikt de standaarden WS-Security 1.1, WS-Addressing, SOAP 1.1 (document-literal binding) en MTOM voor binaire bijlagen.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
-
-- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > WUS: in de querystring van de endpointuri in de SOAP ws-addressing header.
-  - *De bron noemt WS-addressing en SOAP in de context van WUS, maar behandelt niet WS-Security 1.1, SOAP 1.1 document-literal binding of MTOM. Slechts een klein deel van de claim wordt bevestigd.*
-<details><summary>14x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *Deze bron behandelt de ebMS2 koppelvlakstandaard, niet de WUS koppelvlakstandaard. Claims over WUS-specifieke standaarden zijn buiten scope.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet de WUS koppelvlakstandaard. WS-Security, WS-Addressing, SOAP 1.1 en MTOM worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron bevat geen technische details over WUS-standaarden (WS-Security 1.1, WS-Addressing, SOAP 1.1, MTOM). Het beheermodel verwijst alleen globaal naar WUS als open standaard.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *WS-Security 1.1, WS-Addressing, SOAP 1.1 en MTOM als WUS-standaarden worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen WUS standaarden.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *De bron vermeldt WS-Addressing en SOAP, maar noemt niet expliciet WS-Security 1.1, SOAP 1.1 document-literal binding als combinatie, en MTOM. De combinatie als volledige claim is niet te bevestigen vanuit deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *WS-Security 1.1, WS-Addressing, SOAP 1.1 en MTOM worden niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *WS-Security 1.1, WS-Addressing, SOAP 1.1 document-literal binding en MTOM worden niet specifiek vermeld in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0030` — reference.md:71 *(§ ebMS2)*
-
-> ebMS2 berichtformaat is SOAP 1.1 met ebMS2 headers en payload als MIME-attachment.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Dit document specificeert de Koppelvlakstandaard ebMS2 voor berichtenuitwisseling over Digikoppeling (voorheen OverheidsServiceBus) als een toepassing van de EBXML-MSG standaard, de ebXML Message Service Specification versie 2.0 [EBXML-MSG].
-  - *De bron bevestigt het gebruik van SOAP (via EBXML-MSG) en MIME-attachments (Manifest/payload containers). SOAP 1.1 wordt indirect bevestigd via de verwijzing naar [SOAP] (Simple Object Access Protocol 1.1). De combinatie van SOAP met ebMS2 headers en MIME-attachments is consistent met de bron, maar niet als één expliciete definitie beschreven.*
-<details><summary>15x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet ebMS2. ebMS2 berichtformaat wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Geen technische beschrijving van het ebMS2 berichtformaat (SOAP 1.1, ebMS2 headers, MIME-attachment) in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *ebMS2 berichtformaat (SOAP 1.1 met ebMS2 headers en MIME-attachment) wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *SOAP 1.1 met ebMS2 headers en MIME-attachment worden niet behandeld in deze bron.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron beschrijft CPA gebruik en kenmerken maar specificeert het berichtformaat (SOAP 1.1 met ebMS2 headers en MIME-attachment) niet expliciet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *ebMS2 berichtformaat wordt niet behandeld in deze WUS Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *ebMS2 berichtformaat (SOAP 1.1 met ebMS2 headers en MIME-attachment) wordt niet beschreven in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *De bron beschrijft ebMS2 en vermeldt dat het op web-service standaarden is gebaseerd, maar noemt SOAP 1.1 met ebMS2 headers en MIME-attachment niet expliciet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0034` — reference.md:94 *(§ Grote Berichten)*
-
-> Grote Berichten ondersteunt HTTP 1.1 met BYTE-RANGE (RFC 7233) voor hervatbare downloads.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc7233.txt](https://www.rfc-editor.org/rfc/rfc7233.txt)
-  > This document defines HTTP/1.1 range requests, partial responses, and the multipart/byteranges media type. [...] HTTP clients often encounter interrupted data transfers as a result of canceled requests or dropped connections. When a client has stored a partial representation, it is desirable to request the remainder of that representation in a subsequent request rather than transfer the entire ...
-  - *De bron bevestigt dat RFC 7233 de BYTE-RANGE mechanismen voor HTTP/1.1 definieert, inclusief hervatbare downloads. Echter, de bron maakt geen enkele vermelding van 'Digikoppeling' of 'Grote Berichten' — dat Digikoppeling Grote Berichten specifiek HTTP 1.1 met BYTE-RANGE (RFC 7233) ondersteunt, is niet te verifiëren uit deze brontekst. De bron is de RFC zelf, niet de Digikoppeling-specificatie. Het technische mechanisme wordt bevestigd, maar de koppeling aan Digikoppeling Grote Berichten ontbreekt.*
-
-### `ls-dk-0041` — reference.md:131 *(§ TLS-vereisten)*
-
-> TLS004: Cipher suites moeten voldoen aan de NCSC-richtlijnen voor TLS. Zwakke cipher suites zijn niet toegestaan.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS004
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS. Aanbieder en afnemer ondersteunen de minimaal ondersteunde TLS encryptie algoritmen en sleutellengtes zoals beschreven in het [Digikoppeling Beveiligingsdocument]
-  - *De bron bevestigt dat er eisen zijn aan TLS-encryptie-algoritmen en sleutellengtes, maar verwijst voor de details naar het Digikoppeling Beveiligingsdocument. De specifieke eis over NCSC-richtlijnen en verbod op zwakke cipher suites staat niet in deze bron.*
-<details><summary>16x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De bron verwijst voor cipher suites naar 'Digikoppeling Beveiligingsstandaarden en voorschriften' zonder zelf specifieke cipher suites of NCSC-richtlijnen te noemen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *TLS004 en NCSC-richtlijnen voor cipher suites worden niet beschreven in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *NCSC-richtlijnen voor cipher suites worden niet vermeld in deze bron. De bron verwijst voor beveiligingseisen naar een apart document.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *NCSC-richtlijnen voor cipher suites worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *Cipher suites of NCSC-richtlijnen worden niet vermeld in dit document. Er wordt verwezen naar het Digikoppeling Beveiligingsdocument voor actuele protocolvereisten.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Cipher suites en NCSC-richtlijnen (TLS004) worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *NCSC-richtlijnen voor cipher suites worden niet vermeld in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *Cipher suites en NCSC-richtlijnen worden niet vermeld in deze bron. De bron verwijst voor beveiligingsdetails naar het apart document 'Digikoppeling Beveiligingsstandaarden en voorschriften'.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0042` — reference.md:132 *(§ TLS-vereisten)*
-
-> TLS005: Certificaten moeten geldig zijn en de volledige keten tot aan de PKIoverheid-root moet verifieerbaar zijn. Revocation checking (CRL/OCSP) is verplicht.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS005
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > The use of certificate revocation lists (CRL) from the trusted CAs is required. [...] What certificate verification policies and procedures must be followed? PKI overheid procedures are described in Certificate Policy/Programme of Requirements PKIoverheid. The use of certificate revocation lists (CRL) from the trusted CA's is required.
-  - *De bron bevestigt CRL-verificatie als verplicht en geldigheid via PKIoverheid. OCSP wordt niet expliciet genoemd. De 'volledige keten tot PKIoverheid-root' is impliciet via PKIoverheid-procedures maar niet letterlijk geformuleerd.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > GB011 PUSH / PULL De server moet certificaat-revocatie-lijsten (CRL) gebruiken [PKI Policy].
-  - *De bron bevestigt CRL-gebruik. OCSP wordt niet vermeld. De eis over geldigheid van de volledige keten tot PKIoverheid-root wordt niet expliciet beschreven in deze bron.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Een certificaat is geldig als het aan de volgende drie eisen voldoet: De ondertekening van het certificaat berust op een geldige hiërarchie van certificaten afgeleid van het overheid stamcertificaat. De geldigheidsduur van het certificaat is niet verstreken. Het certificaat is niet ingetrokken door de TSP.
-  - *De bron ondersteunt ketenvalidatie en revocation checking via CRL (en optioneel OCSP), maar stelt OCSP niet verplicht ('voor TSP's niet verplicht'). De claim zegt dat revocation checking verplicht is; de bron maakt CRL-raadpleging noodzakelijk maar OCSP optioneel. Ketenvalidatie tot stamcertificaat wordt wel bevestigd.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Het spreekt voor zich dat de gebruikte certificaten worden gecontroleert op geldigheid en revocation.
-  - *De bron bevestigt dat certificaten op geldigheid en revocation gecontroleerd moeten worden, maar noemt de PKIoverheid-root-keten verificatie en CRL/OCSP niet expliciet als technische methoden.*
-<details><summary>13x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *TLS005 en vereisten rondom certificaatgeldigheid, ketenverificatie en revocation checking (CRL/OCSP) komen niet voor in het beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *CRL/OCSP revocation checking en PKIoverheid-root verificatie worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *Certificaatvalidatie, CRL/OCSP of revocation checking worden niet behandeld in dit document.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Certificaatgeldigheid en revocation checking CRL/OCSP (TLS005) worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *CRL/OCSP revocation checking wordt niet vermeld. De bron noemt PKIoverheid-certificaten maar gaat niet in op specifieke validatie-eisen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0048` — reference.md:156 *(§ Berichtniveau-beveiliging)*
-
-> Berichtniveau-ondertekening gebruikt XML Digital Signature (XMLDSIG) met minimaal SHA-256; SHA-1 is niet meer toegestaan.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling berichtniveau-beveiliging signing
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Required in this profile. [...] What canonicalization method(s) must be applied to the data to be signed? The use of XML canonicalization is required. [xml-exc-c14n] [...] What signature method(s) must be applied? The applied signature method is described in Digikoppeling Beveiligingsstandaarden en voorschriften
-  - *De bron bevestigt gebruik van XML Digital Signature (XMLDSIG) voor End-to-End Security. De specifieke eis van SHA-256 minimum en het verbod op SHA-1 staat niet in deze bron; daarvoor wordt verwezen naar 'Digikoppeling Beveiligingsstandaarden en voorschriften'.*
-<details><summary>15x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron beschrijft bestandsoverdracht via HTTP/TLS, niet berichtniveau-ondertekening met XMLDSIG. Dit valt buiten het scope van de Grote Berichten standaard.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Berichtniveau-ondertekening met XMLDSIG, SHA-256 of verbod op SHA-1 worden niet beschreven in het beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *De bron noemt signing-profielen (signed, signed en encrypted) voor WUS en ebMS2, maar bevat geen specificaties over XMLDSIG, SHA-256 of het verbod op SHA-1 voor berichtniveau-ondertekening.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *XML Digital Signature, SHA-256 en het verbod op SHA-1 worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *XML Digital Signature, XMLDSIG, SHA-256 of SHA-1 worden niet vermeld in dit document. Berichtniveau-ondertekening via signing wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Berichtniveau-ondertekening met XMLDSIG en SHA-256 vereisten worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *XML Digital Signature, XMLDSIG, SHA-256 of berichtniveau-ondertekening worden niet besproken in deze bron over Grote Berichten.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *XMLDSIG, SHA-256 en SHA-1 worden niet vermeld. De bron noemt wel dat berichten beveiligd kunnen worden met een technische handtekening, maar zonder technische details over algoritmen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-## UNGROUNDED — geen bron ondersteunt de claim (5)
-
-### `ls-dk-0011` — SKILL.md:73 *(§ Profielkeuze)*
-
-> Bij gebruik van REST-API profiel is FSC (Federated Service Connectivity) verplicht.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API profiel
-
-<details><summary>17x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *FSC (Federated Service Connectivity) wordt niet vermeld in de brontekst; de bron gaat over ebMS2.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *FSC als verplicht onderdeel van het REST-API profiel wordt niet behandeld in deze Grote Berichten spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *FSC (Federated Service Connectivity) wordt niet genoemd in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *FSC (Federated Service Connectivity) wordt niet genoemd in deze bron. De bron gaat over certificaten.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *FSC (Federated Service Connectivity) wordt niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt ebMS2; FSC en REST-API profiel komen niet aan bod.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *REST-API profiel en FSC worden niet behandeld in deze WUS Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *FSC (Federated Service Connectivity) wordt in deze bron niet vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *FSC (Federated Service Connectivity) wordt nergens in de brontekst genoemd. De bron beschrijft OAuth als relevant voor REST API koppelvlakken, maar noemt FSC niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0016` — SKILL.md:145 *(§ REST-API Koppelvlak met OIN (Python/FastAPI))*
-
-> REST-API foutresponses moeten RFC 9457 problem+json formaat gebruiken conform de API Design Rules.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API foutafhandeling
-
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
-  - *RFC 9457 definieert het problem+json formaat zelf, maar bevat geen verwijzing naar Digikoppeling, de Nederlandse API Design Rules, of enige verplichting voor specifieke API-profielen om dit formaat te gebruiken. De bron beschrijft wat problem+json is en hoe het gebruikt kan worden, maar legt geen MUST-verplichting op voor Digikoppeling REST-API's.*
-
-### `ls-dk-0022` — reference.md:45 *(§ REST-API)*
-
-> Het gebruik van FSC is verplicht bij Digikoppeling REST-API vanaf v3.0.1. FSC verzorgt de federatieve autorisatie en logging van API-aanroepen tussen organisaties.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
-
-<details><summary>17x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *FSC wordt niet vermeld in de brontekst; de bron gaat over ebMS2. Verwijzing naar v3.0.1 en FSC als verplichte component bij REST-API ontbreekt volledig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *FSC als verplicht onderdeel van de REST-API koppelvlakstandaard en de versiedrempel v3.0.1 worden niet behandeld in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *FSC en verplicht gebruik ervan bij REST-API worden niet besproken in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *FSC en verplicht gebruik bij REST-API v3.0.1 worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *FSC en versie v3.0.1 worden niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt geen REST-API koppelvlakstandaard of FSC.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *FSC en REST-API v3.0.1 worden niet behandeld in deze WUS Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *FSC en verplicht gebruik ervan bij REST-API v3.0.1 worden niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *FSC wordt niet genoemd in de brontekst. Er is geen vermelding van FSC als verplichting bij Digikoppeling REST-API v3.0.1.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0038` — reference.md:128 *(§ TLS-vereisten)*
-
-> TLS001: TLS 1.2 is minimaal vereist. Eerdere versies (SSL 3.0, TLS 1.0, TLS 1.1) zijn niet toegestaan.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS001
-
-<details><summary>17x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De bron verwijst voor specifieke TLS-versies naar 'Digikoppeling Beveiligingsstandaarden en voorschriften' zonder de versienummers zelf te noemen. Er staat alleen 'The currently allowed protocol versions for TLS are described in Digikoppeling Beveiligingsstandaarden en voorschriften' en 'TLS implementations must NOT support SSL v3 backwards compatibility mode.' De specifieke eis TLS 1.2 minimum staat niet in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron verwijst voor TLS-vereisten naar het Digikoppeling Beveiligingsdocument maar specificeert zelf geen minimale TLS-versies. TLS 1.2 als minimum en verbod op SSL 3.0/TLS 1.0/1.1 worden niet in deze bron beschreven.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *TLS001 en versievereisten (TLS 1.2 minimaal, SSL 3.0/TLS 1.0/1.1 verboden) worden niet beschreven in het beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *De bron verwijst naar Digikoppeling Beveiligingsstandaarden en -voorschriften voor specifieke TLS-versie-eisen, maar bevat zelf geen concrete TLS-versienummers of verboden versies.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *TLS-versievereisten (minimaal TLS 1.2, verbod op SSL 3.0/TLS 1.0/1.1) worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron noemt TLS als verplicht maar specificeert geen minimale versie (1.2) en verbiedt geen eerdere versies expliciet. Er staat alleen een noot: 'voor de actuele versies van het te gebruiken protocol bij de uitwisseling zie [Digikoppeling Beveiligingsdocument]'.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *TLS-versievereisten (TLS001) worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *De bron vermeldt TLS als vereiste maar specificeert nergens minimale versies (TLS 1.2) of verbod op oudere versies (SSL 3.0, TLS 1.0, TLS 1.1).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *De bron verwijst naar het document 'Digikoppeling Beveiligingsstandaarden en voorschriften' voor beveiligingseisen, maar bevat zelf geen specifieke TLS-versievereisten.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0039` — reference.md:129 *(§ TLS-vereisten)*
-
-> TLS002: TLS 1.3 wordt aanbevolen wanneer beide partijen dit ondersteunen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS002
-
-<details><summary>17x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *TLS 1.3 aanbeveling wordt niet vermeld in deze bron. De bron verwijst voor TLS-versies naar een apart beveiligingsdocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron verwijst voor TLS-details naar het Digikoppeling Beveiligingsdocument. TLS 1.3 aanbeveling wordt niet in deze bron behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *TLS002 en aanbeveling voor TLS 1.3 komen niet voor in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *TLS 1.3 en aanbevelingen daarvoor komen niet voor in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *TLS 1.3 aanbeveling wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *TLS 1.3 wordt nergens in dit document vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *TLS 1.3 aanbeveling (TLS002) wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *TLS 1.3 wordt niet genoemd in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *TLS 1.3 wordt nergens in de bron vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (3)
-
-### `ls-dk-0002` — SKILL.md:40 *(§ Repositories)*
-
-> Digikoppeling-Architectuur is vastgesteld als v2.1.1 en gepubliceerd op gitdocumentatie.logius.nl.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling-Architectuur
-
-**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md: 'Tag achter: publicatie v2.1.1 vs tag 2.0.2'. GitHub toont oudere tag; gitdocumentatie.logius.nl is leidend. De CONTRADICTED-verdicts komen van GitHub/logius-standaarden.github.io, niet van de gezaghebbende publicatiebron.
-
-- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  > Redirecting to v2.1.1
-  - *De redirect verwijst naar v2.1.1, wat de versieclaim ondersteunt. Maar de publicatie-URL en verdere inhoud zijn niet beschikbaar in de aangeleverde brontekst.*
-- **CONTRADICTED** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
-  > Releases: Release 2.0.2 Latest Dec 9, 2022 + 2 releases
-  - *De bron vermeldt release 2.0.2 als meest recente versie, niet v2.1.1. De gepubliceerde URL klopt wel (gitdocumentatie.logius.nl), maar het versienummer wijkt af.*
-- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
-  > Deze versie: https://gitdocumentatie.logius.nl/publicatie/dk/architectuur/2.1.0/
-  - *De bron vermeldt expliciet versie 2.1.0, niet 2.1.1 zoals de claim stelt. Het tweede deel van de claim (gepubliceerd op gitdocumentatie.logius.nl) klopt wel.*
-<details><summary>24x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding. Geen inhoud over versienummers van Digikoppeling-Architectuur.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst verwijst naar de Digikoppeling Architectuur als referentie maar vermeldt geen versienummer v2.1.1.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Versie-informatie over Digikoppeling-Architectuur staat niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron vermeldt de Digikoppeling Architectuur als apart document maar noemt geen versienummer v2.1.1.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De brontekst is de GitHub repository-pagina voor de REST-API koppelvlakstandaard. Er is geen informatie over Digikoppeling-Architectuur v2.1.1 of publicatie op gitdocumentatie.logius.nl.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron verwijst nergens naar Digikoppeling-Architectuur als document of versienummer. De brontekst behandelt uitsluitend de REST-API koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst betreft uitsluitend de Digikoppeling-Koppelvlakstandaard-ebMS2 repository. Er is geen informatie over Digikoppeling-Architectuur.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst verwijst naar Digikoppeling Architectuur als normatieve referentie (URL: https://gitdocumentatie.logius.nl/publicatie/dk/architectuur/) maar noemt geen versienummer v2.1.1.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over Digikoppeling-Architectuur v2.1.1.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat over de Digikoppeling Koppelvlakstandaard WUS en bevat geen informatie over het versienummer of publicatiestatus van de Digikoppeling-Architectuur.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over Digikoppeling-Architectuur. Versie-informatie over Digikoppeling-Architectuur staat niet in deze brontekst.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron vermeldt geen versienummer van Digikoppeling-Architectuur. Het document verwijst wel naar 'Digikoppeling_Architectuur' als document maar geeft geen versienummer.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De brontekst betreft de repository voor Digikoppeling-Beveiligingsstandaarden-en-voorschriften, niet Digikoppeling-Architectuur. Geen informatie over versie of publicatie van de Architectuur-standaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron verwijst naar de Digikoppeling Architectuur documentatie (informatieve referentie DK-Architectuur) maar noemt geen versienummer. Publicatie-metadata zoals versienummers staan zelden in een andere standaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over Digikoppeling-Architectuur. Versie-informatie voor dat document staat niet in deze bron.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De bron gaat uitsluitend over Digikoppeling Identificatie en Authenticatie. Geen informatie over Digikoppeling-Architectuur v2.1.1.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
-  - *De brontekst is de GitHub repository-pagina van OIN-Stelsel. Er staat geen informatie over Digikoppeling-Architectuur of versienummers daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
-  - *De bron gaat over het OIN-Stelsel, niet over de Digikoppeling-Architectuur. Versienummers van andere Digikoppeling-documenten worden niet vermeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
-  - *De brontekst bevat alleen de GitHub repository-pagina van het Digikoppeling Beheermodel. Er staat geen informatie over versienummers van Digikoppeling-Architectuur of publicatielocaties.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
-  - *De bron verwijst naar de Digikoppeling Architectuur via een normatieve referentie [DK-Architectuur] met URL, maar noemt geen versienummer. Versie-metadata zoals 'v2.1.1' staat niet in deze beheermodeldocumentatie.*
-</details>
-
-### `ls-dk-0004` — SKILL.md:42 *(§ Repositories)*
-
-> Digikoppeling-Koppelvlakstandaard-ebMS2 is vastgesteld als v3.3.2.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
-
-**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md: 'Geen discrepantie (tag komt overeen)' voor ebMS2 v3.3.2. Het CONTRADICTED-verdict komt van github.com (repo-tag), maar gitdocumentatie.logius.nl/publicatie/dk/ebms geeft SUPPORTED. GitHub-tag loopt achter conform gedocumenteerd patroon.
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Digikoppeling Koppelvlakstandaard ebMS2 3.3.2 Logius Standaard Vastgestelde versie 31 mei 2024
-- **CONTRADICTED** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  > Releases 4 — 3.3.1 Latest Apr 11, 2022 + 3 releases
-  - *De bron toont 3.3.1 als de Latest release. De claim stelt v3.3.2, maar de bron kent geen v3.3.2 als vastgestelde versie. Strikt genomen tegenstrijdig: bron noemt 3.3.1 als meest recente, niet 3.3.2. Confidence medium omdat de bron alleen de GitHub-pagina betreft en releases kunnen zijn bijgewerkt na de paginatekst.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  > 31-05-2024 3.3.2 Logius Herstel tabel onder 2.3 Ondersteunde varianten
-  - *De bron bevestigt dat versie 3.3.2 bestaat en de meest recente versie is in de documentbeheer-tabel, maar dit is een werkversie (werkversie 09 maart 2026). De claim dat v3.3.2 'vastgesteld' is wordt niet expliciet bevestigd — de bron zelf heeft de status 'werkversie'.*
-<details><summary>24x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Versie-informatie over de ebMS2 koppelvlakstandaard staat niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Geen versienummer voor ebMS2 koppelvlakstandaard vermeld in de bron.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
-  - *De bron vermeldt de ebMS2 koppelvlakstandaard als bestaand document maar noemt geen versienummer.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron betreft de REST-API repository; er is geen informatie over de ebMS2 koppelvlakstandaard of versienummers daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron behandelt de REST-API koppelvlakstandaard, niet ebMS2. Geen versie-informatie over ebMS2 aanwezig.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over de ebMS2 koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst vermeldt ebMS2 als alternatieve standaard maar geeft geen versienummer voor de ebMS2 koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over de ebMS2 koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron vermeldt geen versienummer van de ebMS2 koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over de ebMS2 koppelvlakstandaard of diens versienummer.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron verwijst naar de ebMS2 koppelvlakstandaard (DK-gbachtcert) als informatieve referentie, maar noemt geen versienummer v3.3.2.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over de ebMS2 koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De bron bevat geen informatie over de ebMS2 koppelvlakstandaard of versienummer v3.3.2.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
-  - *De brontekst bevat geen informatie over de ebMS2 koppelvlakstandaard of versienummers.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
-  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Koppelvlakstandaard-ebMS2 wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
-  - *De brontekst bevat geen informatie over versienummers van de ebMS2 koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
-  - *ebMS2 wordt terloops genoemd in de context van internationale standaarden (ebMS [EBXML-MSG]), maar een versienummer voor de Digikoppeling-Koppelvlakstandaard-ebMS2 ontbreekt volledig.*
-</details>
-
-### `ls-dk-0006` — SKILL.md:44 *(§ Repositories)*
+### `ls-dk-0007` — SKILL.md:44 *(§ Repositories)*
 
 > Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten) is vastgesteld als v3.8.1.
 
 **Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten koppelvlakstandaard
 
-**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md: 'Geen discrepantie (tag komt overeen, al zijn er ook sub-releases 3.8.1-2, 3.8.1-3)' voor GB v3.8.1. SUPPORTED op gitdocumentatie.logius.nl/publicatie/dk/gb; CONTRADICTED op logius-standaarden.github.io door sub-releases. Dit is gedocumenteerde situatie.
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > Digikoppeling Koppelvlakstandaard Grote Berichten 3.8.1 Logius Standaard Vastgestelde versie 11 april 2022
-- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
-  > Vorige versie: https://gitdocumentatie.logius.nl/publicatie/dk/gb/3.8/ ... Documentbeheer: 06/10/2020 3.8 Logius RFC 2020-2, RFC 2020-3 | 11/04/2022 3.8.1 Logius Vermelding REST-API koppelvlak
-  - *De bron toont dat de meest recente gepubliceerde versie v3.8 of v3.8.1 is (werkversie is nog niet vastgesteld). De claim stelt v3.8.1 als vastgesteld, maar de bron is een werkversie die nog niet door het TO is goedgekeurd. De vorige gepubliceerde versie was 3.8, met 3.8.1 als meest recente documentbeheer-entry. Een expliciete vaststelling als 'v3.8.1' is niet bevestigd.*
-<details><summary>25x NOT_FOUND (klap uit)</summary>
+<details><summary>8x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+  - *De bron verwijst naar de Digikoppeling Koppelvlakstandaard Grote Berichten maar noemt geen versienummer v3.8.1.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *De bron behandelt de REST-API koppelvlakstandaard; het versienummer van de Grote Berichten-standaard wordt niet vermeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst gaat over ebMS2; Grote Berichten koppelvlakstandaard en versienummer v3.8.1 worden niet vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Geen versienummer voor Grote Berichten koppelvlakstandaard vermeld in de bron.*
+  - *De bron vermeldt geen versienummer voor de Grote Berichten koppelvlakstandaard.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  - *De brontekst bevat geen versie-informatie over de Grote Berichten koppelvlakstandaard.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
-  - *De bron vermeldt de Grote Berichten koppelvlakstandaard als bestaand document maar noemt geen versienummer.*
+  - *De bron vermeldt de Grote Berichten koppelvlakstandaard als gerelateerd document maar geeft geen versienummer.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron betreft de REST-API repository; er is geen informatie over de Grote Berichten koppelvlakstandaard of versienummers daarvan.*
+  - *De bron betreft uitsluitend de REST-API koppelvlakstandaard repository. Informatie over de Grote Berichten koppelvlakstandaard staat niet in deze bron.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron behandelt de REST-API koppelvlakstandaard, niet Grote Berichten. Geen versie-informatie over GB aanwezig.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over de Grote Berichten koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst behandelt de ebMS2 standaard. Digikoppeling Grote Berichten of versienummer v3.8.1 worden niet vermeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over de Grote Berichten koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat uitsluitend over de WUS koppelvlakstandaard en bevat geen informatie over de Grote Berichten koppelvlakstandaard of een versienummer daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
-  - *Hoewel de bron wel over Digikoppeling-Koppelvlakstandaard-GB gaat, bevat de aangeleverde brontekst geen versienummer. De GitHub-pagina toont alleen dat het repository bestaat en gepubliceerd is op gitdocumentatie.logius.nl/publicatie/dk/gb/, maar geen vastgestelde versie v3.8.1.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over de Grote Berichten koppelvlakstandaard of diens versienummer.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron noemt Grote Berichten in de onderbouwing van TLS-gebruik, maar bevat geen versienummer voor die standaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over de Grote Berichten koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De bron bevat geen informatie over de Grote Berichten koppelvlakstandaard of versienummer v3.8.1.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
-  - *De brontekst bevat geen informatie over de Grote Berichten koppelvlakstandaard of versienummers.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
-  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Koppelvlakstandaard-GB wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
   - *De brontekst bevat geen informatie over versienummers van de Grote Berichten koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
-  - *Grote Berichten wordt als voorbeeld aangehaald ('Grote Berichten Push variant'), maar geen versienummer voor de koppelvlakstandaard wordt vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De bron gaat over ebMS2, niet over Grote Berichten.*
 </details>
 
-## GROUNDED — minstens één bron ondersteunt de claim (22)
+### `ls-dk-0008` — SKILL.md:45 *(§ Repositories)*
+
+> Digikoppeling-Beveiligingsstandaarden-en-voorschriften is vastgesteld als v3.0.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling beveiligingsstandaarden
+
+<details><summary>8x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De bron verwijst naar Digikoppeling Beveiligingsstandaarden en voorschriften maar noemt geen versienummer v3.0.0.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De bron verwijst naar Digikoppeling Beveiligingsstandaarden en voorschriften maar noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron vermeldt geen versienummer voor Digikoppeling-Beveiligingsstandaarden-en-voorschriften, alleen een verwijzing naar het document.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  - *De brontekst bevat geen versie-informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt de Beveiligingsstandaarden en voorschriften als gerelateerd document maar geeft geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft uitsluitend de REST-API koppelvlakstandaard repository. Informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften staat niet in deze bron.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De brontekst verwijst naar Digikoppeling Beveiligingsstandaarden en voorschriften als normatieve referentie, maar vermeldt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De bron gaat over ebMS2, niet over beveiligingsstandaarden en voorschriften.*
+</details>
+
+### `ls-dk-0009` — SKILL.md:46 *(§ Repositories)*
+
+> Digikoppeling-Identificatie-en-Authenticatie is vastgesteld als v1.5.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling identificatie en authenticatie
+
+<details><summary>8x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De bron verwijst naar Digikoppeling Identificatie en Authenticatie maar noemt geen versienummer v1.5.0.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De bron verwijst naar Digikoppeling Identificatie en Authenticatie maar noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron vermeldt geen versienummer voor Digikoppeling-Identificatie-en-Authenticatie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  - *De brontekst bevat geen versie-informatie over Digikoppeling-Identificatie-en-Authenticatie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt Digikoppeling Identificatie en Authenticatie als gerelateerd document maar geeft geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft uitsluitend de REST-API koppelvlakstandaard repository. Informatie over Digikoppeling-Identificatie-en-Authenticatie staat niet in deze bron.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De brontekst verwijst naar Digikoppeling Identificatie en Authenticatie als normatieve referentie, maar vermeldt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De bron gaat over ebMS2, niet over Identificatie en Authenticatie.*
+</details>
+
+### `ls-dk-0010` — SKILL.md:47 *(§ Repositories)*
+
+> OIN-Stelsel is vastgesteld als v3.0.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-Stelsel
+
+<details><summary>8x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *OIN-Stelsel als apart document of versie v3.0.0 wordt in deze bron niet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *OIN-Stelsel als document of versienummer wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron vermeldt het OIN-stelsel maar geen versienummer voor het OIN-Stelsel document.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  - *De brontekst bevat geen informatie over het OIN-Stelsel of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *Het OIN-Stelsel als afzonderlijk vastgesteld document met versienummer wordt in de bron niet vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft uitsluitend de REST-API koppelvlakstandaard repository. Informatie over het OIN-Stelsel staat niet in deze bron.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De brontekst bevat geen informatie over het OIN-Stelsel of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De bron gaat over ebMS2, niet over het OIN-Stelsel.*
+</details>
+
+### `ls-dk-0037` — reference.md:94 *(§ Grote Berichten)*
+
+> Grote Berichten gebruikt HTTP 1.1 met ondersteuning voor BYTE-RANGE (RFC 7233) voor hervatbare downloads.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
+
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7233.txt](https://www.rfc-editor.org/rfc/rfc7233.txt)
+  - *De bron is RFC 7233 zelf (de HTTP Range Requests specificatie). Deze bron beschrijft de technische werking van byte-range requests, maar bevat geen informatie over Digikoppeling Grote Berichten of hoe dat profiel HTTP 1.1 en RFC 7233 toepast. De claim gaat over een specifiek Digikoppeling-profiel, niet over RFC 7233 zelf.*
+
+### `ls-dk-0039` — reference.md:116 *(§ Grote Berichten)*
+
+> Er is geen bovengrens gedefinieerd voor de bestandsgrootte bij Grote Berichten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
+
+<details><summary>8x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De bron noemt alleen de ondergrens van 20 MiB maar doet geen uitspraak over een bovengrens of het ontbreken daarvan.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *Bovengrens voor bestandsgrootte bij Grote Berichten wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt uitsluitend ebMS2. Bestandsgroottes bij Grote Berichten worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Geen bovengrens voor bestandsgrootte bij Grote Berichten: onderwerp Grote Berichten ontbreekt volledig in deze bron.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron stelt een ondergrens van 20 MiB maar noemt geen bovengrens. De afwezigheid van een bovengrens is impliciet, maar de bron spreekt dit nergens expliciet uit.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen bovengrens voor bestandsgrootte bij Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *Bestandsgrootte bij Grote Berichten wordt niet besproken in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Geen informatie over Grote Berichten of bestandsgroottes in deze bron.*
+</details>
+
+## CONTRADICTED — bron spreekt de claim expliciet tegen (3)
+
+### `ls-dk-0015` — SKILL.md:103 *(§ Profielkenmerken Matrix)*
+
+> REST-API profiel maakt gebruik van TLS voor transportbeveiliging; signing en encryptie op berichtniveau zijn niet gestandaardiseerd binnen het REST-API-profiel.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API profiel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Versleuteling op basis van mTLS conform de Digikoppeling Beveiligings voorschriften [...] Digikoppeling REST API kent nog geen gestandaardiseerde versies voor signing of encryptie
+- **CONTRADICTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Vanaf versie 2.0 van het Digikoppeling REST API profiel wordt signing en encryptie ondersteund (zie 3.5 Signing & Encryptie (in HTTP REST Context)). [...] Indien signing van HTTP body/header wordt toegepast is het Verplicht om dit te doen volgens de regels van de ADR Module ADR-HTTP Message and payload signing with JAdES
+  - *De claim stelt dat signing en encryptie op berichtniveau 'niet gestandaardiseerd' zijn binnen het REST-API-profiel, maar de bron beschrijft expliciet dat signing en encryptie wel gestandaardiseerd zijn (via JAdES en ADR-modules), zij het optioneel toepasbaar.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt het REST-API profiel niet; dit is een ebMS2-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt het REST-API profiel niet inhoudelijk.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Het REST-API profiel en berichtniveau signing/encryptie worden niet behandeld in deze bron over Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen REST-API profiel specifiek. TLS wordt algemeen behandeld maar niet in relatie tot het REST-API profiel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *REST-API profiel en TLS voor transportbeveiliging worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *REST-API profiel en TLS-transportbeveiliging worden niet besproken in deze OIN-handreiking.*
+</details>
+
+### `ls-dk-0020` — SKILL.md:365 *(§ Retry Strategie (ebMS2 Reliable Messaging))*
+
+> ebMS2 osb-rm garandeert at-most-once delivery: berichten worden nooit dubbel afgeleverd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
+
+- **CONTRADICTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Reliable Messaging profile 2, Once-And-Only-Once Reliable Messaging at the End-To-End level only based upon end-to-end retransmission. [...] The ToParty MSH must also filter any duplicate messages based on ebXML MessageId.
+  - *De bron beschrijft 'Once-And-Only-Once' delivery, wat exactly-once betekent, niet at-most-once. At-most-once zou betekenen dat berichten nooit dubbel worden afgeleverd maar eventueel verloren kunnen gaan zonder herlevering. Reliable messaging combineert herlevering (dus at-least-once op transport) met duplicate eliminatie, resulterend in exactly-once, niet at-most-once.*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De brontekst beschrijft het ebMS2 osb-rm profiel als betrouwbaar ('precies één keer afgeleverd'), maar de specifieke term 'at-most-once delivery' en de garantie dat berichten nooit dubbel worden afgeleverd worden niet als zodanig benoemd. De bron beschrijft 'Betrouwbaar: Garantie dat een bericht met zekerheid (precies één keer) wordt afgeleverd', wat eerder at-least-once of exactly-once suggereert, maar de exacte delivery-semantiek van at-most-once staat niet expliciet benoemd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *ebMS2 delivery-garanties worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt ebMS2 osb-rm delivery guarantees niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *ebMS2 osb-rm delivery guarantees worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen at-most-once delivery garanties van ebMS2.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *at-most-once delivery bij ebMS2 wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *At-most-once delivery bij ebMS2 osb-rm wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0055` — reference.md:83 *(§ ebMS2)*
+
+> ebMS2 Message Ordering is optionele volgordelijkheid van berichten via ConversationId en SequenceNumber.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Volgorde van berichten zo mogelijk handhaven [...] Asynchroon berichten correleren d.m.v. message ID [...] Meerdere berichten logisch samenvoegen
+  - *De bron bevestigt dat ebMS2 volgordelijkheid ondersteunt en berichten via message ID correleert. ConversationId wordt elders in de bron vermeld als ebMS-concept. 'SequenceNumber' als specifiek technisch element en de kwalificatie 'optioneel' voor de volgordelijkheid worden niet expliciet in de bron benoemd; de bron zegt 'zo mogelijk handhaven', wat optionaliteit impliceert maar niet via de term 'optioneel' bevestigt.*
+- **CONTRADICTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Message Order is strongly discouraged in these profiles. Many organisations use message handlers that do not support this functionality. Therefore, it can only be used if communicating parties agree to this option in advance.
+  - *De claim stelt dat Message Ordering een optionele mogelijkheid is. De bron markeert het als 'Optional' maar voegt expliciet toe dat het 'strongly discouraged' is. Bovendien werkt Message Ordering in ebMS2 niet via ConversationId en SequenceNumber als gecombineerd mechanisme zoals de claim suggereert — de bron koppelt volgordelijkheid aan het Message Order module (Section 9), niet aan ConversationId. ConversationId dient voor correlatie van berichten, niet voor volgordelijkheid. De beschrijving van het mechanisme in de claim klopt niet met wat de bron beschrijft.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De brontekst gaat over het Digikoppeling REST API profiel. Het ebMS2 osb-rm profiel wordt enkel kort vermeld in een vergelijkingstabel, maar Message Ordering via ConversationId en SequenceNumber wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *ebMS2 en Message Ordering via ConversationId en SequenceNumber komen niet voor in deze WUS-standaard. De bron vermeldt zelfs expliciet dat WS-RM (Reliable Messaging) verwijzingen zijn verwijderd in versie 3.5.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *ebMS2 Message Ordering, ConversationId en SequenceNumber worden niet behandeld in deze Grote Berichten koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen ebMS2 Message Ordering, ConversationId of SequenceNumber.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *ebMS2 Message Ordering via ConversationId en SequenceNumber wordt niet behandeld in deze bron over Identificatie en Authenticatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *ebMS2, Message Ordering, ConversationId en SequenceNumber worden niet behandeld in deze bron.*
+</details>
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (10)
+
+### `ls-dk-0014` — SKILL.md:83 *(§ Profielkeuze)*
+
+> Bij routering via een niet-vertrouwde intermediair moet de signed (-S) of signed+encrypted (-SE/-E) variant van het gekozen profiel worden gekozen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling profielkeuze beveiliging
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Bevind zich tussen partijen een niet vertrouwde (transparante) intermediair? Kies dan voor een Signed profiel. Mag een niet vertrouwde intermediair informatie niet inzien? Kies dan voor een Encyrpted profiel.
+  - *De bron adviseert ('kies dan voor') signed/encrypted profielen bij niet-vertrouwde intermediairs, maar formuleert dit als aanbeveling/hulpmiddel bij profielkeuze, niet als expliciete MUST-verplichting.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > End-to-End Security: op basis van Reliable Messaging of Best Effort wordt een bericht beveiligd tussen de uiteindelijke Consumer en de uiteindelijke Provider, ook wanneer er zich intermediairs bevinden in het pad tussen die twee.
+  - *De bron beschrijft End-to-End Security voor het geval van intermediairs, maar formuleert dit niet expliciet als een verplichting bij 'niet-vertrouwde intermediairs'. De bron beschrijft de profielen, maar niet een keuzeregel op basis van vertrouwen van de intermediair.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > End-to-End Security: een bericht wordt beveiligd tussen de uiteindelijke consumer en de uiteindelijke provider, ook wanneer er zich intermediairs bevinden in het pad tussen die twee. [...] voor End-to-End Security, door middel van signing (ondertekening) en (optioneel) encryptie (versleuteling) op berichtniveau
+  - *De bron bevestigt dat end-to-end beveiliging (signing/encryptie) primair van toepassing is bij intermediairs. De claim stelt dat het gekozen profiel de -S of -SE/-E variant MOET zijn bij niet-vertrouwde intermediairs — de bron zegt dit is 'primair van toepassing' maar legt geen expliciete MUST-verplichting op specifiek bij niet-vertrouwde intermediairs. De claim is breder dan wat de bron normatief stelt.*
+<details><summary>5x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De bron beschrijft geen keuzeregels voor profielkeuze bij niet-vertrouwde intermediairs voor signed/encrypted varianten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Profielkeuze bij niet-vertrouwde intermediairs (signed/encrypted varianten) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen profielkeuze op basis van intermediairs of signed/encrypted varianten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *Profielkeuze beveiliging bij niet-vertrouwde intermediair wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Profielkeuze bij routering via niet-vertrouwde intermediair wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0016` — SKILL.md:105 *(§ Profielkenmerken Matrix)*
+
+> Grote Berichten gebruikt TLS voor transport; payload-encryptie kan aanvullend worden toegepast maar is niet voorgeschreven in het profiel.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS.
+  - *TLS voor transport wordt bevestigd. Payload-encryptie als aanvullende mogelijkheid wordt niet vermeld in de bron; het tweede deel van de claim (payload-encryptie kan aanvullend maar is niet voorgeschreven) is NOT_FOUND.*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De brontekst beschrijft Grote Berichten in secties 4.4.5, 5.4, 6.6 en 9.1.1, maar maakt geen specifieke uitspraak over of payload-encryptie niet voorgeschreven is als aanvullende optie. De bron noemt wel dat Grote Berichten gebruik maakt van HTTPS-downloads en dat security gelijkwaardig is aan andere koppelvlakstandaarden, maar de specifieke claim over payload-encryptie als niet-voorgeschreven optie staat niet in de brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *Grote Berichten en payload-encryptie worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt Grote Berichten niet; dit is een ebMS2-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt Grote Berichten niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen Grote Berichten profiel specifiek.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *Grote Berichten en TLS/payload-encryptie worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Grote Berichten en TLS-transport komen niet voor in deze bron.*
+</details>
+
+### `ls-dk-0018` — SKILL.md:362 *(§ Retry Strategie (ebMS2 Reliable Messaging))*
+
+> Bij ebMS2 profiel osb-rm geldt geen voorgeschreven backoff-strategie voor het retry interval; dit is configureerbaar in de CPA via RetryInterval.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Where possible, the values of Retries and RetryInterval should be set to allow reliable delivery of messages even after prolonged unavailability. If no value is defined by the parties, a value of 5 days is used.
+  - *De bron bevestigt dat RetryInterval configureerbaar is in de CPA en dat er geen vaste waarde is opgelegd, maar noemt geen expliciete backoff-strategie als wel of niet voorgeschreven. De claim over 'geen voorgeschreven backoff-strategie' wordt indirect ondersteund.*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De brontekst bevat geen informatie over backoff-strategieën of RetryInterval configuratie in de CPA voor het ebMS2 osb-rm profiel. Dit niveau van detail ontbreekt volledig in de architectuurdocumentatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *ebMS2 en CPA/RetryInterval worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt ebMS2 osb-rm niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *ebMS2 osb-rm backoff-strategie en CPA RetryInterval worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen ebMS2 retry-strategie of CPA RetryInterval.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *ebMS2 osb-rm backoff-strategie en RetryInterval worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *ebMS2 osb-rm backoff-strategie en RetryInterval worden niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0025` — reference.md:45 *(§ REST-API)*
+
+> Het gebruik van Federated Service Connectivity (FSC) is verplicht bij Digikoppeling REST-API vanaf v3.0.1.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Het Digikoppeling Koppelvlakstandaard REST-API is gebaseerd op de Federated Services Connectivity (FSC) standaard en de REST API Design Rules die in 2020 door het Kennisplatform API's zijn ontwikkeld.
+  - *De bron bevestigt dat de REST-API koppelvlakstandaard gebaseerd is op FSC, maar maakt geen uitspraak over een specifieke versienummer (v3.0.1) of dat FSC 'verplicht' is in de zin van een absolute must. De bron beschrijft FSC als basis maar noemt geen versienummer.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Gebruik van de FSC-standaard binnen het Digikoppeling REST API profiel is verplicht [...] Voor bestaande implementaties is het toegestaan tot 1/1/2027 gebruik te maken van versie 1.1 van de Digikoppeling REST-API Koppelvlakstandaard.
+  - *FSC is inderdaad verplicht, maar de claim stelt 'vanaf v3.0.1'. De bron bevestigt de verplichting maar koppelt die aan v4.0.0; versie 3.0.1 wordt alleen vermeld als de vorige versie die tot 2027 nog gebruikt mag worden. Of FSC al in 3.0.1 verplicht was, is niet te bepalen uit deze bron.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt het REST-API profiel en FSC niet; dit is een ebMS2-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt het REST-API profiel en FSC-verplichting niet inhoudelijk.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *FSC-verplichting bij REST-API v3.0.1 wordt niet behandeld in deze bron over Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen REST-API koppelvlakstandaard v3.0.1 of FSC-verplichting.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *FSC-verplichting bij Digikoppeling REST-API v3.0.1 wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *FSC-verplichting bij Digikoppeling REST-API v3.0.1 wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0027` — reference.md:40 *(§ REST-API)*
+
+> Het service contract bij REST-API koppelvlak is een OpenAPI Specification (OAS) 3.x.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Een servicecontract voor een REST API service heet een OAS. Deze beschrijving wordt opgesteld door de aanbieder van de service. [...] Voor het beschrijven van DK-Rest API's is het gebruik van OAS verplicht.
+  - *De bron bevestigt dat OAS verplicht is voor DK-REST API's, maar noemt geen specifieke versie '3.x'. De bron verwijst naar [Pas-toe-of-leg-uit] voor de te gebruiken versie: 'Op [Pas-toe-of-leg-uit] staat beschreven welke versie toegepast moet worden.'*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *OpenAPI Specification (OAS) als service contract voor het REST-API koppelvlak wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt uitsluitend de ebMS2 koppelvlakstandaard. REST-API of OpenAPI Specification wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt het REST-API profiel en OpenAPI Specification niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *OpenAPI Specification als service contract voor REST-API wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen OpenAPI Specification of service contracts bij REST-API.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *OpenAPI Specification als service contract bij REST-API wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *OpenAPI Specification als service contract bij REST-API koppelvlak wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0029` — reference.md:58 *(§ WUS (SOAP))*
+
+> WUS 2W-be-S garandeert integriteit en onweerlegbaarheid via digitale ondertekening met WS-Security en XML Digital Signature (XMLDSIG).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS 2W-be-S profiel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WB003 Indien WS-Security wordt toegepast, is ondertekenen verplicht [...] WB004 Ondertekenen van bericht onderdelen SOAP:body, SOAP:headers (WS-Addressing headers en Timestamp) is verplicht bij toepassing van End-to-End beveiliging. [...] Met het ondertekenen wordt authenticatie, integriteit en onweerlegbaarheid ondersteund.
+  - *De bron bevestigt dat signing via WS-Security verplicht is voor het 2W-be-S profiel en dat dit integriteit en onweerlegbaarheid ondersteunt. De claim noemt specifiek 'XML Digital Signature (XMLDSIG)' — de bron vermeldt XMLDSIG niet expliciet bij naam, maar verwijst naar WS-I BSP 1.1 en WS-Security, waaronder XMLDSIG valt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > SIGN002 Signing conform XMLDSIG is verplicht [...] SIGN001 Signing met SHA-2 is verplicht. Minimaal SHA-256.
+  - *De bron bevestigt XMLDSIG en SHA-2 signing, maar specificeert dit niet in relatie tot het WUS 2W-be-S profiel of WS-Security. De claims over integriteit en onweerlegbaarheid zijn niet letterlijk terug te vinden.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De brontekst vermeldt dat het WUS 2W-be-S profiel bestaat voor signing, maar beschrijft niet specifiek de technische mechanismen WS-Security en XML Digital Signature (XMLDSIG). De architectuurdocumentatie verwijst voor deze details naar de koppelvlakstandaard WUS zelf.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *WUS 2W-be-S profiel en WS-Security/XMLDSIG worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt uitsluitend ebMS2. WUS-profielen worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *WUS 2W-be-S profiel met WS-Security en XMLDSIG wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *WUS 2W-be-S profiel en WS-Security/XMLDSIG worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *WUS 2W-be-S profiel en WS-Security/XMLDSIG worden niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0030` — reference.md:59 *(§ WUS (SOAP))*
+
+> WUS 2W-be-SE garandeert integriteit, onweerlegbaarheid en vertrouwelijkheid via ondertekening en versleuteling met WS-Security en XML Encryption.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS 2W-be-SE profiel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WB003 Indien WS-Security wordt toegepast, is ondertekenen verplicht en versleutelen optioneel (keuze profiel Digikoppeling 2W-be-S, Digikoppeling 2W-be-SE,). [...] WB005 Bij toepassen van versleutelen geldt dit voor de volgende bericht onderdelen: SOAP:body
+  - *De bron bevestigt ondertekening én versleuteling voor 2W-be-SE, en dat dit integriteit, onweerlegbaarheid en vertrouwelijkheid biedt. 'XML Encryption' als term wordt niet expliciet genoemd; de bron verwijst naar WS-Security en Digikoppeling Beveiligingsstandaarden voor de algoritmen.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > ENC001 Indien er gebruik wordt gemaakt van XML encryption op payload niveau dient de FIPS 197 standaard (AES) te worden gebruikt. ENC002 Encryptie conform XML versleuteling is verplicht
+  - *De bron bevestigt XML Encryption en AES, maar koppelt dit niet specifiek aan het WUS 2W-be-SE profiel of WS-Security. Integriteit en onweerlegbaarheid via XMLDSIG worden elders in de bron bevestigd, maar niet gecombineerd in relatie tot dit specifieke profiel.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De brontekst vermeldt dat het WUS 2W-be-SE profiel bestaat voor signing en encryption, maar beschrijft niet specifiek de technische mechanismen WS-Security en XML Encryption. De architectuurdocumentatie verwijst voor deze details naar de koppelvlakstandaard WUS zelf.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *WUS 2W-be-SE profiel wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt uitsluitend ebMS2. WUS-profielen worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *WUS 2W-be-SE profiel wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *WUS 2W-be-SE profiel en XML Encryption worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *WUS 2W-be-SE profiel en XML Encryption worden niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0033` — reference.md:71 *(§ ebMS2)*
+
+> ebMS2 gebruikt SOAP 1.1 met ebMS2 headers en payload als MIME-attachment als berichtformaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Manifest elements must only reference business documents or other payloads that are included in the ebXML message as a MIME part
+  - *De bron bevestigt het gebruik van MIME-attachments voor payload en verwijst naar SOAP, maar benoemt niet expliciet 'SOAP 1.1 met ebMS2 headers' als berichtformaat. De MIME-attachment structuur wordt bevestigd; de SOAP 1.1-specificatie wordt impliciet gehanteerd via referentie aan [SOAP] (versie 1.1) in de normatieve referenties.*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De bron beschrijft ebMS2 functioneel maar vermeldt nergens dat SOAP 1.1 specifiek wordt gebruikt of dat de payload als MIME-attachment wordt verstuurd. Dit is technisch detailniveau dat buiten de architectuurdocumentatie valt.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *ebMS2 berichtformaat (SOAP 1.1 met MIME-attachment) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt ebMS2 niet inhoudelijk.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *ebMS2 berichtformaat (SOAP 1.1 met MIME-attachments) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen ebMS2 berichtformaat of MIME-attachments.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *ebMS2 berichtformaat (SOAP 1.1 met MIME-attachment) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *ebMS2 berichtformaat met SOAP 1.1 en MIME-attachment wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0050` — reference.md:165 *(§ Berichtniveau-beveiliging)*
+
+> Encryptie op berichtniveau gebruikt symmetrische versleuteling met AES-128 of AES-256 voor de payload en asymmetrische versleuteling (RSA) voor de sessiesleutel.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling berichtniveau-beveiliging
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > ENC001 Indien er gebruik wordt gemaakt van XML encryption op payload niveau dient de FIPS 197 standaard (AES) te worden gebruikt. ENC003 De ondersteunde data encryption algoritmen zijn: 3DES(*) AES128 AES256 ENC004 Het Key transport algorithm maakt gebruik van de RSA-OAEP algoritmen.
+  - *AES-128 en AES-256 voor payload worden bevestigd, evenals RSA voor sleuteltransport. De bron noemt echter geen 'sessiesleutel' expliciet en spreekt van RSA-OAEP, niet generiek 'asymmetrische versleuteling (RSA)'. De strekking klopt grotendeels.*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De bron vermeldt 'Encrypted' als profiel voor versleuteling van payload en attachments, maar geeft geen informatie over AES-128, AES-256 of RSA als specifieke algoritmen. Algoritme-eisen vallen buiten scope van dit architectuurdocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *AES-128/AES-256 en RSA voor sessiesleutels worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron verwijst voor encryptie-algoritmen naar 'Digikoppeling Beveiligingsstandaarden en voorschriften'. Specifieke vermelding van AES-128, AES-256 of RSA voor sessiesleutelversleuteling ontbreekt in deze bron.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron beschrijft encryptie (WB005, WB006, WB008) maar verwijst voor concrete algoritmen (AES-128, AES-256, RSA) naar het externe beveiligingsdocument. De specifieke algoritmen staan niet in deze brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Berichtniveau-encryptie met AES of RSA wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *Berichtniveau-encryptie met AES en RSA wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *AES- of RSA-encryptie op berichtniveau wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0052` — reference.md:45 *(§ REST-API)*
+
+> FSC verzorgt de federatieve autorisatie en logging van API-aanroepen tussen organisaties bij Digikoppeling REST-API.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API FSC-integratie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Het Digikoppeling Koppelvlakstandaard REST-API is gebaseerd op de Federated Services Connectivity (FSC) standaard en de REST API Design Rules [...] De standaard FSC schrijft voor hoe gekoppeld kan worden met een API's, hoe API's in een netwerk gevonden kunnen worden en wanneer en hoe log regels moeten worden weggeschreven.
+  - *De bron bevestigt dat FSC de basis is voor het REST-API koppelvlak en dat FSC logging en discovery regelt. 'Federatieve autorisatie' als term staat niet in de bron; de bron noemt wel 'Mechanisme voor het autoriseren van koppelingen met een API' als functionaliteit van de DK REST-API standaard. Het woord 'federatief' in relatie tot autorisatie is niet expliciet aanwezig.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Hoe de identiteit van een organisatie wordt bepaald en vertrouwd. Hoe een autorisatie om te mogen koppelen met een API gegeven, geweigerd of ontnomen wordt. [...] Hoe logregels weggeschreven moet worden.
+  - *De bron bevestigt dat FSC autorisatie en logging regelt, maar de term 'federatieve autorisatie' als zodanig staat niet in de bron. De claim is een goede parafrase maar de specifieke formulering 'federatieve autorisatie van API-aanroepen' is iets specifieker dan wat de bron letterlijk zegt.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt uitsluitend ebMS2. FSC (Federated Service Connectivity) of federatieve autorisatie bij REST-API wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *FSC (Federated Service Connectivity) en REST-API worden in deze WUS-standaard niet behandeld als onderwerp.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *FSC (Federated Service Connectivity) wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen FSC of federatieve autorisatie en logging bij REST-API.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *FSC en federatieve autorisatie bij Digikoppeling REST-API worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *FSC en federatieve autorisatie van API-aanroepen worden niet behandeld in deze bron.*
+</details>
+
+## UNGROUNDED — geen bron ondersteunt de claim (1)
+
+### `ls-dk-0017` — SKILL.md:145 *(§ Implementatievoorbeelden)*
+
+> RFC 9457 problem+json foutafhandeling is verplicht per API Design Rules voor REST-API foutresponses.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API foutafhandeling
+
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
+  - *RFC 9457 definieert het problem+json formaat zelf, maar bevat geen verwijzing naar API Design Rules of Digikoppeling. De claim dat gebruik verplicht is 'per API Design Rules' is een normatieve uitspraak over een externe standaard (API Design Rules) die niet in deze brontekst staat. De bron beschrijft alleen het formaat en zegt dat het gebruikt KAN worden; een verplichting opgelegd door API Design Rules staat hier niet in.*
+
+## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (2)
+
+### `ls-dk-0003` — SKILL.md:40 *(§ Repositories)*
+
+> Digikoppeling-Architectuur is vastgesteld als v2.1.1.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling-Architectuur
+
+**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md tabel: 'Digikoppeling-Architectuur publicatie v2.1.1 vs tag 2.0.2'. CONTRADICTED door logius-standaarden.github.io (GitHub-tag 2.0.2), maar gitdocumentatie.logius.nl is leidend per gedocumenteerde keuze: 'De skill gebruikt versienummers van gitdocumentatie.logius.nl als bron van waarheid voor vastgestelde (DEF) versies.'
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Digikoppeling Architectuur 2.1.1 Logius Standaard Vastgestelde versie 30 januari 2025
+- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  > Digikoppeling Architectuur 2.1.0 Logius Standaard Vastgestelde versie 30 januari 2025
+  - *De bron vermeldt expliciet versie 2.1.0, niet 2.1.1 zoals de claim stelt.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De bron gaat over de REST-API koppelvlakstandaard, niet over de Digikoppeling-Architectuur. Versienummers van andere documenten worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron vermeldt geen versienummer voor Digikoppeling-Architectuur. Er wordt alleen naar het document verwezen als referentie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  - *De brontekst vermeldt alleen versie 2.0 (vastgesteld maart 2021) en release 2.0.2 (dec 2022). Versie 2.1.1 wordt nergens genoemd.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De brontekst betreft de GitHub-repository van de REST-API koppelvlakstandaard. Versie-informatie over Digikoppeling-Architectuur staat niet in deze bron.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De brontekst bevat geen informatie over versienummers van Digikoppeling-Architectuur.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst betreft de GitHub-repository van Digikoppeling-Koppelvlakstandaard-ebMS2, niet Digikoppeling-Architectuur. Versie-informatie over dat document staat hier niet.*
+</details>
+
+### `ls-dk-0004` — SKILL.md:41 *(§ Repositories)*
+
+> Digikoppeling-Koppelvlakstandaard-REST-API is vastgesteld als v4.0.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+
+**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md tabel: 'Digikoppeling-Koppelvlakstandaard-REST-API publicatie v4.0.0 vs tag 3.0.0'. CONTRADICTED door GitHub-tag 3.0.0, maar gitdocumentatie.logius.nl is leidend per gedocumenteerde keuze: 'De skill gebruikt versienummers van gitdocumentatie.logius.nl als bron van waarheid voor vastgestelde (DEF) versies.'
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Digikoppeling Koppelvlakstandaard REST-API 4.0.0 Logius Standaard Vastgestelde versie 21 april 2026
+- **CONTRADICTED** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  > 1.1.1 release Latest Dec 9, 2022 + 8 releases
+  - *De meest recente release die zichtbaar is in de bron is v1.1.1 (dec 2022). Er is geen v4.0.0 vermeld. De claim dat de standaard als v4.0.0 is vastgesteld wordt niet ondersteund; de bron toont een significant lager versienummer als laatste release.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De bron verwijst naar de Digikoppeling Koppelvlakstandaard REST-API maar noemt geen versienummer. Versie-metadata van afzonderlijke koppelvlakstandaarden staat niet in dit architectuurdocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron bevat geen informatie over de REST-API koppelvlakstandaard versie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  - *De bron verwijst alleen naar het bestaan van een REST API profiel; versienummers van koppelvlakstandaarden staan niet in deze brontekst.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt de REST-API koppelvlakstandaard als gerelateerd document maar geeft geen versienummer.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De brontekst is de werkversie van de REST-API koppelvlakstandaard zelf, maar vermeldt geen vastgesteld versienummer v4.0.0. De vorige versie wordt aangeduid als 3.0.0 via de URL, maar een vastgesteld v4.0.0 wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De bron gaat over ebMS2, niet over de REST-API koppelvlakstandaard.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (32)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
 ### `ls-dk-0001` — SKILL.md:25 *(§ Digikoppeling)*
 
+> Digikoppeling is de Nederlandse standaard voor beveiligde elektronische gegevensuitwisseling tussen overheidsorganisaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling algemeen
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Digikoppeling is een standaard voor gestructureerde gegevensuitwisseling waarmee overheden op een veilige manier gegevens met elkaar kunnen uitwisselen.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Het Digikoppeling Rest API profiel is gericht op Machine-to-Machine (M2M) en Government-to-Government (G2G) interacties conform de algemene uitgangspunten van de Digikoppeling standaard
+  - *De bron bevestigt dat Digikoppeling een standaard is voor gegevensuitwisseling tussen overheidsorganisaties, maar gebruikt niet de formulering 'Nederlandse standaard voor beveiligde elektronische gegevensuitwisseling'. De scope en aard worden impliciet bevestigd maar niet als definitie uitgeschreven.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Digikoppeling biedt de mogelijkheid om op een sterk gestandaardiseerde wijze berichten uit te wisselen tussen service aanbieders en service afnemers.
+  - *De bron beschrijft Digikoppeling als standaard voor gegevensuitwisseling, maar beperkt het niet expliciet tot 'overheidsorganisaties' en noemt 'beveiligde elektronische gegevensuitwisseling' niet als samengevatte omschrijving. Het gaat over 'service aanbieders en service afnemers' in algemene zin.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > Digikoppeling biedt de mogelijkheid om op een gestandaardiseerde wijze berichten uit te wisselen tussen partijen.
+  - *De bron bevestigt dat Digikoppeling een standaard is voor gestandaardiseerde berichtenuitwisseling, maar vermeldt niet expliciet 'beveiligde' uitwisseling als kernkenmerk in de definitie, noch beperkt het zich expliciet tot 'overheidsorganisaties' in de definitiezin. Beveiliging wordt wel elders beschreven (TLS, PKIoverheid).*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > Digikoppeling biedt de mogelijkheid om op een sterk gestandaardiseerde wijze berichten uit te wisselen tussen serviceaanbieders (service providers) en serviceafnemers (service requesters of consumers).
+  - *De bron bevestigt dat Digikoppeling een standaard is voor gegevensuitwisseling, maar noemt niet expliciet 'overheidsorganisaties' als exclusieve doelgroep, noch wordt 'de Nederlandse standaard' als zodanig gepositioneerd.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  > Digikoppeling maakt het mogelijk voor overheidsorganisaties om op een gestandaardiseerde wijze gebruik te maken van elkaars services, conform de NORA (Nederlandse Overheids Referentie Architectuur).
+  - *De bron bevestigt dat Digikoppeling een gestandaardiseerde uitwisseling biedt tussen overheidsorganisaties, maar omschrijft het niet expliciet als 'de Nederlandse standaard voor beveiligde elektronische gegevensuitwisseling'. Het beveiligingsaspect en de kwalificatie 'de Nederlandse standaard' worden niet letterlijk zo gesteld.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  > Het Organisatie-identificatienummer OIN, voorheen Overheidsidentificatienummer, is onderdeel van de Digikoppeling standaard. De standaard wordt gebruikt in elektronische gegevensuitwisseling met en door de overheid.
+  - *De bron bevestigt dat Digikoppeling een standaard is voor elektronische gegevensuitwisseling met/door de overheid, maar beschrijft het niet expliciet als 'beveiligd' of beperkt tot 'tussen overheidsorganisaties'. De bron is een OIN-handreiking, niet de Digikoppeling-standaard zelf.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron beschrijft de WUS koppelvlakstandaard maar definieert Digikoppeling niet expliciet als 'de Nederlandse standaard voor beveiligde elektronische gegevensuitwisseling tussen overheidsorganisaties'. De tekst noemt wel dat het gaat om gegevensuitwisseling via Digikoppeling, maar de bredere definitieclaim staat er niet in.*
+
+### `ls-dk-0002` — SKILL.md:25 *(§ Digikoppeling)*
+
 > Digikoppeling is opgenomen op de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling algemeen
 
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  > Digikoppeling is opgenomen op de pas toe of leg uit lijst van het Forum Standaardisatie.
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > De Digikoppeling standaard is opgenomen in de lijst met 'pas toe of leg uit'-standaarden van het College Standaardisatie. Het betreft de koppelvlakstandaarden ebMS2, WUS, REST API en Grote Berichten.
-<details><summary>15x NOT_FOUND (klap uit)</summary>
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Het OBDO heeft Digikoppeling daarom op de 'Pas toe of leg uit'-lijst geplaatst.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Het Digikoppeling Rest API profiel is gericht op Machine-to-Machine (M2M) en Government-to-Government (G2G) interacties conform de algemene uitgangspunten van de Digikoppeling standaard en het toepassingsgebied van Digikoppeling op de Pas-toe-of-leg-uit lijst (PTLU) van het Forum Standaardisatie
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  > Verplicht ('Pas toe leg uit') [...] Digikoppeling staat sinds 20 mei 2009 op de 'Pas toe of leg uit'-lijst.
+<details><summary>5x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *De brontekst bevat alleen een redirect-melding ('Redirecting to v2.1.1') en geen inhoudelijke tekst over de pas-toe-of-leg-uit-lijst.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De brontekst bevat alleen een redirect-melding ('Redirecting to v4.0.0') en geen inhoudelijke tekst over de Forum Standaardisatie-lijst.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst (ebMS2 koppelvlakstandaard) bevat geen vermelding van de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *De brontekst bevat alleen een redirect-melding ('Redirecting to v3.8.1'). Er is geen inhoudelijke tekst beschikbaar om deze claim te verifiëren.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron behandelt de koppelvlakstandaard Grote Berichten; de 'pas toe of leg uit'-lijst van Forum Standaardisatie wordt niet vermeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *De brontekst bevat alleen een redirect-melding ('Redirecting to v3.0.0') en geen inhoudelijke tekst over het Forum Standaardisatie of de pas-toe-of-leg-uit-lijst.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v2.2.2') en geen inhoudelijke informatie over het OIN-stelsel of Digikoppeling algemeen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *De bron behandelt certificaten en PKIoverheid binnen Digikoppeling. De 'pas toe of leg uit'-lijst van het Forum Standaardisatie wordt nergens genoemd.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *De bron behandelt adressering en routering met OIN; geen vermelding van de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt de 'pas toe of leg uit'-lijst van het Forum Standaardisatie niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *De brontekst behandelt de Best Practices WUS en bevat geen informatie over de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
   - *De bron vermeldt niets over de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v1.13.0'). Er is geen inhoudelijke tekst beschikbaar om de claim te verifiëren.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v2026-2027') en geen inhoudelijke informatie over Digikoppeling of de pas-toe-of-leg-uit-lijst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron maakt geen melding van de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron maakt geen melding van de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron vermeldt niets over de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
+- **NOT_FOUND** (low) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst is een navigatiepagina van het Forum Standaardisatie met alleen menustructuur en linklijsten. Digikoppeling wordt nergens specifiek genoemd. De tekst bevestigt wel dat er een 'pas toe of leg uit'-lijst bestaat, maar of Digikoppeling daarop staat is niet te verifiëren uit deze bron.*
 </details>
 
-### `ls-dk-0005` — SKILL.md:43 *(§ Repositories)*
+### `ls-dk-0005` — SKILL.md:42 *(§ Repositories)*
 
-> Digikoppeling-Koppelvlakstandaard-WUS is vastgesteld als v3.8.1.
+> Digikoppeling-Koppelvlakstandaard-ebMS2 is vastgesteld als v3.3.2.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
 
-- **SUPPORTED** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
-  > Releases 4 — 3.8.1 Latest Apr 11, 2022 + 3 releases
-  - *De bron toont expliciet dat release 3.8.1 de 'Latest' release is van de Digikoppeling-Koppelvlakstandaard-WUS repository.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
-  > 11/04/2022 3.8.1 Logius Vermelding REST-API koppelvlak
-  - *De documentbeheer-tabel vermeldt versie 3.8.1 als de meest recente gepubliceerde versie. Echter is de huidige brontekst een werkversie (werkversie 20 april 2026) die nog niet vastgesteld is: 'Dit is een werkversie die op elk moment kan worden gewijzigd, verwijderd of vervangen door andere documenten. Het is geen door het TO goedgekeurde consultatieversie.' De claim dat v3.8.1 'vastgesteld' is wordt impliciet ondersteund door de documentbeheer-tabel, maar de bron zelf is een latere werkversie, niet de vastgestelde versie.*
-<details><summary>25x NOT_FOUND (klap uit)</summary>
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Digikoppeling Koppelvlakstandaard ebMS2 3.3.2 Logius Standaard Vastgestelde versie 31 mei 2024
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  > Releases 4 — 3.3.1 Latest Apr 11, 2022 + 3 releases
+  - *De bron bevestigt dat dit de ebMS2-repository is en toont 3.3.1 als latest release. Claim stelt v3.3.2, maar de bron vermeldt 3.3.1 als meest recente zichtbare release. Mogelijk bestaat 3.3.2 in een latere release die niet zichtbaar is in de aangeleverde tekst. CONTRADICTED is te sterk omdat de paginatekst mogelijk afgekapt is; PARTIALLY_SUPPORTED omdat de repository klopt maar het versienummer afwijkt.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+  - *De bron verwijst naar de Digikoppeling Koppelvlakstandaard ebMS2 maar noemt geen versienummer v3.3.2.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst gaat over ebMS2, niet over de WUS koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Versie-informatie over de WUS koppelvlakstandaard staat niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Geen versienummer voor WUS koppelvlakstandaard vermeld in de bron.*
+  - *De bron behandelt de REST-API koppelvlakstandaard; het versienummer van de ebMS2-standaard wordt niet vermeld.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  - *De brontekst bevat geen versie-informatie over de ebMS2 koppelvlakstandaard.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
-  - *De bron vermeldt de WUS koppelvlakstandaard als bestaand document maar noemt geen versienummer.*
+  - *De bron vermeldt de ebMS2 koppelvlakstandaard als gerelateerd document maar geeft geen versienummer.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron betreft de REST-API repository; er is geen informatie over de WUS koppelvlakstandaard of versienummers daarvan.*
+  - *De bron betreft uitsluitend de REST-API koppelvlakstandaard repository. Informatie over de ebMS2 koppelvlakstandaard staat niet in deze bron.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron behandelt de REST-API koppelvlakstandaard, niet WUS. Geen versie-informatie over WUS aanwezig.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over de WUS koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst gaat uitsluitend over de ebMS2 koppelvlakstandaard. De WUS koppelvlakstandaard en versienummer v3.8.1 worden niet genoemd.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over de WUS koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron vermeldt geen versienummer van de WUS koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over de WUS koppelvlakstandaard of diens versienummer.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron verwijst niet naar de WUS koppelvlakstandaard en noemt geen versienummer.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over de WUS koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De bron bevat geen informatie over de WUS koppelvlakstandaard of versienummer v3.8.1.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
-  - *De brontekst bevat geen informatie over de WUS koppelvlakstandaard of versienummers.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
-  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Koppelvlakstandaard-WUS wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
-  - *De brontekst bevat geen informatie over versienummers van de WUS koppelvlakstandaard.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
-  - *WUS wordt meerdere keren genoemd als onderliggende standaard, maar geen versienummer voor de Digikoppeling-Koppelvlakstandaard-WUS wordt vermeld.*
+  - *De brontekst behandelt de REST-API koppelvlakstandaard. Er is geen informatie over versienummers van de ebMS2 koppelvlakstandaard.*
 </details>
 
-### `ls-dk-0008` — SKILL.md:46 *(§ Repositories)*
+### `ls-dk-0011` — SKILL.md:68 *(§ Profielkeuze)*
 
-> Digikoppeling-Identificatie-en-Authenticatie is vastgesteld als v1.5.0.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling identificatie en authenticatie
-
-- **SUPPORTED** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
-  > Digikoppeling Identificatie en Authenticatie 1.5.0 Logius Standaard Vastgestelde versie 15 mei 2025
-<details><summary>26x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *Digikoppeling-Identificatie-en-Authenticatie en versienummer v1.5.0 worden niet vermeld in de brontekst.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Versie-informatie over Digikoppeling-Identificatie-en-Authenticatie staat niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Geen versienummer voor Identificatie-en-Authenticatie vermeld in de bron.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
-  - *De bron vermeldt Digikoppeling Identificatie en Authenticatie als bestaand document maar noemt geen versienummer.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron betreft de REST-API repository; er is geen informatie over Digikoppeling-Identificatie-en-Authenticatie of versienummers daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
-  - *De bron verwijst naar Digikoppeling Identificatie en Authenticatie als referentie [DK-IDAuth] maar noemt geen versienummer v1.5.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over Digikoppeling-Identificatie-en-Authenticatie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
-  - *Digikoppeling-Identificatie-en-Authenticatie en versienummer v1.5.0 worden niet vermeld in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over Digikoppeling-Identificatie-en-Authenticatie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
-  - *De brontekst bevat geen informatie over het document Digikoppeling-Identificatie-en-Authenticatie of een versienummer daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
-  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over Digikoppeling-Identificatie-en-Authenticatie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
-  - *Digikoppeling-Identificatie-en-Authenticatie wordt niet vermeld in de bron.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over Digikoppeling-Identificatie-en-Authenticatie of diens versienummer.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
-  - *De bron verwijst naar Digikoppeling Identificatie en Authenticatie als informatieve referentie (DK-IDAuth), maar noemt geen versienummer.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
-  - *De brontekst betreft inderdaad de GitHub-repo van Digikoppeling-Identificatie-en-Authenticatie, maar bevat geen versienummer (v1.5.0). De README vermeldt alleen werkversie- en publicatielinks, geen vastgesteld versienummer.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
-  - *De brontekst bevat geen informatie over Digikoppeling-Identificatie-en-Authenticatie of versienummers.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
-  - *De bron gaat over het OIN-Stelsel. Digikoppeling-Identificatie-en-Authenticatie als apart document met versienummer wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
-  - *De brontekst bevat geen informatie over versienummers van Digikoppeling-Identificatie-en-Authenticatie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
-  - *Digikoppeling-Identificatie-en-Authenticatie wordt niet als document genoemd in deze bron; geen versienummer beschikbaar.*
-</details>
-
-### `ls-dk-0010` — SKILL.md:68 *(§ Profielkeuze)*
-
-> Berichten groter dan 20 MiB moeten via het Grote Berichten koppelvlak worden uitgewisseld.
+> Berichten groter dan 20 MiB moeten via de koppelvlakstandaard Grote Berichten worden uitgewisseld.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling Grote Berichten
 
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Grote berichten vormen een functionele uitbreiding op Digikoppeling uitwisseling voor de veilige bestandsoverdracht van berichten groter dan 20 MiB.
+  - *De bron beschrijft dat berichten groter dan 20 MiB via Grote Berichten worden uitgewisseld als functionele uitbreiding, maar formuleert dit als een situatie die 'zich kan voordoen' en een alternatieve aanpak, niet als expliciete MUST-verplichting met die drempelwaarde.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
   > VW001 Als partijen niet tot overeenstemming komen MOETEN zij berichten groter dan 20 MiB via het Koppelvlak Grote Berichten afhandelen.
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Berichten (Bevragingen of Meldingen) die een grootte hebben van meer dan 20 MiB kunnen op een andere wijze worden uitgewisseld. Hiervoor gelden specifieke afspraken.
-  - *De bron zegt 'kunnen op een andere wijze worden uitgewisseld', niet dat dit verplicht (MUST) is. De claim stelt 'moeten', maar de bron formuleert het als mogelijkheid, niet als verplichting.*
-<details><summary>15x NOT_FOUND (klap uit)</summary>
+  - *Exact overeenkomstig, met de nuance dat VW000 bilaterale afwijking toestaat.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *De drempelwaarde van 20 MiB voor Grote Berichten wordt niet vermeld in deze bron over de REST-API koppelvlakstandaard.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De brontekst gaat over ebMS2 en vermeldt geen drempelwaarde van 20 MiB voor Grote Berichten.*
+  - *De bron bevat geen informatie over de grens van 20 MiB voor Grote Berichten. Dit is een ebMS2-specificatie, niet een Grote Berichten document.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+  - *De bron gaat over de WUS koppelvlakstandaard en behandelt geen Grote Berichten of een grens van 20 MiB.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron gaat over beveiligingsstandaarden en -voorschriften. Er is geen vermelding van een drempelwaarde van 20 MiB of de koppelvlakstandaard Grote Berichten.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *De brontekst gaat over Identificatie en Authenticatie binnen Digikoppeling. Grote Berichten en de 20 MiB drempelwaarde worden niet behandeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron vermeldt Grote Berichten als onderdeel van Digikoppeling maar specificeert geen grenswaarde van 20 MiB.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *De bron gaat over certificaten en PKIoverheid. Grote Berichten en drempelwaarden worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *De bron gaat niet over Grote Berichten of een drempelwaarde van 20 MiB.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron gaat over ebMS2 best practices; het Grote Berichten koppelvlak en de 20 MiB drempelwaarde worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *De brontekst gaat over WUS Best Practices en bevat geen informatie over Grote Berichten of de 20 MiB drempelwaarde.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *De bron noemt geen drempelwaarde van 20 MiB. Er wordt wel gesproken over grote berichten die niet efficiënt door adapters verwerkt kunnen worden, maar zonder specifieke grenswaarde.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt het OIN-stelsel. Drempelwaarden voor Grote Berichten komen niet voor in deze tekst.*
 </details>
 
-### `ls-dk-0014` — SKILL.md:96 *(§ Profielkenmerken Matrix)*
+### `ls-dk-0012` — SKILL.md:74 *(§ Profielkeuze)*
 
-> Het profiel osb-rm biedt reliable, asynchrone berichtuitwisseling met signing mogelijk via osb-rm-S.
+> Bij gebruik van REST-API profiel is FSC verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API profiel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Het Digikoppeling Koppelvlakstandaard REST-API is gebaseerd op de Federated Services Connectivity (FSC) standaard en de REST API Design Rules die in 2020 door het Kennisplatform API's zijn ontwikkeld. De standaard FSC schrijft voor hoe gekoppeld kan worden met een API's, hoe API's in een netwerk gevonden kunnen worden en wanneer en hoe log regels moeten worden weggeschreven.
+  - *De bron stelt dat het REST-API profiel gebaseerd is op FSC en dat FSC schrijft voor hoe gekoppeld wordt, maar formuleert FSC niet als een expliciete MUST-verplichting ('is verplicht') voor gebruikers van het REST-API profiel.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Gebruik van de FSC-standaard binnen het Digikoppeling REST API profiel is verplicht
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron bevat geen informatie over het REST-API profiel of FSC. Dit is een ebMS2-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt het REST-API profiel niet inhoudelijk; er is alleen een korte vermelding dat naast WUS ook ebMS2- en REST-API-standaarden bestaan.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron gaat over Grote Berichten, niet over het REST-API profiel en FSC-verplichting.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen REST-API profiel of FSC-verplichting.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *De brontekst behandelt geen REST-API profiel of FSC-verplichting.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *REST-API profiel en FSC-verplichting worden niet besproken in deze OIN-handreiking.*
+</details>
+
+### `ls-dk-0013` — SKILL.md:79 *(§ Profielkeuze)*
+
+> Het ebMS2 reliable profiel (osb-rm) biedt betrouwbare aflevering.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Digikoppeling ebMS heeft reliable profiel (osb-rm) dat de bevestiging van ontvangst borgt.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Reliable Messaging: asynchrone uitwisseling met ontvangst bevestigingen en duplicaateliminatie door de ontvangende message handler*. Dit profiel is onder meer geschikt voor alle berichtenstromen die leiden tot updates van gegevensverzamelingen.
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *Het ebMS2 reliable profiel en betrouwbare aflevering worden niet inhoudelijk beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron gaat over WUS. ebMS2 en het osb-rm profiel worden niet inhoudelijk behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron behandelt het ebMS2 osb-rm profiel niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen ebMS2 profielen of reliable messaging.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *ebMS2 reliable profiel wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *ebMS2 osb-rm profiel komt niet voor in deze bron.*
+</details>
+
+### `ls-dk-0019` — SKILL.md:363 *(§ Retry Strategie (ebMS2 Reliable Messaging))*
+
+> Bij ebMS2 osb-rm geldt zonder afspraak een PersistDuration van 5 dagen.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Reliable Messaging: asynchrone uitwisseling met ontvangst bevestigingen en duplicaateliminatie door de ontvangende message handler. [...] Best Effort – Signed 1 osb-be-s [...] Reliable – Signed 1 osb-rm-s
-  - *De bron bevestigt dat osb-rm asynchroon is met reliable messaging (ontvangstbevestigingen) en dat een signed variant osb-rm-s bestaat.*
-<details><summary>16x NOT_FOUND (klap uit)</summary>
+  > Depends on the retry interval as defined in the particular collaboration, defined by the involved parties. If no value is defined by the parties, a value of 5 days is used.
+<details><summary>7x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+  - *De brontekst bevat geen informatie over PersistDuration of een standaardwaarde van 5 dagen voor het ebMS2 osb-rm profiel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *ebMS2 osb-rm PersistDuration wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+  - *De bron behandelt ebMS2 osb-rm PersistDuration niet.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Het osb-rm profiel van ebMS2 wordt niet behandeld in deze spec.*
+  - *PersistDuration bij ebMS2 osb-rm wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt geen PersistDuration of ebMS2 osb-rm configuratie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *PersistDuration bij ebMS2 osb-rm wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Het osb-rm profiel wordt niet beschreven in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Het osb-rm profiel en reliable/asynchrone berichtuitwisseling worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Het profiel osb-rm wordt niet besproken in deze bron.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt wel ebMS2 reliable messaging in algemene zin, maar noemt het profiel 'osb-rm' of 'osb-rm-S' niet expliciet als profielnaam.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *ebMS2 osb-rm profiel wordt niet behandeld in deze WUS Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *Het osb-rm profiel en bijbehorende kenmerken worden niet beschreven in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *Het specifieke profiel 'osb-rm' wordt niet bij naam genoemd in de bron. De bron beschrijft ebMS2 en reliable messaging in algemene termen maar noemt geen specifieke profielnamen zoals osb-rm of osb-rm-S.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *PersistDuration bij ebMS2 osb-rm komt niet voor in deze bron.*
 </details>
 
-### `ls-dk-0017` — SKILL.md:364 *(§ Retry Strategie (ebMS2 Reliable Messaging))*
+### `ls-dk-0021` — SKILL.md:364 *(§ Retry Strategie (ebMS2 Reliable Messaging))*
 
-> Bij het profiel osb-rm geldt duplicate-eliminatie: ontvanger herkent duplicaten op basis van MessageId.
+> ebMS2 osb-rm duplicate elimination herkent duplicaten op basis van MessageId.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling ebMS2 osb-rm reliable messaging
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Duplicate Elimination is required [...] The ToParty MSH must also filter any duplicate messages based on ebXML MessageId.
-- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > tns:duplicateElimination = "always"
-  - *De bron toont dat duplicateElimination op 'always' staat in de MessagingCharacteristics. Dit ondersteunt de claim dat duplicate-eliminatie op MessageId van toepassing is, hoewel het mechanisme (MessageId) niet expliciet wordt benoemd.*
-<details><summary>15x NOT_FOUND (klap uit)</summary>
+  > The ToParty MSH must also filter any duplicate messages based on ebXML MessageId.
+<details><summary>7x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+  - *De brontekst noemt geen duplicate elimination op basis van MessageId voor het ebMS2 osb-rm profiel. Dit detailniveau ontbreekt in de architectuurdocumentatie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *ebMS2 duplicate elimination op basis van MessageId wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+  - *De bron behandelt ebMS2 duplicate elimination niet.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Duplicate-eliminatie op basis van MessageId bij osb-rm wordt niet behandeld in deze Grote Berichten spec.*
+  - *ebMS2 duplicate elimination op basis van MessageId wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt geen duplicate elimination of MessageId in ebMS2.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *ebMS2 duplicate elimination op basis van MessageId wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Duplicate-eliminatie en MessageId worden niet besproken in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Duplicate-eliminatie en osb-rm reliable messaging worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Duplicate-eliminatie en MessageId worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *ebMS2 osb-rm en duplicate-eliminatie worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *Duplicate-eliminatie op basis van MessageId bij osb-rm wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *Het profiel 'osb-rm' en duplicate-eliminatie op basis van MessageId worden niet specifiek behandeld in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Duplicate elimination op basis van MessageId wordt niet behandeld in deze bron.*
 </details>
 
-### `ls-dk-0019` — reference.md:7 *(§ Architectuur)*
+### `ls-dk-0022` — reference.md:7 *(§ Architectuur)*
 
 > De Digikoppeling-architectuur is gebaseerd op een drielagenmodel dat inhoud, logistiek en transport van elkaar scheidt.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling architectuur
 
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > De drie lagen (inhoud, logistiek en transport) zijn in hoge mate ontkoppeld en dus onafhankelijk van elkaar. Afspraken over de inhoud van een bericht (payload) staan los van de logistieke laag. [...] De keuzes in de logistieke laag hebben op hun beurt geen invloed op de inrichting van de transportlaag
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > De uitwisseling tussen partijen wordt in drie lagen opgedeeld: Inhoud [...] Logistiek [...] Transport [...] Digikoppeling richt zich dus uitsluitend op de logistieke laag.
+  > De uitwisseling tussen partijen wordt in drie lagen opgedeeld: Inhoud: Op deze laag worden de afspraken gemaakt de inhoud van het uit te wisselen bericht [...] Logistiek: Op deze laag bevinden zich de afspraken betreffende transportprotocollen [...] Transport: deze laag verzorgt het daadwerkelijke transport van het bericht.
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > De uitwisseling tussen partijen wordt in drie lagen opgedeeld: Inhoud [...] Logistiek [...] Transport [...] Digikoppeling richt zich dus uitsluitend op de logistieke laag.
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  > Digikoppeling vormt de logistieke laag voor standaardisatie van communicatie tussen systemen bij overheidsorganisatie op basis van webservice standaarden. Digikoppeling is daardoor een laag die zich bevindt tussen het transportnetwerk (b.v. Diginetwerk of Internet) en de applicatielaag (functionele berichtinhoud).
-  - *De bron bevestigt de scheiding tussen transport, logistiek (Digikoppeling) en applicatielaag (inhoud), maar beschrijft dit niet expliciet als een 'drielagenmodel' met die terminologie.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > De uitwisseling tussen partijen is in drie lagen opgedeeld: Inhoud (gegevens) [...] Logistiek (processen) [...] Transport (techniek): deze laag verzorgt het daadwerkelijke transport van het bericht (TCP/IP). Digikoppeling richt zich uitsluitend op de logistieke laag.
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  > De uitwisseling tussen service providers en - requesters is in drie lagen opgedeeld: Inhoud: deze laag bevat afspraken over de inhoud van het uit te wisselen bericht... Logistiek: op deze laag bevinden zich de afspraken betreffende transportprotocollen... Transport: deze laag verzorgt het daadwerkelijke transport van het bericht.
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > De uitwisseling tussen partijen wordt in drie lagen opgedeeld: Inhoud: Op deze laag worden de afspraken gemaakt over de inhoud van het uit te wisselen bericht... Logistiek: Op deze laag bevinden zich de afspraken betreffende transportprotocollen... Transport: deze laag verzorgt het daadwerkelijke transport van het bericht.
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Om digitale berichten uit te wisselen moeten organisaties op drie niveaus afspraken maken: Over de inhoud en betekenis van berichten (payload en eventuele bijlagen) [...] Over de logistiek (envelop) [...] Over het transport (netwerk)
-<details><summary>10x NOT_FOUND (klap uit)</summary>
+  > De uitwisseling tussen partijen wordt in drie lagen opgedeeld: Inhoud [...] Logistiek [...] Transport
+  - *Het drielagenmodel (inhoud, logistiek, transport) wordt expliciet beschreven.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > De uitwisseling tussen service providers en requesters wordt in drie lagen opgedeeld: Inhoud: op deze laag worden de afspraken gemaakt over de inhoud van het uit te wisselen bericht [...] Logistiek: op deze laag bevinden zich de afspraken betreffende transportprotocollen [...] Transport: deze laag verzorgt het daadwerkelijke transport van het bericht
+<details><summary>4x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *Het drielagenmodel van de Digikoppeling-architectuur wordt niet beschreven in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron beschrijft de WUS koppelvlakstandaard en noemt dat Digikoppeling 'over logistiek gaat, dus over de envelop en niet over de inhoud', maar een expliciet drielagenmodel (inhoud, logistiek, transport) wordt niet beschreven.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *Het drielagenmodel (inhoud, logistiek, transport) wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Het drielagenmodel (inhoud, logistiek, transport) wordt niet beschreven in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Het drielagenmodel (inhoud, logistiek, transport) wordt niet besproken in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Het drielagenmodel van Digikoppeling (inhoud, logistiek, transport) wordt niet beschreven in deze OIN-handreiking.*
 </details>
 
-### `ls-dk-0020` — reference.md:11 *(§ Drielagenmodel)*
+### `ls-dk-0023` — reference.md:11 *(§ Drielagenmodel)*
 
 > Digikoppeling is payload-agnostisch: het maakt niet uit of het om XML, JSON, PDF of een ander formaat gaat.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling architectuur inhoudlaag
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling architectuur
 
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Digikoppeling gaat over logistiek, dus over de envelop en niet over de inhoud. [...] Inhoud: Op deze laag worden de afspraken gemaakt de inhoud van het uit te wisselen bericht, dus de structuur, semantiek en waardebereiken. Digikoppeling houdt zich niet met de inhoud bezig, 'heeft geen boodschap aan de boodschap'.
-  - *De bron bevestigt payload-agnosticiteit, al worden geen specifieke formaten (XML, JSON, PDF) opgesomd. De strekking is volledig ondersteund.*
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > Digikoppeling heeft geen boodschap aan de boodschap [...] Merk op dat dit ook een "groot" xml bestand kan zijn, een CAD bestand, een PDF document, een ZIP bestand, et cetera.
-  - *De bron bevestigt dat Digikoppeling payload-agnostisch is en meerdere formaten noemt. JSON wordt niet expliciet vermeld, maar het principe wordt wel onderbouwd.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Digikoppeling heeft 'Geen boodschap aan de boodschap'. [...] Digikoppeling bemoeit zich niet met de inhoud
+  - *De bron ondersteunt het principe van payload-agnosticiteit ('geen boodschap aan de boodschap'). Echter, elders stelt de bron dat WUS/ebMS berichten XML vereisen ('De payload van een bericht moet beschreven zijn in valide XML') en dat REST API JSON of XML retourneert. De claim dat PDF of elk ander formaat door alle koppelvlakken wordt ondersteund wordt niet volledig bevestigd; bijlagen mogen andere formaten hebben, maar de payload zelf kent beperkingen.*
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Digikoppeling richt zich dus uitsluitend op de logistieke laag. [...] Digikoppeling gaat over logistiek, dus over de envelop en niet over de inhoud.
+  - *De bron stelt dat Digikoppeling payload-neutraal is ('heeft geen boodschap aan de boodschap'), wat de claim over payload-agnosticiteit ondersteunt, al worden XML/JSON/PDF niet expliciet genoemd.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > Digikoppeling gaat over logistiek, dus over de envelop en niet over de inhoud.
+  - *De bron ondersteunt het idee dat Digikoppeling over de logistieke laag gaat en niet over de inhoud, wat payload-agnosticiteit impliceert. De expliciete claim dat het 'niet uitmaakt of het XML, JSON, PDF of een ander formaat betreft' staat niet letterlijk in de bron.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > Digikoppeling houdt zich niet met de inhoud bezig, 'Digikoppeling heeft geen boodschap aan de boodschap'. [...] Merk op dat dit ook een "groot" xml bestand kan zijn, een CAD bestand, een PDF document, een ZIP bestand, et cetera.
+  - *Payload-agnosticiteit wordt zowel expliciet als via voorbeelden bevestigd.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
   > Digikoppeling houdt zich niet met de inhoud bezig, 'heeft geen boodschap aan de boodschap'.
-  - *De bron bevestigt dat Digikoppeling payload-agnostisch is, al worden specifieke formaten zoals XML, JSON of PDF niet opgesomd.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  > Digikoppeling houdt zich niet met de inhoud bezig, "heeft geen boodschap aan de boodschap".
-  - *De bron bevestigt dat Digikoppeling payload-agnostisch is, maar noemt geen specifieke formaten zoals XML, JSON of PDF. De strekking klopt, maar de claim is specifieker dan wat de bron zegt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Digikoppeling houdt zich niet met de inhoud bezig, 'heeft geen boodschap aan de boodschap'.
-  - *De bron bevestigt dat Digikoppeling payload-agnostisch is, maar noemt geen specifieke formaten zoals XML, JSON of PDF.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Digikoppeling richt zich op de 'envelop' van het bericht, niet op de inhoud. Daardoor kan iedere organisatie die Digikoppeling gebruikt, de postverzending onafhankelijk van de inhoud inrichten.
-  - *De bron bevestigt dat Digikoppeling zich richt op de envelop en niet de inhoud, wat payload-agnosticiteit impliceert. Specifieke bestandsformaten (XML, JSON, PDF) worden niet benoemd.*
-<details><summary>11x NOT_FOUND (klap uit)</summary>
+  - *De bron bevestigt payload-agnosticiteit impliciet maar duidelijk. Expliciete vermelding van XML, JSON, PDF ontbreekt, maar de strekking is gelijk.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Payload-agnosticiteit van Digikoppeling wordt niet expliciet beschreven in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *Payload-agnosticiteit van Digikoppeling wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Payload-agnosticiteit (XML, JSON, PDF, etc.) wordt niet besproken in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Payload-agnosticiteit (XML, JSON, PDF) wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Payload-agnosticiteit (XML, JSON, PDF) wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Payload-agnosticiteit van Digikoppeling wordt niet behandeld in deze bron.*
 </details>
 
-### `ls-dk-0021` — reference.md:15 *(§ Drielagenmodel)*
+### `ls-dk-0024` — reference.md:15 *(§ Drielagenmodel)*
 
 > Digikoppeling schrijft het gebruik van HTTPS (TLS) voor als transportprotocol.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling transportlaag
 
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Gebruik van HTTPS [...] Gebruik van HTTPS voor grote berichten. Gebruik van tweezijdig TLS voor het veilig transporteren van gegevens via internet is verplicht.
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > De Digikoppeling Beveilingsstandaarden en voorschriften verplichten het gebruik van 2-zijdig TLS met minimaal TLS versie 1.2
+  - *De bron bevestigt TLS als verplicht transportprotocol (via verwijzing naar de beveiligingsstandaarden), maar de expliciete verwijzing naar HTTPS als zodanig is indirect. De bron vermeldt ook poort 443 voor dataverkeer, wat HTTPS impliceert.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
   > HTTPS is the required transport protocol. [...] Voor alle profielen wordt twee-zijdig TLS gebruikt op transport niveau (HTTPS).
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WT001 Authenticatie op transportniveau gebeurt op basis TLS met tweezijdige authenticatie. [...] Client and Server authenticatie is vereist gebruikmakend van HTTPS en alle in Digikoppeling Beveiligingsstandaarden en voorschriften genoemde TLS versies.
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
   > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS. [...] GB012 PUSH / PULL Het HTTPS transport MOET over poort 443 plaatsvinden.
-- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  > Een groot aantal ICT leveranciers biedt ondersteuning aan de voor Digikoppeling benodigde open standaarden (WUS, ebMS, HTTPS) in hun producten en dienstverlening.
-  - *HTTPS wordt als basisstandaard genoemd, maar de bron schrijft het niet expliciet voor als verplicht transportprotocol met een MUST-verplichting.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Digikoppeling schrijft voor dat het transport kanaal (internet of diginetwerk) wordt beveiligd via tweezijdig TLS.
-  - *De bron bevestigt dat TLS verplicht is voor het transportkanaal, maar noemt HTTPS niet expliciet. Tweezijdig TLS wordt bevestigd, wat consistent is met de claim.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Voor de authenticatie van de zender en de ontvanger in het berichtenverkeer tussen overheidspartijen worden PKIo-certificaten gebruikt. Het PKIo-certificaat wordt zowel gebruikt om het transport van de berichten veilig te laten verlopen (gebruikmakend van het TLS-protocol) als voor authenticatie.
-  - *De bron bevestigt dat TLS wordt gebruikt voor transport, maar schrijft HTTPS niet expliciet voor als verplichting (MUST). De claim is specifieker dan wat de bron stelt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > tns:TransportProtocol tns:version = "1.1" > HTTP [...] tns:TransportSecurityProtocol tns:version = "1.0" > TLS
-  - *De bron bevestigt HTTP met TLS als transportprotocol voor ebMS2, maar spreekt niet van een algemeen voorschrift voor HTTPS/TLS over alle Digikoppeling koppelvlakken. Het betreft hier de ebMS2 context specifiek.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  > Logistiek: op deze laag bevinden zich de afspraken betreffende transportprotocollen (HTTP), messaging (SOAP), adressering, beveiliging (authenticatie en encryptie) en betrouwbaarheid.
-  - *De bron noemt HTTP als transportprotocol maar niet expliciet HTTPS of TLS als verplichting in deze passage. TLS wordt elders in de bron impliciet aangeduid (bij foutcodes: 'protocolfouten, hebben betrekking op TLS of HTTP fouten') maar niet als expliciete must.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Logistiek: Op deze laag bevinden zich de afspraken betreffende transportprotocollen (HTTP), messaging (SOAP/REST), beveiliging (authenticatie en encryptie) en betrouwbaarheid.
-  - *De bron noemt HTTP als transportprotocol en TLS als vereiste bij Grote Berichten, maar schrijft HTTPS niet expliciet voor als algemeen verplicht transportprotocol voor alle Digikoppeling-varianten.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Voor ophalen van het grote bestand maakt de standaard gebruik van HTTPS-downloads. [...] transportprotocollen (HTTP)
-  - *De bron noemt HTTP als transportprotocol en HTTPS voor grote berichten, maar schrijft dit niet expliciet voor als MUST-vereiste voor alle koppelvlakken. TLS/HTTPS wordt impliciet vereist via beveiliging maar niet als expliciete MUST geformuleerd in dit document.*
-<details><summary>8x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *HTTPS/TLS als verplicht transportprotocol wordt expliciet voorgeschreven.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > op deze laag bevinden zich de afspraken betreffende transportprotocollen (HTTP & TLS) [...] TLS005 Het is verplicht voor communicatie over HTTPS port 443 te gebruiken
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *HTTPS/TLS als verplicht transportprotocol wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *HTTPS/TLS als verplicht transportprotocol wordt niet voorgeschreven in deze OIN-handreiking.*
+
+### `ls-dk-0026` — reference.md:39 *(§ REST-API)*
+
+> De REST-API koppelvlakstandaard is gebaseerd op de API Design Rules (ADR) van het Kennisplatform API's, zoals vastgesteld door het Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Het Digikoppeling Koppelvlakstandaard REST-API is gebaseerd op de Federated Services Connectivity (FSC) standaard en de REST API Design Rules die in 2020 door het Kennisplatform API's zijn ontwikkeld.
+  - *De bron bevestigt de ADR-basis. De toevoeging 'zoals vastgesteld door het Forum Standaardisatie' wordt indirect ondersteund door de verwijzing naar [ADR] en [Pas-toe-of-leg-uit] in de referenties.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Het Digikoppeling REST API profiel is o.a. gebaseerd op de REST-API Design Rules standaard zoals ontwikkeld door het Kennisplatform API's en in beheer gebracht bij Logius Stelsels & Standaarden
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt de REST-API koppelvlakstandaard en API Design Rules niet; dit is een ebMS2-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt het REST-API profiel en API Design Rules niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *API Design Rules en Forum Standaardisatie worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen REST-API koppelvlakstandaard of ADR-referentie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *Relatie tussen REST-API koppelvlakstandaard en ADR/Forum Standaardisatie wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *De relatie tussen REST-API koppelvlakstandaard en ADR/Forum Standaardisatie wordt niet behandeld in deze bron.*
 </details>
 
-### `ls-dk-0029` — reference.md:70 *(§ ebMS2)*
+### `ls-dk-0028` — reference.md:51 *(§ WUS (SOAP))*
 
-> ebMS2 service contract is een CPA (Collaboration Protocol Agreement): een XML-document dat door beide partijen wordt overeengekomen.
+> WUS staat voor WSDL, UDDI en SOAP en biedt synchrone berichtuitwisseling op basis van webservices.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
 
-- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Een deployment specificatie is niet hetzelfde als een ebXML samenwerkingsprotocol overeenkomst (ook wel aangeduid met een "Collaboration Protocol Profile and Agreement) [ISO 15000-1]. Wel hebben sommige onderdelen van een deployment specificatie gevolgen voor de specifieke invulling van CPA-elementen.
-  - *De bron bevestigt dat een CPA (Collaboration Protocol Agreement) gebruikt wordt en dat beide partijen dit overeenkomen, maar beschrijft het indirect via meerdere verwijzingen naar CPA-elementen en het CPA-register. De definitie als 'XML-document dat door beide partijen wordt overeengekomen' is impliciet aanwezig maar niet letterlijk zo geformuleerd.*
-- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Bij Digikoppeling op basis van ebMS2 worden certificaten echter ook opgenomen in de CPA's die organisaties uitwisselen.
-  - *De bron bevestigt het bestaan van CPA's als uitgewisseld document bij ebMS2, maar omschrijft de CPA niet volledig als 'XML-document dat door beide partijen wordt overeengekomen'. De kernstelling dat ebMS2 CPA's gebruikt die partijen uitwisselen is ondersteund.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > ebMS: OIN van zender en ontvanger worden vastgelegd als PartyId in het CPA (berichtencontract). De ebMS-berichtenheader wordt gegenereerd op basis van de CPA.
-  - *De bron bevestigt dat CPA een berichtencontract is en dat ebMS gebruik maakt van CPA. De claim dat het een 'XML-document dat door beide partijen wordt overeengekomen' is wordt niet expliciet bevestigd, maar de term 'berichtencontract' impliceert dit deels.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > Een CPA is een formeel xml document om de gebruikte functionele en technische eigenschappen van de ebMS2 protocol-karakteristieken vast te leggen. Het is dus een formele beschrijving voor het vastleggen van de gegevensuitwisseling.
-  - *De bron bevestigt dat een CPA een XML-document is dat door beide partijen wordt overeengekomen voor de ebMS2 gegevensuitwisseling.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Een CPA is een formeel xml-document om de gebruikte functionele en technische eigenschappen van de ebMS2 protocol-karakteristieken vast te leggen. [...] Een CPA moet worden gecreëerd als twee partijen afspreken om van elkaars ebMS2 services gebruik te maken. Beide partijen moeten de CPA importeren
-<details><summary>11x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > De naam WUS staat voor WSDL, UDDI en SOAP, drie belangrijke deelstandaarden. [...] De Digikoppeling Koppelvlakstandaard WUS ondersteunt het uitvoeren van synchrone requests tussen geautomatiseerde informatiesystemen.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WUS is een acroniem voor WSDL, UDDI en SOAP: WUS dus. Daarmee wordt een familie van internationale standaarden van OASIS en W3C bedoeld; deze worden ook vaak met WS-* aangeduid. Deze standaarden gaan over application-to-application webservices.
+  - *De bron bevestigt de expansie van het acroniem en de aard als synchrone webservice-standaard. 'Synchrone berichtuitwisseling' volgt uit WS003 (alleen request/response) en de beschrijving van Best Effort als 'synchrone uitwisselingen'.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet ebMS2. CPA wordt niet behandeld.*
+  - *WUS (WSDL, UDDI, SOAP) wordt niet inhoudelijk beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt uitsluitend ebMS2. WUS (WSDL, UDDI, SOAP) wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *WUS (WSDL, UDDI, SOAP) en synchrone berichtuitwisseling worden niet behandeld in deze bron over Grote Berichten.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt geen WUS koppelvlakstandaard of de betekenis van het acroniem.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *WUS (WSDL, UDDI, SOAP) wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron vermeldt het CPA-register wel als hulpmiddel, maar beschrijft niet dat het ebMS2 service contract een CPA is of wat de inhoud daarvan is.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *ebMS2 CPA (Collaboration Protocol Agreement) wordt niet behandeld in deze WUS Best Practices bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *CPA (Collaboration Protocol Agreement) als service contract voor ebMS2 wordt niet beschreven in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *WUS (WSDL, UDDI, SOAP) en synchrone berichtuitwisseling worden niet behandeld in deze OIN-handreiking.*
 </details>
 
-### `ls-dk-0031` — reference.md:74 *(§ ebMS2)*
+### `ls-dk-0031` — reference.md:60 *(§ WUS (SOAP))*
 
-> ebMS2 profiel osb-rm garandeert once-and-only-once (exactly-once) delivery, duplicate-eliminatie en Message Acknowledgements.
+> WUS gebruikt de standaarden WS-Security 1.1, WS-Addressing, SOAP 1.1 (document-literal binding), en MTOM voor binaire bijlagen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WB001 Toepassen WS-Security 1.0 en WS-Security 1.1 [...] WA001 Digikoppeling WUS gebruikt de volgende velden uit WS-Addressing [...] WW001 Voor de SOAP berichten wordt SOAP 1.1 en 'document-literal binding' gehanteerd [...] WM001 Toepassen MTOM wordt door webservice provider bepaald.
+  - *Alle genoemde standaarden (WS-Security 1.1, WS-Addressing, SOAP 1.1 document-literal, MTOM) worden in de bron bevestigd.*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De brontekst noemt WUS als gebaseerd op OASIS WS-BRSP standaarden en benoemt WSDL, UDDI en SOAP, maar specificeert niet de exacte versies zoals WS-Security 1.1, WS-Addressing, SOAP 1.1 document-literal binding, of MTOM. Dit detailniveau ontbreekt in de architectuurdocumentatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *WS-Security, WS-Addressing, SOAP 1.1 en MTOM worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt uitsluitend ebMS2. WUS-standaarden worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *WUS-specifieke standaarden (WS-Security 1.1, WS-Addressing, SOAP, MTOM) worden niet behandeld in deze bron over Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen WUS koppelvlakstandaard specifiek, WS-Security 1.1, WS-Addressing, SOAP 1.1 of MTOM.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *WS-Security 1.1, WS-Addressing, SOAP 1.1 en MTOM worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *WS-Security 1.1, WS-Addressing, SOAP 1.1 en MTOM worden niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0032` — reference.md:74 *(§ ebMS2)*
+
+> ebMS2 osb-rm biedt once-and-only-once (exactly-once) delivery, duplicate-eliminatie en Message Acknowledgements.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
 
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Een betrouwbaar profiel garandeert dat een bericht met zekerheid (precies één keer) wordt afgeleverd en dat berichten zo mogelijk in de juiste volgorde worden afgeleverd, ook als de ontvanger tijdelijk niet beschikbaar is.
+  - *De bron bevestigt 'exactly-once delivery' en hertransmissies (impliciet duplicate-eliminatie), en noemt 'Hertransmissies op protocolniveau totdat ontvangst is bevestigd' en 'Onweerlegbaarheid op protocolniveau (non-repudiation)'. Message Acknowledgements worden indirect bevestigd via 'ontvangstbevestigingen'. De term 'duplicate-eliminatie' als expliciete functionaliteit staat niet letterlijk in de bron.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
   > Reliable Messaging Required in this profile. Reliable Messaging profile 2, Once-And-Only-Once Reliable Messaging at the End-To-End level only based upon end-to-end retransmission. In this profile the FromParty MSH (message origination) must request, and the ToParty MSH (message final destination) must send an acknowledgment message. The ToParty MSH must also filter any duplicate messages based ...
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > tns:duplicateElimination = "always" [...] tns:ackRequested = "always"
-  - *De bron bevestigt duplicate-eliminatie en acknowledgements. 'Once-and-only-once' wordt niet met die term benoemd; het osb-rm profielnaam wordt niet als zodanig vermeld.*
-<details><summary>14x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *ebMS2 osb-rm delivery-garanties worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet het ebMS2 osb-rm profiel. Once-and-only-once delivery en Message Acknowledgements worden niet behandeld.*
+  - *De bron behandelt ebMS2 osb-rm niet. WS-RM (reliable messaging) wordt juist expliciet vermeld als verwijderd in versie 3.5: 'Verwijzingen naar WS-RM verwijderd'.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *ebMS2 osb-rm once-and-only-once delivery en Message Acknowledgements worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt geen ebMS2 osb-rm profiel of once-and-only-once delivery.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *ebMS2 osb-rm once-and-only-once delivery en Message Acknowledgements worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Het ebMS2 osb-rm profiel en eigenschappen als once-and-only-once delivery worden niet beschreven in het beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Once-and-only-once delivery, duplicate-eliminatie en Message Acknowledgements voor osb-rm worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Once-and-only-once delivery en Message Acknowledgements worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *ebMS2 osb-rm profiel en once-and-only-once delivery worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *Once-and-only-once delivery en Message Acknowledgements bij osb-rm worden niet beschreven in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *Het specifieke profiel 'osb-rm' en termen als 'once-and-only-once' of 'exactly-once delivery' worden niet in de bron gebruikt. De bron beschrijft reliable messaging in algemene termen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Once-and-only-once delivery en Message Acknowledgements bij ebMS2 osb-rm worden niet behandeld in deze bron.*
 </details>
 
-### `ls-dk-0032` — reference.md:92 *(§ Grote Berichten)*
+### `ls-dk-0034` — reference.md:70 *(§ ebMS2)*
 
-> Grote Berichten hanteert een drempelwaarde: berichten groter dan 20 MiB moeten via Grote Berichten worden uitgewisseld.
+> Het service contract bij ebMS2 is een CPA (Collaboration Protocol Agreement), een XML-document dat door beide partijen wordt overeengekomen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Een CPA is een formeel xml-document om de gebruikte functionele en technische eigenschappen van de ebMS2 protocol-karakteristieken vast te leggen. Het is dus een formele beschrijving voor het vastleggen van de gegevensuitwisseling. Een CPA moet worden gecreëerd als twee partijen afspreken om van elkaars ebMS2 services gebruik te maken. Beide partijen moeten de CPA importeren in hun Digikoppelin...
+  - *CPA staat voor Collaboration Protocol Agreement, is XML-gebaseerd en wordt door beide partijen overeengekomen. Volledig ondersteund.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > It is required to specify the resulting ebMS collaboration with a CPA. [...] Is a specific registry for storing CPA's required? [...] It is highly recommended to use the "CPA Register" facility. A web-based program is available by which CPA's are created and stored.
+  - *De bron bevestigt dat een CPA vereist is en dat dit een XML-document is dat door beide partijen wordt overeengekomen (Collaboration Protocol Agreement).*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *CPA als service contract bij ebMS2 wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron behandelt ebMS2 en CPA niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *CPA als service contract voor ebMS2 wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De bron behandelt geen CPA of service contracts bij ebMS2.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *CPA als service contract bij ebMS2 wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *CPA als service contract bij ebMS2 wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0035` — reference.md:92 *(§ Grote Berichten)*
+
+> De drempelwaarde voor Grote Berichten is 20 MiB: berichten groter dan 20 MiB moeten via Grote Berichten worden uitgewisseld.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling Grote Berichten
 
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Grote berichten vormen een functionele uitbreiding op Digikoppeling uitwisseling voor de veilige bestandsoverdracht van berichten groter dan 20 MiB
+  - *De bron bevestigt dat de drempelwaarde 20 MiB is, maar stelt niet expliciet dat berichten groter dan 20 MiB 'moeten' via Grote Berichten worden uitgewisseld (MUST). De bron beschrijft het als een uitwisselingsoptie voor die gevallen, niet als harde verplichting in de architectuurtekst.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
   > VW001 Als partijen niet tot overeenstemming komen MOETEN zij berichten groter dan 20 MiB via het Koppelvlak Grote Berichten afhandelen.
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Berichten (Bevragingen of Meldingen) die een grootte hebben van meer dan 20 MiB kunnen op een andere wijze worden uitgewisseld. Hiervoor gelden specifieke afspraken.
-  - *De drempelwaarde van 20 MiB wordt bevestigd. De claim stelt 'moeten' (MUST), maar de bron formuleert dit als 'kunnen', niet als harde verplichting.*
-<details><summary>15x NOT_FOUND (klap uit)</summary>
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *De drempelwaarde van 20 MiB voor Grote Berichten wordt niet vermeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *De bron behandelt de ebMS2 koppelvlakstandaard en vermeldt nergens een drempelwaarde van 20 MiB voor Grote Berichten. Grote Berichten is een apart Digikoppeling-onderdeel dat niet in deze spec beschreven wordt.*
+  - *De bron behandelt uitsluitend ebMS2. Grote Berichten of een drempelwaarde van 20 MiB wordt niet behandeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+  - *De brontekst gaat over Digikoppeling WUS. Grote Berichten en een drempelwaarde van 20 MiB worden niet behandeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt geen drempelwaarde van 20 MiB of Grote Berichten.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De drempelwaarde van 20 MiB voor Grote Berichten wordt niet genoemd in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
   - *De 20 MiB drempelwaarde voor Grote Berichten wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Grote Berichten en de 20 MiB drempelwaarde worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt het Grote Berichten koppelvlak en de 20 MiB drempelwaarde niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Grote Berichten en de 20 MiB drempelwaarde worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *Een drempelwaarde van 20 MiB wordt niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *De 20 MiB drempelwaarde voor Grote Berichten wordt niet behandeld in deze OIN-handreiking.*
 </details>
 
-### `ls-dk-0033` — reference.md:90 *(§ Grote Berichten)*
+### `ls-dk-0036` — reference.md:90 *(§ Grote Berichten)*
 
-> Grote Berichten gebruikt het claim-check patroon: het grote bestand wordt buiten de reguliere berichtenuitwisseling overgedragen, terwijl een referentie via het normale kanaal wordt verstuurd.
+> Grote Berichten gebruikt het claim-check patroon: het grote bestand wordt buiten de reguliere berichtenuitwisseling om overgedragen, terwijl een referentie via het normale kanaal wordt verstuurd.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
 
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Het principe dat Digikoppeling grote berichten toepast is het 'claim-check' principe. Dit betekent dat het bericht zelf (WUS/ebMS2/REST) alleen een referentie (claim-check) naar het grote bestand bevat. Deze referentie wordt vervolgens gebruikt om het bestand zelf op te halen.
+  - *Volledig ondersteund, inclusief de overdrachtsmethode buiten de reguliere berichtenuitwisseling.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
   > De verzender stelt metadata samen over het grote bestand en deelt deze metadata in een Digikoppeling-bericht [in een zgn. stuurbericht]. Uitwisseling van het grote bestand vindt plaats via een PULL of een PUSH principe.
-  - *Het claim-check patroon wordt beschreven: het grote bestand wordt buiten de reguliere berichtenuitwisseling overgedragen, terwijl een referentie (stuurbericht met metadata) via het normale kanaal wordt verstuurd.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > De verzender stelt metadata samen over het grote bestand en deelt deze metadata in een Digikoppeling-bericht [in een zgn. stuurbericht]. Uitwisseling van het grote bestand vindt plaats via een PULL of een PUSH principe.
-  - *De bron beschrijft het claim-check patroon in andere bewoordingen: het grote bestand wordt buiten de reguliere berichtenstroom overgedragen terwijl een stuurbericht met metadata via het normale kanaal wordt verstuurd.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Het principe dat Digikoppeling grote berichten toepast is het 'claim-check' principe. Dit betekent dat het bericht zelf (WUS of ebMS2) alleen een referentie (claim-check) naar het grote bestand bevat. Deze referentie wordt vervolgens gebruikt om het bestand zelf op te halen.
-<details><summary>14x NOT_FOUND (klap uit)</summary>
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *Het claim-check patroon bij Grote Berichten wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *Het claim-check patroon voor Grote Berichten wordt niet besproken in deze ebMS2 koppelvlakstandaard.*
+  - *De bron behandelt uitsluitend ebMS2. Het claim-check patroon voor Grote Berichten wordt niet behandeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+  - *Het claim-check patroon voor Grote Berichten komt niet voor in deze WUS-specificatie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt geen claim-check patroon of Grote Berichten.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *De brontekst behandelt Digikoppeling Identificatie en Authenticatie. Grote Berichten en het claim-check patroon worden niet besproken in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Het claim-check patroon voor Grote Berichten wordt niet beschreven in het beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Het claim-check patroon voor Grote Berichten wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Het claim-check patroon voor Grote Berichten wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt het Grote Berichten koppelvlak en het claim-check patroon niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Grote Berichten en het claim-check patroon worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron gaat over het OIN-stelsel, niet over Digikoppeling Grote Berichten of het claim-check patroon.*
 </details>
 
-### `ls-dk-0035` — reference.md:115 *(§ Grote Berichten)*
+### `ls-dk-0038` — reference.md:115 *(§ Grote Berichten)*
 
 > Grote Berichten is altijd een aanvulling op een ander koppelvlak (REST-API, WUS of ebMS2); het reguliere bericht met de claim-check wordt via een van deze protocollen verstuurd.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling Grote Berichten
 
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > VW002 Voor de overdracht van metadata MOET gebruik gemaakt worden van Digikoppeling, zoals aangeven in het hoofdstuk Metadata in dit document. [...] De metadata zelf wordt verzonden via een (WUS/ebMS/API) Digikoppeling Koppelvlak
-  - *De bron bevestigt expliciet dat Grote Berichten altijd gecombineerd wordt met een ander koppelvlak (WUS, ebMS of API).*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > De metadata zelf wordt verzonden via het REST-API, ebMS of WUS Koppelvlak... Voorafgaand aan deze actie dient altijd een meta-bericht verstuurd te worden door de verzender. Dit kan met behulp van het REST-API, WUS of ebMS profiel.
-- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Met WUS of ebMS2 wordt een referentie (link) verstuurd, De referentie wordt gebruikt om een groot bestand te downloaden. [...] De Digikoppeling Koppelvlakstandaard Grote Berichten (KVS GB) maakt gebruik van WUS en ebMS2 voor het verzenden van metadata.
-  - *De bron bevestigt dat Grote Berichten een aanvulling is op WUS of ebMS2. REST-API wordt hier niet expliciet als derde optie genoemd — de bron noemt alleen WUS en ebMS2 in deze context.*
-<details><summary>14x NOT_FOUND (klap uit)</summary>
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > De Digikoppeling Koppelvlakstandaard Grote Berichten maakt gebruik van WUS, ebMS2 of REST voor het verzenden van metadata. Voor ophalen van het grote bestand maakt de standaard gebruik van HTTPS-downloads.
+  - *De bron bevestigt dat Grote Berichten altijd een aanvulling is op WUS, ebMS2 of REST, en dat de claim-check via een van deze protocollen wordt verstuurd.*
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > De metadata zelf wordt verzonden via een (WUS/ebMS/API) Digikoppeling Koppelvlak
+  - *De bron bevestigt dat Grote Berichten altijd gecombineerd wordt met WUS, ebMS2 of REST-API voor het stuurbericht. De claim noemt echter 'altijd een aanvulling' als harde vereiste; de bron formuleert dit als feitelijke werking maar niet expliciet als MUST. Technisch correct, maar de modaliteit MUST wordt niet letterlijk zo gesteld.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze ebMS2 koppelvlakstandaard.*
+  - *De bron behandelt uitsluitend ebMS2. Grote Berichten als aanvullend koppelvlak wordt niet behandeld.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+  - *Grote Berichten als aanvulling op een koppelvlak wordt niet besproken in deze WUS-standaard.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt geen Grote Berichten als aanvulling op andere koppelvlakken.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron beschrijft niet dat Grote Berichten altijd een aanvulling is op een ander koppelvlak.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *De bron behandelt het Grote Berichten koppelvlak niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt het OIN-stelsel; geen informatie over Grote Berichten of koppelvlakken.*
 </details>
 
-### `ls-dk-0037` — reference.md:124 *(§ TLS-vereisten)*
+### `ls-dk-0040` — reference.md:128 *(§ TLS-vereisten)*
 
-> TLS is verplicht voor alle Digikoppeling-communicatie.
+> TLS001: Authenticatie is verplicht met TLS en PKIoverheid-certificaten voor alle Digikoppeling-communicatie.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiliging TLS
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling TLS-vereisten
 
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > In Digikoppeling is ervoor gekozen om PKIoverheid certificaten te gebruiken op het niveau van het communicatiekanaal (TLS) om de directe communicatiepartners te authenticeren (enkele hop).
+  - *De bron bevestigt dat PKIoverheid-certificaten en TLS worden gebruikt voor authenticatie, maar formuleert dit niet als een expliciete 'TLS001'-verplichting met de exacte formulering uit de claim. De verplichting van tweezijdig TLS staat elders in de bron bevestigd.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > De Digikoppeling Beveiligingsstandaarden en voorschriften gaan specifiek in op het verplichte gebruik van PKIO certificaten
+  - *De bron bevestigt het verplichte gebruik van PKIoverheid-certificaten en TLS, maar de specifieke formulering 'TLS001' en de volledige claim-tekst zijn niet te verifiëren; de bron verwijst door naar een ander document.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Client and Server authentication is required using HTTPS and TLS. [...] The use of PKI Overheid certificates is required in which an OIN is used in the Subject.serialNumber.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WT001 Authenticatie op transportniveau gebeurt op basis TLS met tweezijdige authenticatie. [...] WT002 De te gebruiken certificaten in de productie omgeving voldoen aan de eisen van PKIoverheid (PvE 3b)
+  - *De bron bevestigt TLS met PKIoverheid-certificaten voor Digikoppeling WUS. Het claim spreekt van 'alle Digikoppeling-communicatie', terwijl de bron alleen WUS dekt. De claim verwijst ook naar een specifiek voorschrift 'TLS001' dat niet als zodanig in de bron staat.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB008 PUSH / PULL Zowel de client als de server organisatie MOET zich authentiseren met een PKIoverheid certificaat [PKI CA], [PKIoverheid Certificaten]. De basis voor authenticatie en autorisatie in Digikoppeling is OIN.
+  - *De bron bevestigt PKIoverheid-certificaten en TLS voor Grote Berichten specifiek (GB006, GB008). De claim spreekt over 'alle Digikoppeling-communicatie', maar de bron dekt alleen de Grote Berichten koppelvlakstandaard. Voor de bredere claim over alle Digikoppeling-communicatie verwijst de bron naar het Digikoppeling Beveiligingsdocument dat niet beschikbaar is.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > TLS001 Authenticatie is verplicht met TLS en PKIoverheid certificaten
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *TLS-vereisten worden niet behandeld in deze bron over Identificatie en Authenticatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *De bron beschrijft het OIN-stelsel. TLS-vereisten voor Digikoppeling worden niet behandeld.*
+
+### `ls-dk-0041` — reference.md:129 *(§ TLS-vereisten)*
+
+> TLS002: Tweezijdig TLS (mutual TLS) is verplicht voor alle vormen van berichtuitwisseling via Digikoppeling.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling TLS-vereisten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Gebruik van tweezijdig TLS voor het veilig transporteren van gegevens via internet is verplicht.
+  - *Volledig ondersteund; tweezijdig TLS (mutual TLS) is expliciet als verplicht aangemerkt.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > De Digikoppeling Beveilingsstandaarden en voorschriften verplichten het gebruik van 2-zijdig TLS met minimaal TLS versie 1.2
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
   > Voor alle profielen gelden de volgende eigenschappen: Vertrouwelijkheid en authenticatie van zender en ontvanger wordt als volgt gerealiseerd: Voor Point-to-Point Security, door middel van twee-zijdig TLS op transport-niveau (in het HTTP kanaal). (De toepassing ervan wordt dus ook verplicht verklaard bij gebruik van security op berichtniveau.)
-  - *De bron stelt expliciet dat twee-zijdig TLS verplicht is voor alle profielen. De profieltabel bevestigt ook: 'Voor alle profielen wordt twee-zijdig TLS gebruikt op transport niveau (HTTPS)'.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS.
-  - *De bron bevestigt TLS-verplichting voor bestandsoverdracht bij Grote Berichten. De bron beperkt zich tot de Grote Berichten context.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Digikoppeling schrijft voor dat het transport kanaal (internet of diginetwerk) wordt beveiligd via tweezijdig TLS.
-  - *De bron bevestigt dat TLS verplicht is voor het transportkanaal, maar specificeert niet expliciet dat dit voor 'alle' Digikoppeling-communicatie geldt zonder uitzondering. De claim zegt 'alle', de bron spreekt over het transportkanaal in het algemeen.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Het PKIo-certificaat wordt zowel gebruikt om het transport van de berichten veilig te laten verlopen (gebruikmakend van het TLS-protocol) als voor authenticatie. Bij het gebruik van Digikoppeling wordt tweezijdige authenticatie vereist.
-  - *De bron bevestigt TLS-gebruik voor berichttransport en dat tweezijdige authenticatie vereist is, maar stelt TLS niet expliciet als verplicht voor álle Digikoppeling-communicatie in de zin van een normerende uitspraak.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > TransportProtocol over HTTP met TLS met server certificaat [...] Client Authentication over HTTP met client certificaat. Dit is verplicht.
-  - *De bron bevestigt TLS als verplicht transportprotocol voor ebMS2, maar doet geen uitspraak over alle Digikoppeling-communicatie in het algemeen. De claim is breder dan wat de bron afdekt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Alleen verbindingen waarbij zowel de client als de server over een geldig certificaat beschikken zijn toegestaan (TLS).
-  - *De bron bevestigt TLS-verplichting in de context van Grote Berichten, maar dit is een Best Practices document en geen normatieve koppelvlakstandaard. De claim stelt dat TLS verplicht is voor 'alle Digikoppeling-communicatie', wat breder is dan wat deze bron dekt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Digikoppeling schrijft het gebruik van PKIoverheidcertificaten met een OIN voor om de identiteit van een website of server te controleren (authenticatie). Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen.
-  - *De bron vermeldt beveiligde verbindingen en PKIoverheid-certificaten, maar specificeert TLS niet expliciet als verplicht protocol voor alle communicatie. HTTPS-downloads worden wel genoemd voor Grote Berichten.*
-<details><summary>10x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WT001 Authenticatie op transportniveau gebeurt op basis TLS met tweezijdige authenticatie. [...] Alle Digikoppeling profielen verplichten point-to-point beveiliging.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB008 PUSH / PULL Zowel de client als de server organisatie MOET zich authentiseren met een PKIoverheid certificaat [...] (2-zijdig TLS).
+  - *De bron bevestigt 2-zijdig TLS (mutual TLS) voor Grote Berichten. De claim stelt dit voor 'alle vormen van berichtuitwisseling via Digikoppeling'; de bron dekt alleen Grote Berichten en verwijst voor bredere TLS-eisen naar het Digikoppeling Beveiligingsdocument.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > TLS002 Tweezijdig TLS is verplicht Digikoppeling schrijft het gebruik van twee-zijdig TLS voor en verplicht dit voor alle vormen van berichtuitwisseling via Digikoppeling.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *Tweezijdig TLS wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron bevat geen normatieve vereisten over TLS voor Digikoppeling-communicatie.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *TLS wordt in de bron wel impliciet aangeduid (bij foutcategorieën) maar niet als expliciete verplichting voor alle Digikoppeling-communicatie geformuleerd.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
+  - *Geen TLS-vereisten in deze bron.*
 
-### `ls-dk-0040` — reference.md:130 *(§ TLS-vereisten)*
+### `ls-dk-0042` — reference.md:130 *(§ TLS-vereisten)*
 
-> TLS003: Mutual TLS (mTLS) is verplicht: zowel client als server moeten zich authenticeren met een PKIoverheid-certificaat.
+> TLS003: De TLS-implementatie mag niet op SSL v3 en eerdere versies terugvallen; backward compatibility mode voor SSL v3 en eerder dient te worden uitgezet.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS003
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Digikoppeling TLS-vereisten
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Client and Server authentication is required using HTTPS and TLS. [...] Client-side authentication is required.
-  - *De bron bevestigt mutual TLS (zowel client als server authenticatie) en PKIoverheid-certificaten. De eis staat in secties 5.2.3 en 5.11.4.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > GB008 PUSH / PULL Zowel de client als de server organisatie MOET zich authentiseren met een PKIoverheid certificaat [PKI CA], [PKIoverheid Certificaten]. De basis voor authenticatie en autorisatie in Digikoppeling is OIN. [...] (2-zijdig TLS).
-  - *De bron bevestigt mutual TLS met PKIoverheid-certificaten.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Digikoppeling schrijft voor dat het transport kanaal (internet of diginetwerk) wordt beveiligd via tweezijdig TLS. Beide partijen wisselen hun publieke sleutels uit en zetten hiermee een tweezijdig versleutelde TLS verbinding op.
-  - *De bron bevestigt tweezijdig TLS (mTLS) en het gebruik van PKIoverheid-certificaten, maar vermeldt niet expliciet dat dit als 'verplicht' (MUST) is vastgelegd in een genummerde standaard TLS003.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Bij het gebruik van Digikoppeling wordt tweezijdige authenticatie vereist. Zender en ontvanger moeten elkaars certificaat vertrouwen en elkaars publieke TLS-sleutel kennen.
-  - *De bron bevestigt tweezijdige authenticatie en certificaatgebruik, maar noemt PKIoverheid niet expliciet als vereiste en gebruikt niet de term 'mTLS'. De claim is specifieker dan wat de bron stelt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > Client Authentication over HTTP met client certificaat. Dit is verplicht. In het client certificaat staat in het subject.Serialnumber de PartyId van de 'client' organisatie.
-  - *De bron bevestigt dat mutual TLS (client én server certificaat) verplicht is en dat het PKIoverheid-certificaten betreft. Echter, de term 'PKIoverheid' wordt in 3.4.16 vermeld: 'Er moet gebruik gemaakt worden van certificaten die voldoen aan de eisen van de PKI Overheid.' De combinatie is aanwezig maar niet zo expliciet als de claim stelt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Alleen verbindingen waarbij zowel de client als de server over een geldig certificaat beschikken zijn toegestaan (TLS).
-  - *De bron bevestigt mutual TLS (beide partijen met certificaat), maar vermeldt 'PKIoverheid-certificaat' niet expliciet in deze zin. Elders wordt OIN-gerelateerde certificaten en PKIoverheid-hiërarchie wel vermeld, maar de specifieke term 'mTLS' of 'Mutual TLS' als verplichting staat niet letterlijk in de bron.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Digikoppeling schrijft het gebruik van PKIoverheidcertificaten met een OIN voor om de identiteit van een website of server te controleren (authenticatie). Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen.
-  - *De bron bevestigt dat beide partijen PKIoverheid-certificaten gebruiken voor authenticatie, wat mTLS impliceert. De term 'mutual TLS' of 'mTLS' wordt echter niet expliciet genoemd, en de verplichting wordt niet in die exacte terminologie gesteld.*
-<details><summary>10x NOT_FOUND (klap uit)</summary>
+  > Note: Message service handlers should NOT be able to operate in SSL v3 backward compatibility mode. [...] TLS implementations must NOT support SSL v3 backwards compatiblity mode.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > De TLS implementatie mag niet op een oudere TLS of SSL versie terug kunnen vallen.
+  - *De bron verbiedt terugvallen op oudere TLS of SSL versies in het algemeen, maar noemt SSL v3 niet expliciet. De claim specificeert 'SSL v3 en eerdere versies', wat iets preciezer is dan wat de bron stelt.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > TLS003 De TLS implementatie mag niet op SSL v3 en eerdere versies terugvallen Backward compatibility mode voor SSL v3 en eerdere versies dient te worden uitgezet.
+<details><summary>5x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *TLS003 en mTLS-verplichting met PKIoverheid-certificaten worden niet behandeld in het beheermodel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Mutual TLS en PKIoverheid-certificaten als verplichting (TLS003) worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-</details>
-
-### `ls-dk-0043` — reference.md:133 *(§ TLS-vereisten)*
-
-> TLS006: Het OIN van de organisatie moet opgenomen zijn in het Subject.SerialNumber-veld van het PKIoverheid-certificaat.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS006
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > The use of PKI Overheid certificates is required in which an OIN is used in the Subject.serialNumber.
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Voor de unieke identificatie en authenticatie van deze organisaties wordt het OIN opgenomen in een PKIoverheid certificaat in het zogenaamde Subject.serialNumber-veld door de TSP.
-  - *De bron bevestigt dat het OIN in Subject.serialNumber wordt opgenomen. De claim zegt 'Subject.SerialNumber' (hoofdletter S), de bron zegt 'Subject.serialNumber' — dit is dezelfde veldnaam. De claim is volledig ondersteund voor het OIN-veld. Echter de claim stelt dit als MUST (TLS006-standaard), terwijl de bron de verplichting wel impliceert maar niet als genummerde standaard presenteert. PARTIALLY_SUPPORTED vanwege het ontbreken van de TLS006-standaardnummering.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Een PKIo-certificaat dat gebruikt wordt voor berichtenuitwisseling met Digikoppeling bevat het OIN van de organisatie of organisatieonderdeel. Dit OIN wordt opgeslagen in het Subject.SerialNumber veld van het certificaat.
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > In het client certificaat staat in het subject.Serialnumber de PartyId van de 'client' organisatie. [...] Het nummer zal ook gebruikt worden in het cliënt certificaat voor het subject.Serialnumber veld.
-  - *De bron bevestigt expliciet dat het OIN (als PartyId) in het subject.SerialNumber van het certificaat wordt opgenomen.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen.
-  - *De bron bevestigt dat het OIN in het PKIoverheid-certificaat moet worden opgenomen, maar specificeert niet het veld 'Subject.SerialNumber' expliciet.*
-<details><summary>12x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+  - *De bron vermeldt nergens een verbod op SSL v3 of het uitschakelen van backward compatibility mode. Dit detailniveau staat in de Digikoppeling Beveiligingsstandaarden, niet in de Architectuur.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *SSL v3 en backward compatibility worden niet expliciet vermeld in deze bron. De bron verwijst naar de Beveiligingsstandaarden voor TLS-details maar reproduceert die regels niet.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron vermeldt OIN in relatie tot certificaten en autorisatie, maar beschrijft niet specifiek dat het OIN in het Subject.SerialNumber-veld moet worden opgenomen.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron verwijst voor TLS-algoritmen naar het Digikoppeling Beveiligingsdocument maar bevat zelf geen specificaties over SSL v3 of backward compatibility.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *SSL v3 backward compatibility wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *TLS006 en het opnemen van het OIN in Subject.SerialNumber worden niet beschreven in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *OIN in Subject.SerialNumber van PKIoverheid-certificaat (TLS006) wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *De bron vermeldt dat OIN in certificaten zit en gebruikt wordt, maar specificeert niet het Subject.SerialNumber-veld als de verplichte locatie voor het OIN.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Geen TLS-vereisten of SSL-versiebeleid in deze bron.*
 </details>
 
-### `ls-dk-0044` — reference.md:137 *(§ PKIoverheid Certificaten)*
+### `ls-dk-0043` — reference.md:131 *(§ TLS-vereisten)*
 
-> Alle Digikoppeling-deelnemers moeten PKIoverheid-certificaten gebruiken voor authenticatie.
+> TLS004: Een serviceaanbieder is verplicht TLS 1.2 te ondersteunen; daarnaast is het aanbevolen om TLS 1.3 te ondersteunen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling PKIoverheid certificaten
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling TLS-vereisten
 
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > The use of PKI Overheid certificates is required in which an OIN is used in the Subject.serialNumber. [...] Client-side authentication is required. What client Certificate Authorities are acceptable? PKI overheid maintains a list of approved trusted service providers.
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > GB008 PUSH / PULL Zowel de client als de server organisatie MOET zich authentiseren met een PKIoverheid certificaat [PKI CA], [PKIoverheid Certificaten].
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  > "De Digikoppeling-standaard en in het bijzonder 'Gebruik en achtergrond Digikoppeling-certificaten' sluiten aan bij de PKI.Overheid."
-  - *De bron bevestigt de relatie met PKIoverheid maar legt geen expliciete MUST-verplichting op dat alle deelnemers PKIoverheid-certificaten moeten gebruiken voor authenticatie.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Een belangrijk aspect voor beveiliging van Digikoppeling is de juiste identificatie, authenticatie en autorisatie van organisaties. Voor Digikoppeling is daarbij gekozen om certificaten toe te passen die voldoen aan de eisen van PKIoverheid.
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Voor de authenticatie van de zender en de ontvanger in het berichtenverkeer tussen overheidspartijen worden PKIo-certificaten gebruikt.
-  - *De bron bevestigt gebruik van PKIo-certificaten voor authenticatie, maar stelt dit niet expliciet als MUST-verplichting voor alle Digikoppeling-deelnemers, en noemt 'PKIoverheid' niet letterlijk (alleen 'PKIo').*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > Er moet gebruik gemaakt worden van certificaten die voldoen aan de eisen van de PKI Overheid.
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Ten behoeve van Digikoppeling grote berichten dient gebruik gemaakt te worden van OIN gerelateerde certificaten.
-  - *De bron spreekt van 'OIN gerelateerde certificaten' en verwijst naar 'certificaat-hierarchie (root-certificaat van Staat der Nederlanden)', wat naar PKIoverheid verwijst, maar de term 'PKIoverheid-certificaten' als expliciete verplichting staat niet letterlijk in de bron.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Digikoppeling schrijft het gebruik van PKIoverheidcertificaten met een OIN voor om de identiteit van een website of server te controleren (authenticatie). Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen.
-<details><summary>9x NOT_FOUND (klap uit)</summary>
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > De Digikoppeling Beveilingsstandaarden en voorschriften verplichten het gebruik van 2-zijdig TLS met minimaal TLS versie 1.2
+  - *De bron bevestigt TLS 1.2 als minimumvereiste, maar het aanbevolen gebruik van TLS 1.3 wordt niet vermeld in de brontekst. PARTIALLY_SUPPORTED zou ook verdedigbaar zijn, maar de kerneis (TLS 1.2 verplicht) wordt bevestigd.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > TLS004 Een Serviceaanbieder is verplicht TLS versie 1.2 te ondersteunen, daarnaast is het aanbevolen voor een Serviceaanbieder om TLS versie 1.3 te ondersteunen.
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *De bron verwijst voor beveiligingsstandaarden naar het document 'Digikoppeling Beveiligingsstandaarden en voorschriften' maar noemt zelf geen specifieke TLS-versievereisten zoals TLS 1.2 of 1.3.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron verwijst voor specifieke TLS-versies naar het document 'Digikoppeling Beveiligingsstandaarden en voorschriften' maar noemt zelf geen specifieke vereiste voor TLS 1.2 of aanbeveling voor TLS 1.3.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron verwijst voor toegestane TLS-versies naar het externe document 'Digikoppeling Beveiligingsstandaarden en voorschriften' maar noemt TLS 1.2 of TLS 1.3 niet expliciet in de brontekst zelf.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron noemt TLS als vereiste en verwijst naar het Digikoppeling Beveiligingsdocument voor specifieke versies en algoritmen, maar vermeldt TLS 1.2 of TLS 1.3 niet expliciet.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *TLS versie-vereisten worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *PKIoverheid-certificaten als verplichting voor alle deelnemers worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Geen TLS-versievereisten in deze bron.*
 </details>
 
-### `ls-dk-0045` — reference.md:147 *(§ OIN-identificatie)*
+### `ls-dk-0044` — reference.md:132 *(§ TLS-vereisten)*
 
-> Het OIN wordt opgenomen in het PKIoverheid-certificaat (Subject.SerialNumber) en wordt gebruikt voor adressering en routering van berichten.
+> TLS005: Voor communicatie over HTTPS is het verplicht poort 443 te gebruiken.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling OIN-identificatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling TLS-vereisten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > De Digikoppeling Beveiligingsstandaarden en voorschriften verplichten het gebruik van de netwerkpoort 443 voor data verkeer.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WT006 Voor communicatie over HTTPS wordt port 443 gebruikt.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB012 PUSH / PULL Het HTTPS transport MOET over poort 443 plaatsvinden.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > TLS005 Het is verplicht voor communicatie over HTTPS port 443 te gebruiken
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Poort 443 wordt niet genoemd in de brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron vermeldt HTTPS als verplicht transportprotocol maar noemt geen specifieke poortverplichting (poort 443).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *Poort 443 vereisten worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Geen poort- of HTTPS-vereisten in deze bron.*
+</details>
+
+### `ls-dk-0045` — reference.md:133 *(§ TLS-vereisten)*
+
+> TLS006: Het is verplicht te voldoen aan de NCSC ICT-beveiligingsrichtlijnen voor TLS.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling TLS-vereisten
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > The use of PKI Overheid certificates is required in which an OIN is used in the Subject.serialNumber. [...] Partners who are going to use ebMS for the first time must use an OIN (Organisatie Identificatie Nummer) for identification.
-  - *De bron bevestigt OIN in Subject.SerialNumber en gebruik voor identificatie. Het gebruik voor 'adressering en routering van berichten' is niet expliciet zo beschreven; de bron noemt OIN primair in de context van PartyId voor identificatie van partijen.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  > GB008 [...] De basis voor authenticatie en autorisatie in Digikoppeling is OIN. GB009 PUSH / PULL De server organisatie MOET het transport autoriseren op basis van het OIN van een valide client certificaat.
-  - *De bron bevestigt OIN in het certificaat voor authenticatie en autorisatie, maar beschrijft niet expliciet het Subject.SerialNumber-veld of het gebruik van OIN voor routering en adressering van berichten.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Voor de unieke identificatie en authenticatie van deze organisaties wordt het OIN opgenomen in een PKIoverheid certificaat in het zogenaamde Subject.serialNumber-veld door de TSP. Identificatie van organisaties vindt voor Digikoppeling plaats aan de hand van het OIN dat is opgenomen in het certificaat.
-  - *De bron bevestigt OIN in Subject.serialNumber en gebruik voor identificatie/authenticatie. De claim noemt ook 'adressering en routering van berichten'; de bron vermeldt dit aspect niet expliciet — alleen authenticatie en autorisatie worden benoemd. Daarom PARTIALLY_SUPPORTED.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Een PKIo-certificaat dat gebruikt wordt voor berichtenuitwisseling met Digikoppeling bevat het OIN van de organisatie of organisatieonderdeel. Dit OIN wordt opgeslagen in het Subject.SerialNumber veld van het certificaat. [...] Adresseren en Routeren vindt plaats op het niveau van de berichtheader. Voor het routeren kan gebruik gemaakt worden van het OIN, het opgegeven endpointadres of beide.
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > Het nummer zal ook gebruikt worden in het cliënt certificaat voor het subject.Serialnumber veld. [...] De PartyId is de (logische) aanduiding waarmee de organisatie geïdentificeerd wordt.
-  - *De bron bevestigt dat OIN in Subject.SerialNumber staat en gebruikt wordt voor identificatie. Het gebruik voor 'adressering en routering' wordt niet expliciet zo benoemd in dit document.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Autorisatie kan vervolgens op basis van een OIN uit dit geldige certificaat ingericht worden.
-  - *De bron bevestigt dat OIN in certificaten zit en voor autorisatie gebruikt wordt, en ook voor adressering in URLs. Het specifieke Subject.SerialNumber-veld wordt echter niet vermeld, en 'routering van berichten' als expliciet gebruik staat niet letterlijk in de bron.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen. Elke overheidsorganisatie die digitaal zaken doet kan een uniek Organisatieidentificatienummer (OIN) krijgen.
-  - *De bron bevestigt dat het OIN in het PKIoverheid-certificaat moet worden opgenomen en voor authenticatie wordt gebruikt. Adressering en routering via OIN worden impliciet vermeld (adresseringsinformatie voor routering in de ebMS2/WUS-secties), maar het specifieke veld 'Subject.SerialNumber' wordt niet expliciet benoemd.*
-<details><summary>10x NOT_FOUND (klap uit)</summary>
+  > The currently allowed protocol versions for TLS are described in Digikoppeling Beveiligingsstandaarden en voorschriften
+  - *De bron bevestigt dat er TLS-beveiligingsrichtlijnen van toepassing zijn, maar verwijst voor de inhoud naar een extern document (Digikoppeling Beveiligingsstandaarden en voorschriften). NCSC-richtlijnen worden niet expliciet bij naam genoemd in deze bron.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > TLS006 Het is verplicht te voldoen aan de NCSC ICT-beveiligingsrichtlijnen voor TLS Zie [ NCSC 2025 ]
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *NCSC ICT-beveiligingsrichtlijnen worden niet vermeld in de brontekst. Dit detailniveau staat in de Digikoppeling Beveiligingsstandaarden.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *NCSC ICT-beveiligingsrichtlijnen worden niet expliciet vermeld in deze brontekst.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron verwijst naar NCSC in de context van TLS-algoritmen ('conform de aanbevelingen in WS-I BSP 1.0 voor beveiliging op transport/kanaal niveau en aanbevelingen van NIST en NCSC'), maar een expliciet voorschrift om te voldoen aan NCSC ICT-beveiligingsrichtlijnen voor TLS staat niet als zodanig in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron verwijst naar het Digikoppeling Beveiligingsdocument voor TLS-algoritmen en sleutellengtes, maar noemt de NCSC ICT-beveiligingsrichtlijnen niet expliciet.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *NCSC ICT-beveiligingsrichtlijnen voor TLS worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron noemt het OIN-register wel als hulpmiddel maar beschrijft niet dat het OIN in Subject.SerialNumber wordt opgenomen of wordt gebruikt voor adressering en routering.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *OIN in PKIoverheid-certificaat voor adressering en routering wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *NCSC-richtlijnen voor TLS worden niet behandeld in deze bron.*
 </details>
 
-### `ls-dk-0046` — reference.md:149 *(§ OIN-identificatie)*
+### `ls-dk-0046` — reference.md:139 *(§ TLS-vereisten)*
 
-> Het OIN-stelsel wordt beheerd door Logius.
+> PKI001: Het OIN van de organisatie moet opgenomen zijn in het subject:serialNumber-veld van het PKIoverheid-certificaat.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling PKI-vereisten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > Het PeerID binnen de context van FSC is OIN. Het OIN wordt bij PKIO certificaten geplaatst in het SerialNumber veld van het Subject.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > The use of PKI Overheid certificates is required in which an OIN is used in the Subject.serialNumber.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > PKI001 Gebruik OIN in subject:serialNumber veld is verplicht Dit is afgesproken met de TSP's in de Digikoppeling Overeenkomsten.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  > De waarde van het OIN in het OIN Register en in het veld subject.serialNumber is inclusief de prefix en suffix en daarbij behorende voorloopnullen. [...] Het gehele nummer wordt opgenomen in het certificaat (subject.serialNumber). Dat gehele nummer geldt dus als OIN.
+  - *De bron bevestigt dat het OIN (inclusief prefix en suffix) wordt opgenomen in subject.serialNumber van het PKIoverheid-certificaat.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  > Het OIN of SubOIN wordt opgenomen in het subject serialNumber veld van het PKIoverheid certificaat. [...] De TSP raadpleegt het OIN van de aanvrager via de COR en neemt dit nummer en naam op in het PKIoverheid certificaat.
+  - *De bron bevestigt expliciet dat het OIN in het Subject.serialNumber-veld wordt opgenomen.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De bron vermeldt dat PKIoverheid-certificaten worden gebruikt voor identificatie en authenticatie, en dat het OIN een uniek identificatienummer is, maar beschrijft niet dat het OIN specifiek in het subject:serialNumber-veld moet worden opgenomen.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron noemt PKIoverheid-certificaten en OIN in WS-Addressing velden (wsa:To/wsa:From via querystring), maar een voorschrift dat het OIN in het subject:serialNumber-veld van het certificaat moet staan ontbreekt in deze brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron vermeldt OIN als basis voor authenticatie en autorisatie en PKIoverheid-certificaten als vereiste, maar beschrijft niet het subject:serialNumber-veld specifiek.*
+</details>
+
+### `ls-dk-0047` — reference.md:140 *(§ TLS-vereisten)*
+
+> PKI002: Het PKIoverheid-certificaat moet geldig zijn (niet verlopen of ingetrokken); revocation checking is vereist.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling PKI-vereisten
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > OIN stands for Organisatie Identificatie Nummer and is maintained by Logius in the COR (Centrale OIN Raadpleegvoorziening).
-- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  > "Bij de Digikoppeling horen de volgende ondersteunende hulpmiddelen en ICT voorzieningen: Digikoppeling OIN Register en het hieraan gekoppelde CPA-register" en de gehele bron is gepubliceerd door Logius als beheerder van Digikoppeling.
-  - *De bron bevestigt impliciet dat Logius het OIN-register beheert als onderdeel van de Digikoppeling-voorzieningen, maar een expliciete zin 'Het OIN-stelsel wordt beheerd door Logius' ontbreekt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > Om certificaten te kunnen bestellen, moet de organisatie een identificerend nummer hebben: het OIN. Dit nummer wordt verkregen bij de beheerorganisatie van Digikoppeling volgens de procedure die is beschreven op de website van Logius.
-  - *De bron noemt Logius als beheerorganisatie van Digikoppeling en OIN-uitgever, wat het beheer door Logius impliceert. Het OIN-stelsel als zodanig wordt niet expliciet 'beheerd door Logius' genoemd; het is een indirecte bevestiging.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  > Als de organisatie nog geen OIN heeft moet een nummer aangevraagd worden bij Logius. De COR (De Centrale OIN Raadpleegvoorziening) wordt gebruikt om informatie vast te leggen over de organisatie en het OIN.
-  - *De bron noemt Logius als de instantie waar OIN aangevraagd wordt, wat impliceert dat Logius het OIN-stelsel beheert, maar 'beheer door Logius' wordt niet expliciet zo geformuleerd.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Logius biedt ondersteuning bij aansluiten en gebruik door middel van: Verstrekken van het benodigde Organisatieidentificatienummer (OIN)
-  - *De bron stelt dat Logius OIN-nummers verstrekt, wat beheer impliceert, maar het 'OIN-stelsel' als zodanig en expliciet beheer ervan door Logius wordt niet met die terminologie benoemd.*
-<details><summary>12x NOT_FOUND (klap uit)</summary>
+  > The use of certificate revocation lists (CRL) from the trusted CAs is required. [...] The requirements as stated in Certificate Policy/Programme of Requirements PKIoverheid have to be used.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > WT004 De geldigheid van het certificaat wordt getoetst met betrekking tot de geldigheidsdatum en de Certificate Revocation List(CRL) die voldoet aan de eisen van PKIoverheid.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB011 PUSH / PULL De server moet certificaat-revocatie-lijsten (CRL) gebruiken [PKI Policy].
+  - *Revocation checking via CRL wordt bevestigd. De claim spreekt ook over 'niet verlopen' certificaten, maar de bron vermeldt dit niet expliciet als aparte vereiste.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > PKI002 PKIoverheid certificaat moet geldig zijn (het mag niet zijn verlopen of ingetrokken). PKI003 (WT004) De geldigheid van het certificaat wordt getoetst met betrekking tot de geldigheidsdatum en de Certificate Revocation List(CRL)
+<details><summary>4x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+  - *De bron vermeldt PKIoverheid-certificaten voor authenticatie maar stelt geen expliciete eisen over geldigheid, verlopen certificaten of revocation checking.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron vermeldt het OIN in de context van certificaten en autorisatie, maar zegt niets over het beheer van het OIN-stelsel door Logius.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *Revocation checking en certificaatgeldigheid worden niet expliciet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *Revocation checking en geldigheidscontrole van certificaten worden niet expliciet besproken in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  - *Logius als beheerder van het OIN-stelsel wordt niet vermeld in deze bron (de bron vermeldt Logius als auteur van het document, maar niet als beheerder van het OIN-stelsel).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *OIN-stelsel en beheer door Logius worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *Het OIN-stelsel en het beheer ervan door Logius wordt niet als zodanig besproken in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron beschrijft het OIN-stelsel maar behandelt geen revocation checking of geldigheidscontrole van certificaten als vereiste.*
 </details>
 
-### `ls-dk-0047` — reference.md:150 *(§ OIN-identificatie)*
+### `ls-dk-0048` — reference.md:141 *(§ TLS-vereisten)*
 
-> Sub-OIN's zijn mogelijk voor organisatieonderdelen of specifieke systemen.
+> PKI005: Certificaten moeten van het type PKIoverheid private root zijn (verplicht sinds 1-1-2021).
 
-**Type:** factual_assertion  ·  **Modaliteit:** MAY  ·  **Scope:** OIN-stelsel
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling PKI-vereisten
 
-- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > The number is unique and allows identification of partners, even if they are not themselves legal entities, but departments or units of larger organizations.
-  - *De bron bevestigt dat OIN gebruikt kan worden voor afdelingen/onderdelen van grotere organisaties, wat de richting van sub-OINs ondersteunt. Maar de term 'sub-OIN' wordt niet gebruikt en het mechanisme van sub-OINs is niet expliciet beschreven.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  > In specifieke gevallen kan autorisatie op een gedetailleerder niveau noodzakelijk zijn. Voor overheidsorganisaties is het bijvoorbeeld mogelijk om een subOIN aan te vragen.
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Het SubOIN is een afgeleide van het OIN en is opgesteld volgens de OIN-nummersystematiek en wordt gebruikt voor een organisatieonderdeel, samenwerkingsverband of voorziening. SubOIN's kunnen worden gebruikt om fijnmazig te identificeren. (Aan een OIN kunnen meerdere SubOIN's gekoppeld worden).
-<details><summary>14x NOT_FOUND (klap uit)</summary>
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > De Trust Anchor voor de FSC Group moet daarom de PKIO Private Root zijn.
+  - *De bron bevestigt PKIO Private Root als vereiste Trust Anchor, wat overeenkomt met de claim over PKIoverheid private root certificaten. De ingangsdatum 1-1-2021 wordt niet vermeld.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > PKI005 Het certificaat moet zijn van het type PKIoverheid private root (PKI Staat der Nederlanden Private Root) Voor Serviceaanbieders en Servicegebruikers geldt dat zij vanaf 1-1-2021 gebruik moeten maken van private root certificaten
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *De bron vermeldt PKIoverheid certificaten herhaaldelijk maar beschrijft nergens het onderscheid 'private root' versus andere root-typen, noch een datum van 1-1-2021 als verplichting. PKI-details staan in het afzonderlijke document 'Digikoppeling Beveiligingsstandaarden en voorschriften', niet in deze Architectuur.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron vermeldt PKIoverheid-certificaten als vereiste maar maakt geen onderscheid tussen private root en public root, noch een ingangsdatum van 1-1-2021.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+  - *PKIoverheid private root als verplicht type certificaat (verplicht sinds 1-1-2021) wordt niet vermeld in deze brontekst.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *Sub-OIN's worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron vermeldt PKIoverheid-certificaten als vereiste maar noemt het onderscheid private root vs. andere roots, noch de datum 1-1-2021.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+  - *PKIoverheid private root en de verplichting daarvan per 1-1-2021 wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *Sub-OIN's voor organisatieonderdelen of systemen worden niet beschreven in het beheermodel. De impactmatrix noemt wel OIN-nummers maar niet sub-OIN's.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *Sub-OIN's worden niet als concept vermeld. Wel wordt gesproken over deel-organisaties met eigen OIN's, maar niet over sub-OIN's specifiek.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  - *Sub-OIN's worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  - *Sub-OIN's worden niet vermeld in de bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  - *Sub-OIN's worden niet vermeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *PKIoverheid private root-certificaatvereisten worden niet behandeld in deze bron.*
 </details>
 
-### `ls-dk-0050` — reference.md:159 *(§ Berichtniveau-beveiliging)*
+### `ls-dk-0049` — reference.md:164 *(§ Berichtniveau-beveiliging)*
+
+> Signing gebruikt XML Digital Signature (XMLDSIG) met minimaal SHA-256; SHA-1 is niet meer toegestaan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling berichtniveau-beveiliging
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > The applied signature method is described in Digikoppeling Beveiligingsstandaarden en voorschriften
+  - *De bron bevestigt dat XML Digital Signature (XMLDSIG) vereist is voor End-to-End Security, maar verwijst voor de specifieke hash-algoritmen (SHA-256, uitsluiting van SHA-1) naar het externe document 'Digikoppeling Beveiligingsstandaarden en voorschriften'. De SHA-256/SHA-1 claim kan niet direct worden bevestigd of weerlegd vanuit deze bron.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > SIGN001 Signing met SHA-2 is verplicht. Minimaal SHA-256. SIGN002 Signing conform XMLDSIG is verplicht [...] Certificaten met SHA-1 als hashfunctie worden vervangen door certificaten met hashfuncties uit de SHA-2-familie
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De bron noemt signing als profiel-optie (Signed, XMLDSIG niet expliciet) maar geen specificaties over SHA-256 of de afschaffing van SHA-1. Cryptografische algoritme-eisen staan in 'Digikoppeling Beveiligingsstandaarden en voorschriften'.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *XML Digital Signature (XMLDSIG) en SHA-256/SHA-1 vereisten worden niet behandeld in deze bron; de bron verwijst voor signing naar JAdES (HTTP context).*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De bron schrijft signing voor (WB003, WB004, WB007) en verwijst voor algoritmen naar 'Digikoppeling Beveiligingsstandaarden en voorschriften'. SHA-256 als minimum en het verbod op SHA-1 staan niet in de brontekst zelf.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron behandelt bestandsoverdracht en metadata; XML Digital Signature, XMLDSIG, SHA-256 of berichtniveau-signing worden niet besproken.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *XML Digital Signature, SHA-256 en berichtniveau-signing worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *XMLDSIG, SHA-256 of berichtniveau-signing worden niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0051` — reference.md:167 *(§ Berichtniveau-beveiliging)*
 
 > Berichtniveau-beveiliging is essentieel wanneer er niet-vertrouwde intermediairs in de keten zitten, omdat TLS alleen de point-to-point verbinding beveiligt.
 
 **Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Digikoppeling berichtniveau-beveiliging
 
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Het versleutelen van berichtinhoud (berichtenniveau versleuteling) kan worden toegepast indien de intermediair niet vertrouwd wordt. [...] TLS kan niet toegepast worden om end-to-end authenticatie uit te voeren in een multi-hop omgeving; zie daarvoor beveiliging op berichtniveau (signed of signed en encrypted profielen).
+  - *De bron ondersteunt de strekking volledig: berichtniveau-beveiliging is nodig bij niet-vertrouwde intermediairs omdat TLS alleen point-to-point werkt.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  > TLS beschermt alleen via één TLS-verbinding en het pad tussen de client en de server kan bestaan uit meerdere onafhankelijke TLS-verbindingen [...] In dergelijke gevallen kan TLS geen end-to-end berichtintegriteit of authenticiteit tussen de client en de server garanderen. HTTP Message signing kan dit geval gebruikt worden om end-to-end bescherming tegen manipulatie te realiseren
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
-  > Voor End-to-End Security, door middel van signing (ondertekening) en (optioneel) encryptie (versleuteling) op bericht-niveau in combinatie met (point-to-point) twee-zijdig TLS in het HTTP kanaal. [...] op basis van Reliable Messaging of Best Effort wordt een bericht beveiligd tussen de uiteindelijke Consumer en de uiteindelijke Provider, ook wanneer er zich intermediairs bevinden in het pad tus...
-  - *De bron stelt expliciet dat berichtniveau-beveiliging nodig is wanneer er intermediairs aanwezig zijn, omdat TLS alleen point-to-point werkt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
-  > Het versleutelen van berichtinhoud (berichtenniveau versleuteling) kan worden toegepast indien de intermediair niet vertrouwd wordt.
-  - *De bron bevestigt dat berichtniveau-encryptie relevant is bij niet-vertrouwde intermediairs, en dat TLS point-to-point is (impliciet via de uitleg over knooppunten). De claim zegt 'SHOULD' (essentieel), de bron zegt 'kan' (MAY). Gedeeltelijke ondersteuning voor de redenering, niet voor de normering.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
-  > Indien het bericht ondertekend en versleuteld is, hoeven gateway 1 en gateway 2 het bericht niet te valideren of ontcijferen. Zolang de addressing informatie niet veranderd wordt, is de meegestuurde 'signature' nog steeds valide.
-  - *De bron bevestigt impliciet het belang van berichtniveau-beveiliging bij intermediairs (gateways hoeven niet te ontcijferen), maar formuleert niet expliciet dat TLS alleen point-to-point beveiligt of dat berichtniveau-beveiliging 'essentieel' is bij niet-vertrouwde intermediairs als normatieve aanbeveling.*
-- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
-  > Bij transparante intermediairs vindt geen tussentijdse opslag van het grote bestand plaats bij de intermediair... Bij Niet-transparante intermediairs is in Digikoppeling-termen de intermediair te zien als een endpoint.
-  - *De bron bespreekt intermediairs en het verschil tussen transparante en niet-transparante varianten, wat de stelling over TLS als point-to-point beveiliging indirect ondersteunt. De claim over berichtniveau-beveiliging als essentieel bij niet-vertrouwde intermediairs wordt echter niet expliciet gemaakt in de bron.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
-  > Een transparante intermediair stuurt berichten door naar het eindpunt (ontvanger) zonder de berichten te bewerken. Een transparante intermediair is zelf dus geen eindpunt in Digikoppeling. Het versleutelen van berichtinhoud (berichtenniveau versleuteling) kan worden toegepast indien de intermediair niet vertrouwd wordt.
-<details><summary>11x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+  > End-to-End Security: op basis van Reliable Messaging of Best Effort wordt een bericht beveiligd tussen de uiteindelijke Consumer en de uiteindelijke Provider, ook wanneer er zich intermediairs bevinden in het pad tussen die twee.
+  - *De bron bevestigt impliciet dat berichtniveau-beveiliging noodzakelijk is bij aanwezigheid van intermediairs, omdat TLS alleen point-to-point beveiligt.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  > End-to-End beveiliging is primair van toepassing in de scenario's waar intermediairs betrokken zijn gedurende de gegevensuitwisseling en in scenario's waarbij onweerlegbaarheid van belang is.
+  - *De bron ondersteunt de strekking dat berichtniveau-beveiliging essentieel is bij niet-vertrouwde intermediairs, omdat TLS alleen point-to-point beveiligt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > TLS kan niet toegepast worden om end-to-end authenticatie uit te voeren in een multi-hop (voor ebMS2) omgeving; zie daarvoor berichtniveau beveiliging in de Digikoppeling Architectuur documentatie.
+  - *De bron bevestigt dat TLS alleen point-to-point beveiligt en berichtniveau beveiliging nodig is bij multi-hop. Het woord 'essentieel' en 'niet-vertrouwde intermediairs' wordt niet letterlijk gebruikt, maar de strekking wordt ondersteund.*
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  > In het geval van een logistiek koppelpunt heeft de aanbieder feitelijk te maken met de identiteit van de achterliggende afnemer. [...] Uiteraard kan dat alleen als er voldoende waarborgen en afspraken (bijvoorbeeld bewerkerovereenkomst) zijn.
+  - *De bron bespreekt intermediairs en koppelpunten maar behandelt dit vanuit een identiteits- en autorisatieperspectief, niet vanuit TLS point-to-point beveiliging. De claim over berichtniveau-beveiliging bij niet-vertrouwde intermediairs wordt niet specifiek ondersteund; slechts de context van intermediairs is aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron bespreekt geen niet-vertrouwde intermediairs of het onderscheid tussen point-to-point TLS en end-to-end berichtniveau-beveiliging.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Berichtniveau-beveiliging en intermediairs worden niet behandeld in deze bron.*
+
+### `ls-dk-0053` — reference.md:157 *(§ OIN-identificatie)*
+
+> Het OIN-stelsel wordt beheerd door Logius.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Logius beheert de Centrale OIN Raadpleegvoorziening (COR) waarin uitgegeven Organisatie identificatienummers zijn gepubliceerd.
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > The OIN stands for Organisatie Identificatie Nummer and is maintained by Logius in the COR (Centrale OIN Raadpleegvoorziening).
+  - *De bron bevestigt dat Logius het OIN beheert via de COR. De term 'OIN-stelsel' als zodanig wordt niet gebruikt, maar de strekking (Logius beheert het OIN) wordt ondersteund. Niet volledig SUPPORTED omdat de bron niet spreekt van een 'stelsel' maar enkel van het nummer en de raadpleegvoorziening.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  > Het organisatie identificatienummer (OIN) is het identificerende nummer voor organisaties die gebruik maken van Digikoppeling. [...] Het OIN kan worden opgezocht in het OIN Register. [...] Het OIN register is bereikbaar via het Digikoppeling Portaal.
+  - *De bron noemt Logius als beheerder van het Digikoppeling Portaal en het OIN Register impliciet, maar noemt 'Logius beheert het OIN-stelsel' niet letterlijk. PKI-CA referentie verwijst naar 'Aansluiten als Trust Service Provider' van Logius.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  > ofwel het OIN wordt uitgereikt door Logius als beheerder van Digikoppeling wanneer noch een RSIN, noch een KvK nummer beschikbaar is. [...] Daarom beslist de beheerder van Digikoppeling over alle verzoeken die afwijken van de in deze notitie aangegeven lijn.
+  - *De bron bevestigt meerdere malen dat Logius beheerder is van het OIN-stelsel en Digikoppeling.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  > Logius beheert het OIN Stelsel. Het OIN valt onder de Digikoppeling Standaard. Het Centrum voor Standaarden, van Logius is beheerder van de Digikoppeling standaard en voert ook het beheer over van het OIN-stelsel, voorwaarden en overeenkomsten.
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De brontekst vermeldt Logius als beheerder van de Digikoppeling REST API standaard en gerelateerde standaarden, maar het OIN-stelsel zelf en het beheer daarvan worden niet expliciet besproken.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Het OIN-stelsel en het beheer ervan door Logius worden niet besproken in deze WUS-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Het OIN-stelsel en het beheer ervan door Logius worden niet behandeld in deze bron.*
+</details>
+
+### `ls-dk-0054` — reference.md:158 *(§ OIN-identificatie)*
+
+> Sub-OIN's zijn mogelijk voor organisatieonderdelen of specifieke systemen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  > Zo kunnen overheidsorganisaties (formeel organisaties met Publiekrechtelijke Rechtspersoonlijkheid) eenvoudig een subOIN aanvragen voor samenwerkingsverbanden waar ze zelf deel aan nemen, eigen organisatieonderdelen en voorzieningen waar ze beheer over voeren
+  - *De bron bevestigt dat sub-OINs mogelijk zijn voor organisatieonderdelen en voorzieningen. De claim noemt ook 'specifieke systemen', wat overeenkomt met 'voorzieningen waar ze beheer over voeren'.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  > Het SubOIN is een afgeleide van het OIN en is opgesteld volgens de OIN-nummersystematiek en wordt gebruikt voor een organisatieonderdeel, samenwerkingsverband of voorziening dat niet zélf in het Handelsregister voorkomt.
+  - *De bron noemt organisatieonderdelen expliciet. 'Specifieke systemen' worden in de bron aangeduid als 'voorzieningen', wat nagenoeg equivalent is.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
-  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+  - *De bron beschrijft het OIN en HRN als identificatienummers voor organisaties, maar noemt sub-OIN's voor organisatieonderdelen of specifieke systemen nergens. Dit detailniveau valt buiten dit architectuurdocument.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
-  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+  - *De brontekst noemt het OIN (Organisatie Identificatie Nummer) in de context van PKIO-certificaten en FSC, maar sub-OIN's worden nergens besproken.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron vermeldt dat het OIN ook gebruikt kan worden voor 'departments or units of larger organizations' die geen zelfstandige rechtspersonen zijn, maar het concept 'sub-OIN' wordt nergens expliciet genoemd of beschreven.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
-  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
-  - *De bron beschrijft de Grote Berichten koppelvlakstandaard. Berichtniveau-beveiliging in relatie tot niet-vertrouwde intermediairs wordt niet behandeld in deze bron.*
+  - *Sub-OIN's worden niet besproken in deze brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Sub-OIN's worden niet besproken in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
-  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
-  - *De bron behandelt het onderwerp van berichtniveau-beveiliging bij niet-vertrouwde intermediairs niet.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
-  - *De bron gaat niet in op de verhouding tussen TLS (point-to-point) en berichtniveau-beveiliging bij niet-vertrouwde intermediairs. Dit onderwerp wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
-  - *Het concept van niet-vertrouwde intermediairs en de beperking van TLS tot point-to-point beveiliging als argument voor berichtniveau-beveiliging wordt niet behandeld in dit document.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt geen sub-OIN's voor organisatieonderdelen of specifieke systemen.*
 </details>
 
 </details>

--- a/skills/ls-dk/audit.md
+++ b/skills/ls-dk/audit.md
@@ -1,0 +1,2412 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-dk — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 9 | 18% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 11 | 22% |
+| UNGROUNDED | 5 | 10% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 3 | 6% |
+| GROUNDED | 22 | 44% |
+
+*Geverifieerd met sonnet, 44 calls, $5.0213.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (9)
+
+### `ls-dk-0003` — SKILL.md:41 *(§ Repositories)*
+
+> Digikoppeling-Koppelvlakstandaard-REST-API is vastgesteld als v4.0.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+
+<details><summary>27x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding. Geen inhoud over versienummers van de REST-API koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst gaat over ebMS2, niet over de REST-API koppelvlakstandaard. Versienummer v4.0.0 wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Versie-informatie over de REST-API koppelvlakstandaard staat niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron noemt REST-API als voorbeeld van een koppelvlakspecificatie maar geeft geen versienummers van specifieke standaarden.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt de REST-API koppelvlakstandaard als bestaand document maar noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De brontekst toont alleen de GitHub repository-pagina met releases (de latest is '1.1.1 release' van Dec 9, 2022) en vermeldt geen versienummer v4.0.0. De getoonde releaseinfo suggereert eerder v1.1.1 als laatste release, maar de brontekst bevat geen volledige releaselijst. Geen vermelding van v4.0.0.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron is de werkversie van de REST-API koppelvlakstandaard maar noemt geen versienummer v4.0.0. De status is 'werkversie 25 maart 2026', geen vastgestelde versie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over de REST-API koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De bron vermeldt in de documentbeheer-tabel versie 3.3.2 als meest recente ebMS2-versie en noemt het REST-API koppelvlak alleen terloops (versie 3.3.1: 'Vermelding REST-API koppelvlak'), maar geeft geen versienummer v4.0.0 voor de REST-API standaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over de REST-API koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst vermeldt het bestaan van een REST-API koppelvlak maar geeft geen versienummer. Er staat alleen: 'Naast de Koppelvlakstandaard WUS zijn er ook de ebMS2- en REST-API-standaarden.' Geen versie-informatie aanwezig.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over de REST-API koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron vermeldt geen versienummer van de REST-API koppelvlakstandaard. Er is slechts een noot dat Digikoppeling ook een REST API profiel kent.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over de REST-API koppelvlakstandaard of diens versienummer.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron behandelt beveiligingsstandaarden en verwijst niet naar de REST-API koppelvlakstandaard of enig versienummer daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over de REST-API koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De bron vermeldt de REST-API koppelvlakstandaard slechts zijdelings ('Vermelding REST-API koppelvlak' in documentbeheer), maar geeft geen versienummer v4.0.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
+  - *De brontekst bevat geen informatie over de REST-API koppelvlakstandaard of versienummers.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
+  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Koppelvlakstandaard-REST-API wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
+  - *De brontekst bevat geen informatie over versienummers van de REST-API koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
+  - *De REST API koppelvlakstandaard wordt wel genoemd als voorbeeld van een toevoeging aan Digikoppeling, maar geen versienummer wordt vermeld in deze bron.*
+</details>
+
+### `ls-dk-0007` — SKILL.md:45 *(§ Repositories)*
+
+> Digikoppeling-Beveiligingsstandaarden-en-voorschriften is vastgesteld als v3.0.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling beveiligingsstandaarden
+
+<details><summary>27x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst verwijst naar Digikoppeling Beveiligingsstandaarden en voorschriften als referentie maar noemt geen versienummer v3.0.0.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Versie-informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften staat niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Beveiligingsstandaarden wordt kort aangehaald als toegevoegd document maar zonder versienummer v3.0.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt de Beveiligingsstandaarden en voorschriften als bestaand document maar noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft de REST-API repository; er is geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron verwijst naar Digikoppeling Beveiligingsstandaarden en voorschriften als referentie [DK-beveiliging] maar noemt geen versienummer v3.0.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De bron verwijst naar 'Digikoppeling Beveiligingsstandaarden en voorschriften' als normatieve referentie maar noemt geen versienummer v3.0.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst verwijst naar 'Digikoppeling Beveiligingsstandaarden en voorschriften' als normatieve referentie maar geeft geen versienummer van dat document.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron vermeldt Digikoppeling-Beveiligingsstandaarden-en-voorschriften alleen als normatieve referentie [DK-beveiliging] zonder versienummer.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron is de GitHub-repositorypagina voor Digikoppeling-Beveiligingsstandaarden-en-voorschriften. Er worden 5 releases vermeld (meest recent: '1.4 (rerelease)' van jan 2022), maar v3.0.0 wordt nergens in de aangeleverde brontekst vermeld. De versie-claim kan niet worden bevestigd noch ontkracht op basis van deze tekst.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron is het beveiligingsstandaarden-document zelf. Het documentbeheer toont versies 1.0 t/m 2.0.1; versie 3.0.0 wordt nergens vermeld. De meest recente versie in het documentbeheer is 2.0.1 (24/06/2025).*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over Beveiligingsstandaarden-en-voorschriften.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De bron bevat geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften of versienummer v3.0.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
+  - *De brontekst bevat geen informatie over Digikoppeling-Beveiligingsstandaarden-en-voorschriften of versienummers.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
+  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Beveiligingsstandaarden-en-voorschriften wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
+  - *De brontekst bevat geen informatie over versienummers van Digikoppeling-Beveiligingsstandaarden-en-voorschriften.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
+  - *Digikoppeling Beveiligingsstandaarden en voorschriften wordt in de documentbeheer-tabel vermeld als toegevoegd in versie 1.4 (april 2016) van het beheermodel, maar een versienummer van het document zelf (v3.0.0) staat niet in de bron.*
+</details>
+
+### `ls-dk-0009` — SKILL.md:47 *(§ Repositories)*
+
+> OIN-Stelsel is vastgesteld als v3.0.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-Stelsel
+
+<details><summary>27x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *OIN-Stelsel als document met versienummer v3.0.0 wordt niet vermeld. OIN wordt wel beschreven als identificatiemechanisme maar zonder verwijzing naar een stelsel-document.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Versie-informatie over het OIN-Stelsel staat niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *OIN-Stelsel wordt vermeld in de impactmatrix maar zonder versienummer v3.0.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *Het OIN-Stelsel als afzonderlijk document met versienummer wordt in de bron niet vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft de REST-API repository; er is geen informatie over het OIN-Stelsel of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *OIN-Stelsel wordt niet als document of versie genoemd in de bron. Het OIN wordt functioneel beschreven maar zonder verwijzing naar een OIN-Stelsel standaard met versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over het OIN-Stelsel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *OIN-Stelsel als apart document met versienummer v3.0.0 wordt niet vermeld. De bron noemt OIN (Organisatie Identificatie Nummer) functioneel maar niet als versioned standaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over het OIN-Stelsel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst bevat geen informatie over het OIN-Stelsel of een versienummer daarvan. OIN wordt wel kort genoemd in de context van adressering maar zonder verwijzing naar een vastgesteld OIN-Stelsel document.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over het OIN-Stelsel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
+  - *OIN-Stelsel wordt niet als document met versienummer vermeld in de bron. OIN wordt wel gebruikt als concept (authenticatie op basis van OIN), maar zonder verwijzing naar een OIN-Stelsel document.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over het OIN-Stelsel of diens versienummer.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *Het OIN-Stelsel wordt niet als zelfstandig document of versie vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over het OIN-Stelsel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De bron verwijst naar het OIN-stelsel en OIN-beleid, maar geeft geen versienummer v3.0.0 voor het OIN-Stelsel document.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
+  - *De brontekst is de GitHub-pagina van de OIN-Stelsel repository zelf, maar bevat geen versienummer (zoals v3.0.0). De gepubliceerde URL wordt wel vermeld (gitdocumentatie.logius.nl/publicatie/dk/oin/), maar versie-metadata staat niet in de repository-overzichtspagina.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
+  - *De bron is het OIN-Stelsel document zelf (werkversie 13 maart 2026), maar een vastgesteld versienummer 'v3.0.0' wordt nergens in de brontekst vermeld. De status is expliciet 'werkversie', niet een vastgestelde versie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
+  - *De brontekst bevat geen informatie over versienummers van het OIN-Stelsel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
+  - *OIN en het OIN-stelsel worden meerdere keren vermeld in de impactmatrix en elders, maar een vastgesteld versienummer zoals v3.0.0 voor het OIN-Stelsel document staat niet in de bron.*
+</details>
+
+### `ls-dk-0023` — reference.md:39 *(§ REST-API)*
+
+> De REST-API koppelvlakstandaard is gebaseerd op de API Design Rules (ADR) van het Kennisplatform API's, vastgesteld door het Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+
+<details><summary>17x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst gaat over ebMS2; API Design Rules en het Kennisplatform API's worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De relatie tussen de REST-API koppelvlakstandaard en de API Design Rules van het Kennisplatform wordt niet behandeld in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De relatie tussen REST-API koppelvlakstandaard en ADR van het Kennisplatform API's wordt niet beschreven in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *API Design Rules en het Kennisplatform API's worden niet genoemd in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *API Design Rules en het Kennisplatform API's worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen REST-API koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *REST-API koppelvlakstandaard en API Design Rules worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *API Design Rules en het Kennisplatform API's worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *De bron noemt de REST API koppelvlakstandaard maar verwijst niet naar de API Design Rules (ADR) van het Kennisplatform API's als grondslag.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0024` — reference.md:40 *(§ REST-API)*
+
+> Het service contract voor REST-API is een OpenAPI Specification (OAS) 3.x.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+
+<details><summary>17x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *OpenAPI Specification wordt niet vermeld in de brontekst; de bron gaat over ebMS2.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *OpenAPI Specification als service contract voor REST-API wordt niet behandeld in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *OpenAPI Specification als service contract voor REST-API wordt niet vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *OpenAPI Specification als service contract voor REST-API wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *OpenAPI Specification wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen REST-API of OAS.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *OpenAPI Specification voor REST-API wordt niet behandeld in deze WUS Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *OpenAPI Specification als service contract voor REST-API wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *OpenAPI Specification (OAS) wordt niet genoemd in de brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0026` — reference.md:58 *(§ WUS (SOAP))*
+
+> WUS profiel 2W-be-S gebruikt WS-Security en XML Digital Signature (XMLDSIG) voor digitale ondertekening en garandeert integriteit en onweerlegbaarheid.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS 2W-be-S profiel
+
+<details><summary>17x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *WUS-profielen worden niet behandeld in de brontekst; de bron gaat over ebMS2.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *WUS profiel 2W-be-S en WS-Security/XMLDSIG worden niet behandeld in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *WS-Security en XMLDSIG voor het 2W-be-S profiel worden niet besproken in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *WUS profiel 2W-be-S en WS-Security/XMLDSIG worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *WUS profiel 2W-be-S en WS-Security/XMLDSIG worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen WUS profielen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Het WUS profiel 2W-be-S en WS-Security/XMLDSIG voor ondertekening worden niet specifiek behandeld in deze Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *WS-Security, XMLDSIG en het 2W-be-S profiel worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *Het specifieke WUS profiel '2W-be-S' en WS-Security / XMLDSIG worden niet bij naam behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0027` — reference.md:59 *(§ WUS (SOAP))*
+
+> WUS profiel 2W-be-SE gebruikt WS-Security en XML Encryption voor ondertekening en versleuteling en garandeert integriteit, onweerlegbaarheid en vertrouwelijkheid.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS 2W-be-SE profiel
+
+<details><summary>15x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *Deze bron behandelt de ebMS2 koppelvlakstandaard, niet de WUS koppelvlakstandaard. Claims over WUS profielen zijn buiten scope van deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet de WUS koppelvlakstandaard. WUS-profielen (2W-be-SE, WS-Security, XML Encryption) worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron is het Digikoppeling Beheermodel en bevat geen technische specificaties van WUS-profielen zoals 2W-be-SE, WS-Security of XML Encryption.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *WUS profiel 2W-be-SE en XML Encryption worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *WUS profiel 2W-be-SE en XML Encryption worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen WUS profielen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Het WUS profiel 2W-be-SE en XML Encryption worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *WS-Security, XML Encryption en het 2W-be-SE profiel worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *Het specifieke WUS profiel '2W-be-SE' en XML Encryption worden niet bij naam behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0036` — reference.md:116 *(§ Grote Berichten)*
+
+> Er is geen bovengrens gedefinieerd voor de bestandsgrootte bij Grote Berichten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
+
+<details><summary>17x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *Bovengrens voor bestandsgrootte bij Grote Berichten wordt niet behandeld in deze bron. Er is wel een opmerking over payload-groottes bij ebMS in sectie 6.5, maar die gaat niet over Grote Berichten als apart koppelvlak.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron definieert een ondergrens van 20 MiB (VW001) maar vermeldt nergens expliciet dat er geen bovengrens is voor bestandsgrootte.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Geen informatie over een bovengrens (of afwezigheid daarvan) voor bestandsgrootte bij Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *De bron gaat uitsluitend over PKIoverheid-certificaten en hun gebruik binnen Digikoppeling. Grote Berichten worden nergens behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Bovengrens voor bestandsgrootte bij Grote Berichten wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *Dit document gaat over ebMS2 best practices, niet over Grote Berichten. Geen vermelding van bestandsgroottes of Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Bovengrens bestandsgrootte bij Grote Berichten wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *De brontekst beschrijft wat grote berichten zijn en hoe ze werken, maar noemt nergens een bovengrens (of het ontbreken daarvan) voor bestandsgrootte.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *De bron noemt alleen de ondergrens van 20 MiB voor grote berichten. Er wordt geen uitspraak gedaan over een bovengrens.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0049` — reference.md:157 *(§ Berichtniveau-beveiliging)*
+
+> Berichtniveau-versleuteling gebruikt AES-128 of AES-256 voor de payload en asymmetrische RSA voor de sessiesleutel.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling berichtniveau-beveiliging encryptie
+
+<details><summary>16x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron vermeldt XML-versleuteling (xmlenc-core) voor End-to-End Security, maar specificeert geen algoritmen zoals AES-128/AES-256 of RSA voor sessiesleutels. Die details staan in het beveiligingsvoorschriftendocument waarnaar verwezen wordt.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron beschrijft bestandsoverdracht via HTTP/TLS, niet berichtniveau-versleuteling met AES of RSA. Dit valt buiten het scope van de Grote Berichten standaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *AES-128/256 en RSA voor berichtniveau-versleuteling worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Berichtniveau-versleuteling met AES-128/AES-256 of RSA voor sessiesleutels wordt niet beschreven in deze bron. De bron vermeldt asymmetrische encryptie in algemene termen maar niet de specifieke algoritmen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *AES-128/256 en RSA voor berichtniveau-versleuteling worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *AES of RSA voor payload-encryptie wordt niet vermeld. In 3.4.15 staat expliciet: 'Geen gebruik van Signing of (payload) Encryption. (Alleen op HTTP nivo wordt informatie beveiligd)' — dit is eerder een indicatie dat payload-encryptie buiten scope valt voor de beschreven profielen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Berichtniveau-versleuteling met AES en RSA wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *AES-128, AES-256 of RSA voor sessiesleutels worden niet vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *AES-128, AES-256 en RSA voor sessiesleutels worden niet vermeld. De bron noemt het versleutelen van berichten als functionaliteit maar zonder algoritmische details.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (11)
+
+### `ls-dk-0012` — SKILL.md:83 *(§ Profielkeuze)*
+
+> Bij berichten via een niet-vertrouwde intermediair moet de signed (-S) of signed+encrypted (-SE/-E) variant worden gekozen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling profielkeuze beveiliging
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > End-to-End Security: op basis van Reliable Messaging of Best Effort wordt een bericht beveiligd tussen de uiteindelijke Consumer en de uiteindelijke Provider, ook wanneer er zich intermediairs bevinden in het pad tussen die twee.
+  - *De bron beschrijft dat End-to-End Security (signed/encrypted variant) wordt gebruikt wanneer er intermediairs zijn, wat de claim ondersteunt voor het ebMS2 domein. De claim stelt dit echter als algemene Digikoppeling-eis; de bron beperkt zich tot ebMS2-profielen.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Het versleutelen van berichtinhoud (berichtenniveau versleuteling) kan worden toegepast indien de intermediair niet vertrouwd wordt.
+  - *De bron bevestigt dat encryptie kan worden toegepast bij niet-vertrouwde intermediairs, maar gebruikt 'kan' (MAY) in plaats van een verplichting (MUST). De claim stelt dat signed/encrypted variant 'moet' worden gekozen; de bron maakt dit optioneel.*
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Profielkeuze op basis van vertrouwde/niet-vertrouwde intermediairs wordt niet behandeld in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron gaat niet in op specifieke profielkeuzes rondom signed/encrypted varianten bij niet-vertrouwde intermediairs.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Profielkeuze bij niet-vertrouwde intermediairs wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen profielkeuze op basis van vertrouwde/niet-vertrouwde intermediairs.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Profielkeuze bij niet-vertrouwde intermediairs wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *De bron behandelt geen profielkeuze voor signed of encrypted varianten bij niet-vertrouwde intermediairs.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *De bron beschrijft dat berichtinhoud kan worden versleuteld bij niet-vertrouwde intermediairs, maar specifieke profielkeuze-vereisten voor signed/encrypted varianten worden niet uitgewerkt in dit document.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0013` — SKILL.md:91 *(§ Profielkenmerken Matrix)*
+
+> REST-API profiel is synchroon en ondersteunt geen berichtniveau signing of encryptie; TLS wordt gebruikt voor transportbeveiliging.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling REST-API profiel
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Noot : REST API Zie het [ Digikoppeling REST API profiel ] voor de ondersteuning van signing en encryptie voor REST API's
+  - *De bron verwijst naar het REST API profiel voor signing en encryptie, maar bevestigt noch ontkent dat het profiel synchroon is of dat TLS de enige transportbeveiliging is. Dat signing/encryptie apart beschreven staan voor REST API suggereert dat het niet inherent aanwezig is, maar de claim als geheel is niet volledig bevestigd.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Een gevolg van het REST principe is wel dat het koppelvlak in principe vooral geschikt is voor bevragingen. [...] Een belangrijk principe van REST is dat de bevraging stateless is.
+  - *De bron bevestigt het synchrone karakter (REST geschikt voor bevragingen). Berichtniveau signing/encryptie en TLS als transportbeveiliging worden niet expliciet voor REST API behandeld in deze bron.*
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst gaat over ebMS2, niet over het REST-API profiel. Synchroniciteit en afwezigheid van berichtniveau signing bij REST worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Eigenschappen van het REST-API profiel (synchroon, signing, encryptie) worden niet behandeld in deze Grote Berichten spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron beschrijft het beheermodel, niet de technische kenmerken van het REST-API profiel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *De bron bespreekt REST API alleen in de context van OIN-gebruik in querystrings; geen uitspraken over synchroniciteit of het ontbreken van berichtniveau signing/encryptie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen REST-API profiel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *REST-API profiel wordt niet behandeld in deze WUS Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *De bron beschrijft REST-API als koppelvlak voor Grote Berichten maar gaat niet in op synchroniciteit, berichtniveau signing/encryptie of TLS als transportbeveiliging in de context van het REST-API profiel als zodanig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0015` — SKILL.md:105 *(§ Profielkenmerken Matrix)*
+
+> Grote Berichten gebruikt TLS voor transport; payload-encryptie kan aanvullend worden toegepast maar is niet voorgeschreven in het profiel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** Digikoppeling Grote Berichten
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS. [...] GB007 PUSH / PULL De minimaal ondersteunde TLS encryptie algoritmen en sleutellengtes worden beschreven in het [Digikoppeling Beveiligingsdocument].
+  - *TLS voor transport wordt bevestigd. Payload-encryptie als aanvullende optie wordt niet expliciet behandeld in de bron; de bron verwijst voor beveiligingsdetails naar het Digikoppeling Beveiligingsdocument.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Ten behoeve van Digikoppeling grote berichten dient gebruik gemaakt te worden van OIN gerelateerde certificaten. Alleen verbindingen waarbij zowel de client als de server over een geldig certificaat beschikken zijn toegestaan (TLS).
+  - *De bron bevestigt TLS als vereiste voor transport. Over aanvullende payload-encryptie zegt de bron niets, en de formulering 'niet voorgeschreven in het profiel' is niet bevestigd of ontkracht.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Voor ophalen van het grote bestand maakt de standaard gebruik van HTTPS-downloads. Daardoor zijn reliability en security gelijkwaardig aan WUS en ebMS2.
+  - *HTTPS (TLS) voor transport wordt bevestigd. Payload-encryptie als aanvullende optie wordt niet expliciet behandeld in deze bron.*
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst behandelt Grote Berichten niet. TLS voor transport wordt wel beschreven voor ebMS2 maar niet in de context van Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Technische details over transportbeveiliging en payload-encryptie voor Grote Berichten ontbreken in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Grote Berichten en payload-encryptie worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Grote Berichten en payload-encryptie worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt het Grote Berichten koppelvlak niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Grote Berichten wordt niet behandeld in deze WUS Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0018` — SKILL.md:365 *(§ Retry Strategie (ebMS2 Reliable Messaging))*
+
+> Bij het profiel osb-rm geldt at-most-once delivery: berichten worden nooit dubbel afgeleverd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Digikoppeling ebMS2 osb-rm reliable messaging
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Reliable Messaging profile 2, Once-And-Only-Once Reliable Messaging at the End-To-End level only based upon end-to-end retransmission. [...] The ToParty MSH must also filter any duplicate messages based on ebXML MessageId.
+  - *De bron beschrijft 'Once-And-Only-Once' delivery en duplicate eliminatie, wat at-most-once delivery impliceert. De claim stelt expliciet 'berichten worden nooit dubbel afgeleverd', maar de standaard garandeert dit via duplicate eliminatie op MessageId-niveau, niet als absolute garantie. De formulering 'nooit dubbel afgeleverd' is sterker dan wat de bron letterlijk stelt.*
+<details><summary>16x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *At-most-once delivery bij osb-rm wordt niet behandeld in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *At-most-once delivery semantics worden niet beschreven in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *At-most-once delivery en osb-rm worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *At-most-once delivery wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron beschrijft reliable messaging en duplicate-eliminatie, maar de term 'at-most-once delivery' wordt niet gebruikt. De ebMS2 once-and-only-once semantiek wijst eerder op exactly-once dan at-most-once. De specifieke claim over at-most-once wordt niet gestaafd of tegengesproken.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *ebMS2 osb-rm at-most-once delivery wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *At-most-once delivery bij osb-rm wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *Het profiel 'osb-rm' en at-most-once delivery worden niet specifiek behandeld in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0025` — reference.md:51 *(§ WUS (SOAP))*
+
+> WUS staat voor WSDL, UDDI en SOAP. Het service contract is een WSDL en het berichtformaat is SOAP XML.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  > In WSDL 1.1 [...] is een Authoring Style advies opgenomen... De meest gangbare zijn... [en] het berichtformaat is SOAP... messaging (SOAP)
+  - *De bron bevestigt dat WUS gebruik maakt van WSDL en SOAP, maar de expansie 'WUS staat voor WSDL, UDDI en SOAP' als acroniem staat niet expliciet in de bron. UDDI wordt nergens genoemd. De claim over WSDL als service contract en SOAP als berichtformaat wordt wel ondersteund.*
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > De naam WUS staat voor WSDL, UDDI en SOAP, drie belangrijke deelstandaarden. [...] Een WSDL is een formeel xml-document om de gebruikte functionele en technische eigenschappen van de berichtuitwisseling via WUS vast te leggen.
+  - *WUS staat voor WSDL, UDDI en SOAP wordt bevestigd, evenals WSDL als servicecontract. SOAP XML als berichtformaat wordt impliciet bevestigd via de WUS-standaard maar niet expliciet als 'SOAP XML berichtformaat' omschreven.*
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *WUS (WSDL, UDDI, SOAP) wordt niet behandeld in de brontekst; de bron gaat over ebMS2.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *WUS (WSDL, UDDI, SOAP) als koppelvlak wordt niet inhoudelijk behandeld in deze Grote Berichten spec, enkel zijdelings vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De afkorting WUS en de technische details (WSDL, UDDI, SOAP) worden niet uitgelegd in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *WUS (WSDL, UDDI, SOAP) en WSDL als service contract worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *WUS, WSDL, UDDI, SOAP als afkortingen of definities worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen WUS koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *De afkorting WUS en WSDL/UDDI/SOAP-definitie worden niet uitgelegd in deze bron. WUS wordt wel vermeld als koppelvlak maar niet nader gespecificeerd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0028` — reference.md:60 *(§ WUS (SOAP))*
+
+> WUS gebruikt de standaarden WS-Security 1.1, WS-Addressing, SOAP 1.1 (document-literal binding) en MTOM voor binaire bijlagen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > WUS: in de querystring van de endpointuri in de SOAP ws-addressing header.
+  - *De bron noemt WS-addressing en SOAP in de context van WUS, maar behandelt niet WS-Security 1.1, SOAP 1.1 document-literal binding of MTOM. Slechts een klein deel van de claim wordt bevestigd.*
+<details><summary>14x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *Deze bron behandelt de ebMS2 koppelvlakstandaard, niet de WUS koppelvlakstandaard. Claims over WUS-specifieke standaarden zijn buiten scope.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet de WUS koppelvlakstandaard. WS-Security, WS-Addressing, SOAP 1.1 en MTOM worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron bevat geen technische details over WUS-standaarden (WS-Security 1.1, WS-Addressing, SOAP 1.1, MTOM). Het beheermodel verwijst alleen globaal naar WUS als open standaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *WS-Security 1.1, WS-Addressing, SOAP 1.1 en MTOM als WUS-standaarden worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen WUS standaarden.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *De bron vermeldt WS-Addressing en SOAP, maar noemt niet expliciet WS-Security 1.1, SOAP 1.1 document-literal binding als combinatie, en MTOM. De combinatie als volledige claim is niet te bevestigen vanuit deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *WS-Security 1.1, WS-Addressing, SOAP 1.1 en MTOM worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *WS-Security 1.1, WS-Addressing, SOAP 1.1 document-literal binding en MTOM worden niet specifiek vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0030` — reference.md:71 *(§ ebMS2)*
+
+> ebMS2 berichtformaat is SOAP 1.1 met ebMS2 headers en payload als MIME-attachment.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Dit document specificeert de Koppelvlakstandaard ebMS2 voor berichtenuitwisseling over Digikoppeling (voorheen OverheidsServiceBus) als een toepassing van de EBXML-MSG standaard, de ebXML Message Service Specification versie 2.0 [EBXML-MSG].
+  - *De bron bevestigt het gebruik van SOAP (via EBXML-MSG) en MIME-attachments (Manifest/payload containers). SOAP 1.1 wordt indirect bevestigd via de verwijzing naar [SOAP] (Simple Object Access Protocol 1.1). De combinatie van SOAP met ebMS2 headers en MIME-attachments is consistent met de bron, maar niet als één expliciete definitie beschreven.*
+<details><summary>15x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet ebMS2. ebMS2 berichtformaat wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Geen technische beschrijving van het ebMS2 berichtformaat (SOAP 1.1, ebMS2 headers, MIME-attachment) in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *ebMS2 berichtformaat (SOAP 1.1 met ebMS2 headers en MIME-attachment) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *SOAP 1.1 met ebMS2 headers en MIME-attachment worden niet behandeld in deze bron.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron beschrijft CPA gebruik en kenmerken maar specificeert het berichtformaat (SOAP 1.1 met ebMS2 headers en MIME-attachment) niet expliciet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *ebMS2 berichtformaat wordt niet behandeld in deze WUS Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *ebMS2 berichtformaat (SOAP 1.1 met ebMS2 headers en MIME-attachment) wordt niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *De bron beschrijft ebMS2 en vermeldt dat het op web-service standaarden is gebaseerd, maar noemt SOAP 1.1 met ebMS2 headers en MIME-attachment niet expliciet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0034` — reference.md:94 *(§ Grote Berichten)*
+
+> Grote Berichten ondersteunt HTTP 1.1 met BYTE-RANGE (RFC 7233) voor hervatbare downloads.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc7233.txt](https://www.rfc-editor.org/rfc/rfc7233.txt)
+  > This document defines HTTP/1.1 range requests, partial responses, and the multipart/byteranges media type. [...] HTTP clients often encounter interrupted data transfers as a result of canceled requests or dropped connections. When a client has stored a partial representation, it is desirable to request the remainder of that representation in a subsequent request rather than transfer the entire ...
+  - *De bron bevestigt dat RFC 7233 de BYTE-RANGE mechanismen voor HTTP/1.1 definieert, inclusief hervatbare downloads. Echter, de bron maakt geen enkele vermelding van 'Digikoppeling' of 'Grote Berichten' — dat Digikoppeling Grote Berichten specifiek HTTP 1.1 met BYTE-RANGE (RFC 7233) ondersteunt, is niet te verifiëren uit deze brontekst. De bron is de RFC zelf, niet de Digikoppeling-specificatie. Het technische mechanisme wordt bevestigd, maar de koppeling aan Digikoppeling Grote Berichten ontbreekt.*
+
+### `ls-dk-0041` — reference.md:131 *(§ TLS-vereisten)*
+
+> TLS004: Cipher suites moeten voldoen aan de NCSC-richtlijnen voor TLS. Zwakke cipher suites zijn niet toegestaan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS004
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS. Aanbieder en afnemer ondersteunen de minimaal ondersteunde TLS encryptie algoritmen en sleutellengtes zoals beschreven in het [Digikoppeling Beveiligingsdocument]
+  - *De bron bevestigt dat er eisen zijn aan TLS-encryptie-algoritmen en sleutellengtes, maar verwijst voor de details naar het Digikoppeling Beveiligingsdocument. De specifieke eis over NCSC-richtlijnen en verbod op zwakke cipher suites staat niet in deze bron.*
+<details><summary>16x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron verwijst voor cipher suites naar 'Digikoppeling Beveiligingsstandaarden en voorschriften' zonder zelf specifieke cipher suites of NCSC-richtlijnen te noemen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *TLS004 en NCSC-richtlijnen voor cipher suites worden niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *NCSC-richtlijnen voor cipher suites worden niet vermeld in deze bron. De bron verwijst voor beveiligingseisen naar een apart document.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *NCSC-richtlijnen voor cipher suites worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *Cipher suites of NCSC-richtlijnen worden niet vermeld in dit document. Er wordt verwezen naar het Digikoppeling Beveiligingsdocument voor actuele protocolvereisten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Cipher suites en NCSC-richtlijnen (TLS004) worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *NCSC-richtlijnen voor cipher suites worden niet vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *Cipher suites en NCSC-richtlijnen worden niet vermeld in deze bron. De bron verwijst voor beveiligingsdetails naar het apart document 'Digikoppeling Beveiligingsstandaarden en voorschriften'.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0042` — reference.md:132 *(§ TLS-vereisten)*
+
+> TLS005: Certificaten moeten geldig zijn en de volledige keten tot aan de PKIoverheid-root moet verifieerbaar zijn. Revocation checking (CRL/OCSP) is verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS005
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > The use of certificate revocation lists (CRL) from the trusted CAs is required. [...] What certificate verification policies and procedures must be followed? PKI overheid procedures are described in Certificate Policy/Programme of Requirements PKIoverheid. The use of certificate revocation lists (CRL) from the trusted CA's is required.
+  - *De bron bevestigt CRL-verificatie als verplicht en geldigheid via PKIoverheid. OCSP wordt niet expliciet genoemd. De 'volledige keten tot PKIoverheid-root' is impliciet via PKIoverheid-procedures maar niet letterlijk geformuleerd.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB011 PUSH / PULL De server moet certificaat-revocatie-lijsten (CRL) gebruiken [PKI Policy].
+  - *De bron bevestigt CRL-gebruik. OCSP wordt niet vermeld. De eis over geldigheid van de volledige keten tot PKIoverheid-root wordt niet expliciet beschreven in deze bron.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Een certificaat is geldig als het aan de volgende drie eisen voldoet: De ondertekening van het certificaat berust op een geldige hiërarchie van certificaten afgeleid van het overheid stamcertificaat. De geldigheidsduur van het certificaat is niet verstreken. Het certificaat is niet ingetrokken door de TSP.
+  - *De bron ondersteunt ketenvalidatie en revocation checking via CRL (en optioneel OCSP), maar stelt OCSP niet verplicht ('voor TSP's niet verplicht'). De claim zegt dat revocation checking verplicht is; de bron maakt CRL-raadpleging noodzakelijk maar OCSP optioneel. Ketenvalidatie tot stamcertificaat wordt wel bevestigd.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Het spreekt voor zich dat de gebruikte certificaten worden gecontroleert op geldigheid en revocation.
+  - *De bron bevestigt dat certificaten op geldigheid en revocation gecontroleerd moeten worden, maar noemt de PKIoverheid-root-keten verificatie en CRL/OCSP niet expliciet als technische methoden.*
+<details><summary>13x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *TLS005 en vereisten rondom certificaatgeldigheid, ketenverificatie en revocation checking (CRL/OCSP) komen niet voor in het beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *CRL/OCSP revocation checking en PKIoverheid-root verificatie worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *Certificaatvalidatie, CRL/OCSP of revocation checking worden niet behandeld in dit document.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Certificaatgeldigheid en revocation checking CRL/OCSP (TLS005) worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *CRL/OCSP revocation checking wordt niet vermeld. De bron noemt PKIoverheid-certificaten maar gaat niet in op specifieke validatie-eisen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0048` — reference.md:156 *(§ Berichtniveau-beveiliging)*
+
+> Berichtniveau-ondertekening gebruikt XML Digital Signature (XMLDSIG) met minimaal SHA-256; SHA-1 is niet meer toegestaan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling berichtniveau-beveiliging signing
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Required in this profile. [...] What canonicalization method(s) must be applied to the data to be signed? The use of XML canonicalization is required. [xml-exc-c14n] [...] What signature method(s) must be applied? The applied signature method is described in Digikoppeling Beveiligingsstandaarden en voorschriften
+  - *De bron bevestigt gebruik van XML Digital Signature (XMLDSIG) voor End-to-End Security. De specifieke eis van SHA-256 minimum en het verbod op SHA-1 staat niet in deze bron; daarvoor wordt verwezen naar 'Digikoppeling Beveiligingsstandaarden en voorschriften'.*
+<details><summary>15x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron beschrijft bestandsoverdracht via HTTP/TLS, niet berichtniveau-ondertekening met XMLDSIG. Dit valt buiten het scope van de Grote Berichten standaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Berichtniveau-ondertekening met XMLDSIG, SHA-256 of verbod op SHA-1 worden niet beschreven in het beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *De bron noemt signing-profielen (signed, signed en encrypted) voor WUS en ebMS2, maar bevat geen specificaties over XMLDSIG, SHA-256 of het verbod op SHA-1 voor berichtniveau-ondertekening.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *XML Digital Signature, SHA-256 en het verbod op SHA-1 worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *XML Digital Signature, XMLDSIG, SHA-256 of SHA-1 worden niet vermeld in dit document. Berichtniveau-ondertekening via signing wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Berichtniveau-ondertekening met XMLDSIG en SHA-256 vereisten worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *XML Digital Signature, XMLDSIG, SHA-256 of berichtniveau-ondertekening worden niet besproken in deze bron over Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *XMLDSIG, SHA-256 en SHA-1 worden niet vermeld. De bron noemt wel dat berichten beveiligd kunnen worden met een technische handtekening, maar zonder technische details over algoritmen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+## UNGROUNDED — geen bron ondersteunt de claim (5)
+
+### `ls-dk-0011` — SKILL.md:73 *(§ Profielkeuze)*
+
+> Bij gebruik van REST-API profiel is FSC (Federated Service Connectivity) verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API profiel
+
+<details><summary>17x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *FSC (Federated Service Connectivity) wordt niet vermeld in de brontekst; de bron gaat over ebMS2.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *FSC als verplicht onderdeel van het REST-API profiel wordt niet behandeld in deze Grote Berichten spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *FSC (Federated Service Connectivity) wordt niet genoemd in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *FSC (Federated Service Connectivity) wordt niet genoemd in deze bron. De bron gaat over certificaten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *FSC (Federated Service Connectivity) wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt ebMS2; FSC en REST-API profiel komen niet aan bod.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *REST-API profiel en FSC worden niet behandeld in deze WUS Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *FSC (Federated Service Connectivity) wordt in deze bron niet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *FSC (Federated Service Connectivity) wordt nergens in de brontekst genoemd. De bron beschrijft OAuth als relevant voor REST API koppelvlakken, maar noemt FSC niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0016` — SKILL.md:145 *(§ REST-API Koppelvlak met OIN (Python/FastAPI))*
+
+> REST-API foutresponses moeten RFC 9457 problem+json formaat gebruiken conform de API Design Rules.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API foutafhandeling
+
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
+  - *RFC 9457 definieert het problem+json formaat zelf, maar bevat geen verwijzing naar Digikoppeling, de Nederlandse API Design Rules, of enige verplichting voor specifieke API-profielen om dit formaat te gebruiken. De bron beschrijft wat problem+json is en hoe het gebruikt kan worden, maar legt geen MUST-verplichting op voor Digikoppeling REST-API's.*
+
+### `ls-dk-0022` — reference.md:45 *(§ REST-API)*
+
+> Het gebruik van FSC is verplicht bij Digikoppeling REST-API vanaf v3.0.1. FSC verzorgt de federatieve autorisatie en logging van API-aanroepen tussen organisaties.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API koppelvlakstandaard
+
+<details><summary>17x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *FSC wordt niet vermeld in de brontekst; de bron gaat over ebMS2. Verwijzing naar v3.0.1 en FSC als verplichte component bij REST-API ontbreekt volledig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *FSC als verplicht onderdeel van de REST-API koppelvlakstandaard en de versiedrempel v3.0.1 worden niet behandeld in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *FSC en verplicht gebruik ervan bij REST-API worden niet besproken in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *FSC en verplicht gebruik bij REST-API v3.0.1 worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *FSC en versie v3.0.1 worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt geen REST-API koppelvlakstandaard of FSC.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *FSC en REST-API v3.0.1 worden niet behandeld in deze WUS Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *FSC en verplicht gebruik ervan bij REST-API v3.0.1 worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *FSC wordt niet genoemd in de brontekst. Er is geen vermelding van FSC als verplichting bij Digikoppeling REST-API v3.0.1.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0038` — reference.md:128 *(§ TLS-vereisten)*
+
+> TLS001: TLS 1.2 is minimaal vereist. Eerdere versies (SSL 3.0, TLS 1.0, TLS 1.1) zijn niet toegestaan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS001
+
+<details><summary>17x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron verwijst voor specifieke TLS-versies naar 'Digikoppeling Beveiligingsstandaarden en voorschriften' zonder de versienummers zelf te noemen. Er staat alleen 'The currently allowed protocol versions for TLS are described in Digikoppeling Beveiligingsstandaarden en voorschriften' en 'TLS implementations must NOT support SSL v3 backwards compatibility mode.' De specifieke eis TLS 1.2 minimum staat niet in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron verwijst voor TLS-vereisten naar het Digikoppeling Beveiligingsdocument maar specificeert zelf geen minimale TLS-versies. TLS 1.2 als minimum en verbod op SSL 3.0/TLS 1.0/1.1 worden niet in deze bron beschreven.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *TLS001 en versievereisten (TLS 1.2 minimaal, SSL 3.0/TLS 1.0/1.1 verboden) worden niet beschreven in het beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *De bron verwijst naar Digikoppeling Beveiligingsstandaarden en -voorschriften voor specifieke TLS-versie-eisen, maar bevat zelf geen concrete TLS-versienummers of verboden versies.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *TLS-versievereisten (minimaal TLS 1.2, verbod op SSL 3.0/TLS 1.0/1.1) worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron noemt TLS als verplicht maar specificeert geen minimale versie (1.2) en verbiedt geen eerdere versies expliciet. Er staat alleen een noot: 'voor de actuele versies van het te gebruiken protocol bij de uitwisseling zie [Digikoppeling Beveiligingsdocument]'.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *TLS-versievereisten (TLS001) worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *De bron vermeldt TLS als vereiste maar specificeert nergens minimale versies (TLS 1.2) of verbod op oudere versies (SSL 3.0, TLS 1.0, TLS 1.1).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *De bron verwijst naar het document 'Digikoppeling Beveiligingsstandaarden en voorschriften' voor beveiligingseisen, maar bevat zelf geen specifieke TLS-versievereisten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0039` — reference.md:129 *(§ TLS-vereisten)*
+
+> TLS002: TLS 1.3 wordt aanbevolen wanneer beide partijen dit ondersteunen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS002
+
+<details><summary>17x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *TLS 1.3 aanbeveling wordt niet vermeld in deze bron. De bron verwijst voor TLS-versies naar een apart beveiligingsdocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron verwijst voor TLS-details naar het Digikoppeling Beveiligingsdocument. TLS 1.3 aanbeveling wordt niet in deze bron behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *TLS002 en aanbeveling voor TLS 1.3 komen niet voor in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *TLS 1.3 en aanbevelingen daarvoor komen niet voor in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *TLS 1.3 aanbeveling wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *TLS 1.3 wordt nergens in dit document vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *TLS 1.3 aanbeveling (TLS002) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *TLS 1.3 wordt niet genoemd in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *TLS 1.3 wordt nergens in de bron vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (3)
+
+### `ls-dk-0002` — SKILL.md:40 *(§ Repositories)*
+
+> Digikoppeling-Architectuur is vastgesteld als v2.1.1 en gepubliceerd op gitdocumentatie.logius.nl.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling-Architectuur
+
+**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md: 'Tag achter: publicatie v2.1.1 vs tag 2.0.2'. GitHub toont oudere tag; gitdocumentatie.logius.nl is leidend. De CONTRADICTED-verdicts komen van GitHub/logius-standaarden.github.io, niet van de gezaghebbende publicatiebron.
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  > Redirecting to v2.1.1
+  - *De redirect verwijst naar v2.1.1, wat de versieclaim ondersteunt. Maar de publicatie-URL en verdere inhoud zijn niet beschikbaar in de aangeleverde brontekst.*
+- **CONTRADICTED** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+  > Releases: Release 2.0.2 Latest Dec 9, 2022 + 2 releases
+  - *De bron vermeldt release 2.0.2 als meest recente versie, niet v2.1.1. De gepubliceerde URL klopt wel (gitdocumentatie.logius.nl), maar het versienummer wijkt af.*
+- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  > Deze versie: https://gitdocumentatie.logius.nl/publicatie/dk/architectuur/2.1.0/
+  - *De bron vermeldt expliciet versie 2.1.0, niet 2.1.1 zoals de claim stelt. Het tweede deel van de claim (gepubliceerd op gitdocumentatie.logius.nl) klopt wel.*
+<details><summary>24x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding. Geen inhoud over versienummers van Digikoppeling-Architectuur.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst verwijst naar de Digikoppeling Architectuur als referentie maar vermeldt geen versienummer v2.1.1.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Versie-informatie over Digikoppeling-Architectuur staat niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron vermeldt de Digikoppeling Architectuur als apart document maar noemt geen versienummer v2.1.1.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De brontekst is de GitHub repository-pagina voor de REST-API koppelvlakstandaard. Er is geen informatie over Digikoppeling-Architectuur v2.1.1 of publicatie op gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron verwijst nergens naar Digikoppeling-Architectuur als document of versienummer. De brontekst behandelt uitsluitend de REST-API koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst betreft uitsluitend de Digikoppeling-Koppelvlakstandaard-ebMS2 repository. Er is geen informatie over Digikoppeling-Architectuur.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst verwijst naar Digikoppeling Architectuur als normatieve referentie (URL: https://gitdocumentatie.logius.nl/publicatie/dk/architectuur/) maar noemt geen versienummer v2.1.1.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over Digikoppeling-Architectuur v2.1.1.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat over de Digikoppeling Koppelvlakstandaard WUS en bevat geen informatie over het versienummer of publicatiestatus van de Digikoppeling-Architectuur.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over Digikoppeling-Architectuur. Versie-informatie over Digikoppeling-Architectuur staat niet in deze brontekst.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron vermeldt geen versienummer van Digikoppeling-Architectuur. Het document verwijst wel naar 'Digikoppeling_Architectuur' als document maar geeft geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De brontekst betreft de repository voor Digikoppeling-Beveiligingsstandaarden-en-voorschriften, niet Digikoppeling-Architectuur. Geen informatie over versie of publicatie van de Architectuur-standaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron verwijst naar de Digikoppeling Architectuur documentatie (informatieve referentie DK-Architectuur) maar noemt geen versienummer. Publicatie-metadata zoals versienummers staan zelden in een andere standaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over Digikoppeling-Architectuur. Versie-informatie voor dat document staat niet in deze bron.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De bron gaat uitsluitend over Digikoppeling Identificatie en Authenticatie. Geen informatie over Digikoppeling-Architectuur v2.1.1.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
+  - *De brontekst is de GitHub repository-pagina van OIN-Stelsel. Er staat geen informatie over Digikoppeling-Architectuur of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
+  - *De bron gaat over het OIN-Stelsel, niet over de Digikoppeling-Architectuur. Versienummers van andere Digikoppeling-documenten worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
+  - *De brontekst bevat alleen de GitHub repository-pagina van het Digikoppeling Beheermodel. Er staat geen informatie over versienummers van Digikoppeling-Architectuur of publicatielocaties.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
+  - *De bron verwijst naar de Digikoppeling Architectuur via een normatieve referentie [DK-Architectuur] met URL, maar noemt geen versienummer. Versie-metadata zoals 'v2.1.1' staat niet in deze beheermodeldocumentatie.*
+</details>
+
+### `ls-dk-0004` — SKILL.md:42 *(§ Repositories)*
+
+> Digikoppeling-Koppelvlakstandaard-ebMS2 is vastgesteld als v3.3.2.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
+
+**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md: 'Geen discrepantie (tag komt overeen)' voor ebMS2 v3.3.2. Het CONTRADICTED-verdict komt van github.com (repo-tag), maar gitdocumentatie.logius.nl/publicatie/dk/ebms geeft SUPPORTED. GitHub-tag loopt achter conform gedocumenteerd patroon.
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Digikoppeling Koppelvlakstandaard ebMS2 3.3.2 Logius Standaard Vastgestelde versie 31 mei 2024
+- **CONTRADICTED** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  > Releases 4 — 3.3.1 Latest Apr 11, 2022 + 3 releases
+  - *De bron toont 3.3.1 als de Latest release. De claim stelt v3.3.2, maar de bron kent geen v3.3.2 als vastgestelde versie. Strikt genomen tegenstrijdig: bron noemt 3.3.1 als meest recente, niet 3.3.2. Confidence medium omdat de bron alleen de GitHub-pagina betreft en releases kunnen zijn bijgewerkt na de paginatekst.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  > 31-05-2024 3.3.2 Logius Herstel tabel onder 2.3 Ondersteunde varianten
+  - *De bron bevestigt dat versie 3.3.2 bestaat en de meest recente versie is in de documentbeheer-tabel, maar dit is een werkversie (werkversie 09 maart 2026). De claim dat v3.3.2 'vastgesteld' is wordt niet expliciet bevestigd — de bron zelf heeft de status 'werkversie'.*
+<details><summary>24x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Versie-informatie over de ebMS2 koppelvlakstandaard staat niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Geen versienummer voor ebMS2 koppelvlakstandaard vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt de ebMS2 koppelvlakstandaard als bestaand document maar noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft de REST-API repository; er is geen informatie over de ebMS2 koppelvlakstandaard of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron behandelt de REST-API koppelvlakstandaard, niet ebMS2. Geen versie-informatie over ebMS2 aanwezig.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over de ebMS2 koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst vermeldt ebMS2 als alternatieve standaard maar geeft geen versienummer voor de ebMS2 koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over de ebMS2 koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron vermeldt geen versienummer van de ebMS2 koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over de ebMS2 koppelvlakstandaard of diens versienummer.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron verwijst naar de ebMS2 koppelvlakstandaard (DK-gbachtcert) als informatieve referentie, maar noemt geen versienummer v3.3.2.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over de ebMS2 koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De bron bevat geen informatie over de ebMS2 koppelvlakstandaard of versienummer v3.3.2.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
+  - *De brontekst bevat geen informatie over de ebMS2 koppelvlakstandaard of versienummers.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
+  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Koppelvlakstandaard-ebMS2 wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
+  - *De brontekst bevat geen informatie over versienummers van de ebMS2 koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
+  - *ebMS2 wordt terloops genoemd in de context van internationale standaarden (ebMS [EBXML-MSG]), maar een versienummer voor de Digikoppeling-Koppelvlakstandaard-ebMS2 ontbreekt volledig.*
+</details>
+
+### `ls-dk-0006` — SKILL.md:44 *(§ Repositories)*
+
+> Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten) is vastgesteld als v3.8.1.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten koppelvlakstandaard
+
+**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md: 'Geen discrepantie (tag komt overeen, al zijn er ook sub-releases 3.8.1-2, 3.8.1-3)' voor GB v3.8.1. SUPPORTED op gitdocumentatie.logius.nl/publicatie/dk/gb; CONTRADICTED op logius-standaarden.github.io door sub-releases. Dit is gedocumenteerde situatie.
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > Digikoppeling Koppelvlakstandaard Grote Berichten 3.8.1 Logius Standaard Vastgestelde versie 11 april 2022
+- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
+  > Vorige versie: https://gitdocumentatie.logius.nl/publicatie/dk/gb/3.8/ ... Documentbeheer: 06/10/2020 3.8 Logius RFC 2020-2, RFC 2020-3 | 11/04/2022 3.8.1 Logius Vermelding REST-API koppelvlak
+  - *De bron toont dat de meest recente gepubliceerde versie v3.8 of v3.8.1 is (werkversie is nog niet vastgesteld). De claim stelt v3.8.1 als vastgesteld, maar de bron is een werkversie die nog niet door het TO is goedgekeurd. De vorige gepubliceerde versie was 3.8, met 3.8.1 als meest recente documentbeheer-entry. Een expliciete vaststelling als 'v3.8.1' is niet bevestigd.*
+<details><summary>25x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst gaat over ebMS2; Grote Berichten koppelvlakstandaard en versienummer v3.8.1 worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Geen versienummer voor Grote Berichten koppelvlakstandaard vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt de Grote Berichten koppelvlakstandaard als bestaand document maar noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft de REST-API repository; er is geen informatie over de Grote Berichten koppelvlakstandaard of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron behandelt de REST-API koppelvlakstandaard, niet Grote Berichten. Geen versie-informatie over GB aanwezig.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over de Grote Berichten koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst behandelt de ebMS2 standaard. Digikoppeling Grote Berichten of versienummer v3.8.1 worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over de Grote Berichten koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat uitsluitend over de WUS koppelvlakstandaard en bevat geen informatie over de Grote Berichten koppelvlakstandaard of een versienummer daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
+  - *Hoewel de bron wel over Digikoppeling-Koppelvlakstandaard-GB gaat, bevat de aangeleverde brontekst geen versienummer. De GitHub-pagina toont alleen dat het repository bestaat en gepubliceerd is op gitdocumentatie.logius.nl/publicatie/dk/gb/, maar geen vastgestelde versie v3.8.1.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over de Grote Berichten koppelvlakstandaard of diens versienummer.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron noemt Grote Berichten in de onderbouwing van TLS-gebruik, maar bevat geen versienummer voor die standaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over de Grote Berichten koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De bron bevat geen informatie over de Grote Berichten koppelvlakstandaard of versienummer v3.8.1.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
+  - *De brontekst bevat geen informatie over de Grote Berichten koppelvlakstandaard of versienummers.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
+  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Koppelvlakstandaard-GB wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
+  - *De brontekst bevat geen informatie over versienummers van de Grote Berichten koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
+  - *Grote Berichten wordt als voorbeeld aangehaald ('Grote Berichten Push variant'), maar geen versienummer voor de koppelvlakstandaard wordt vermeld.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (22)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-dk-0001` — SKILL.md:25 *(§ Digikoppeling)*
+
+> Digikoppeling is opgenomen op de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling algemeen
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  > Digikoppeling is opgenomen op de pas toe of leg uit lijst van het Forum Standaardisatie.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > De Digikoppeling standaard is opgenomen in de lijst met 'pas toe of leg uit'-standaarden van het College Standaardisatie. Het betreft de koppelvlakstandaarden ebMS2, WUS, REST API en Grote Berichten.
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *De brontekst bevat alleen een redirect-melding ('Redirecting to v2.1.1') en geen inhoudelijke tekst over de pas-toe-of-leg-uit-lijst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De brontekst bevat alleen een redirect-melding ('Redirecting to v4.0.0') en geen inhoudelijke tekst over de Forum Standaardisatie-lijst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst (ebMS2 koppelvlakstandaard) bevat geen vermelding van de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *De brontekst bevat alleen een redirect-melding ('Redirecting to v3.8.1'). Er is geen inhoudelijke tekst beschikbaar om deze claim te verifiëren.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron behandelt de koppelvlakstandaard Grote Berichten; de 'pas toe of leg uit'-lijst van Forum Standaardisatie wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *De brontekst bevat alleen een redirect-melding ('Redirecting to v3.0.0') en geen inhoudelijke tekst over het Forum Standaardisatie of de pas-toe-of-leg-uit-lijst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v2.2.2') en geen inhoudelijke informatie over het OIN-stelsel of Digikoppeling algemeen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *De bron behandelt certificaten en PKIoverheid binnen Digikoppeling. De 'pas toe of leg uit'-lijst van het Forum Standaardisatie wordt nergens genoemd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *De bron behandelt adressering en routering met OIN; geen vermelding van de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt de 'pas toe of leg uit'-lijst van het Forum Standaardisatie niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *De brontekst behandelt de Best Practices WUS en bevat geen informatie over de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *De bron vermeldt niets over de 'pas toe of leg uit'-lijst van het Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v1.13.0'). Er is geen inhoudelijke tekst beschikbaar om de claim te verifiëren.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v2026-2027') en geen inhoudelijke informatie over Digikoppeling of de pas-toe-of-leg-uit-lijst.*
+</details>
+
+### `ls-dk-0005` — SKILL.md:43 *(§ Repositories)*
+
+> Digikoppeling-Koppelvlakstandaard-WUS is vastgesteld als v3.8.1.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling WUS koppelvlakstandaard
+
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
+  > Releases 4 — 3.8.1 Latest Apr 11, 2022 + 3 releases
+  - *De bron toont expliciet dat release 3.8.1 de 'Latest' release is van de Digikoppeling-Koppelvlakstandaard-WUS repository.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
+  > 11/04/2022 3.8.1 Logius Vermelding REST-API koppelvlak
+  - *De documentbeheer-tabel vermeldt versie 3.8.1 als de meest recente gepubliceerde versie. Echter is de huidige brontekst een werkversie (werkversie 20 april 2026) die nog niet vastgesteld is: 'Dit is een werkversie die op elk moment kan worden gewijzigd, verwijderd of vervangen door andere documenten. Het is geen door het TO goedgekeurde consultatieversie.' De claim dat v3.8.1 'vastgesteld' is wordt impliciet ondersteund door de documentbeheer-tabel, maar de bron zelf is een latere werkversie, niet de vastgestelde versie.*
+<details><summary>25x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst gaat over ebMS2, niet over de WUS koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Versie-informatie over de WUS koppelvlakstandaard staat niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Geen versienummer voor WUS koppelvlakstandaard vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt de WUS koppelvlakstandaard als bestaand document maar noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft de REST-API repository; er is geen informatie over de WUS koppelvlakstandaard of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron behandelt de REST-API koppelvlakstandaard, niet WUS. Geen versie-informatie over WUS aanwezig.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over de WUS koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst gaat uitsluitend over de ebMS2 koppelvlakstandaard. De WUS koppelvlakstandaard en versienummer v3.8.1 worden niet genoemd.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over de WUS koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron vermeldt geen versienummer van de WUS koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over de WUS koppelvlakstandaard of diens versienummer.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron verwijst niet naar de WUS koppelvlakstandaard en noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De brontekst gaat over Digikoppeling-Identificatie-en-Authenticatie, niet over de WUS koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De bron bevat geen informatie over de WUS koppelvlakstandaard of versienummer v3.8.1.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
+  - *De brontekst bevat geen informatie over de WUS koppelvlakstandaard of versienummers.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
+  - *De bron gaat over het OIN-Stelsel. De Digikoppeling-Koppelvlakstandaard-WUS wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
+  - *De brontekst bevat geen informatie over versienummers van de WUS koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
+  - *WUS wordt meerdere keren genoemd als onderliggende standaard, maar geen versienummer voor de Digikoppeling-Koppelvlakstandaard-WUS wordt vermeld.*
+</details>
+
+### `ls-dk-0008` — SKILL.md:46 *(§ Repositories)*
+
+> Digikoppeling-Identificatie-en-Authenticatie is vastgesteld als v1.5.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling identificatie en authenticatie
+
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie](https://logius-standaarden.github.io/Digikoppeling-Identificatie-en-Authenticatie)
+  > Digikoppeling Identificatie en Authenticatie 1.5.0 Logius Standaard Vastgestelde versie 15 mei 2025
+<details><summary>26x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *Digikoppeling-Identificatie-en-Authenticatie en versienummer v1.5.0 worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Versie-informatie over Digikoppeling-Identificatie-en-Authenticatie staat niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Geen versienummer voor Identificatie-en-Authenticatie vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Architectuur](https://github.com/logius-standaarden/Digikoppeling-Architectuur)
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Architectuur](https://logius-standaarden.github.io/Digikoppeling-Architectuur)
+  - *De bron vermeldt Digikoppeling Identificatie en Authenticatie als bestaand document maar noemt geen versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron betreft de REST-API repository; er is geen informatie over Digikoppeling-Identificatie-en-Authenticatie of versienummers daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-REST-API)
+  - *De bron verwijst naar Digikoppeling Identificatie en Authenticatie als referentie [DK-IDAuth] maar noemt geen versienummer v1.5.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *De brontekst betreft uitsluitend de ebMS2 repository. Er is geen informatie over Digikoppeling-Identificatie-en-Authenticatie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-ebMS2)
+  - *Digikoppeling-Identificatie-en-Authenticatie en versienummer v1.5.0 worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst gaat over de WUS koppelvlakstandaard repository. Geen informatie over Digikoppeling-Identificatie-en-Authenticatie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-WUS)
+  - *De brontekst bevat geen informatie over het document Digikoppeling-Identificatie-en-Authenticatie of een versienummer daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB](https://github.com/logius-standaarden/Digikoppeling-Koppelvlakstandaard-GB)
+  - *De bron gaat over Digikoppeling-Koppelvlakstandaard-GB (Grote Berichten), niet over Digikoppeling-Identificatie-en-Authenticatie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB](https://logius-standaarden.github.io/Digikoppeling-Koppelvlakstandaard-GB)
+  - *Digikoppeling-Identificatie-en-Authenticatie wordt niet vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://github.com/logius-standaarden/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron gaat over de beveiligingsstandaarden repository. Geen informatie over Digikoppeling-Identificatie-en-Authenticatie of diens versienummer.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften](https://logius-standaarden.github.io/Digikoppeling-Beveiligingsstandaarden-en-voorschriften)
+  - *De bron verwijst naar Digikoppeling Identificatie en Authenticatie als informatieve referentie (DK-IDAuth), maar noemt geen versienummer.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie](https://github.com/logius-standaarden/Digikoppeling-Identificatie-en-Authenticatie)
+  - *De brontekst betreft inderdaad de GitHub-repo van Digikoppeling-Identificatie-en-Authenticatie, maar bevat geen versienummer (v1.5.0). De README vermeldt alleen werkversie- en publicatielinks, geen vastgesteld versienummer.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIN-Stelsel](https://github.com/logius-standaarden/OIN-Stelsel)
+  - *De brontekst bevat geen informatie over Digikoppeling-Identificatie-en-Authenticatie of versienummers.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIN-Stelsel](https://logius-standaarden.github.io/OIN-Stelsel)
+  - *De bron gaat over het OIN-Stelsel. Digikoppeling-Identificatie-en-Authenticatie als apart document met versienummer wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Digikoppeling-Beheermodel](https://github.com/logius-standaarden/Digikoppeling-Beheermodel)
+  - *De brontekst bevat geen informatie over versienummers van Digikoppeling-Identificatie-en-Authenticatie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Digikoppeling-Beheermodel](https://logius-standaarden.github.io/Digikoppeling-Beheermodel)
+  - *Digikoppeling-Identificatie-en-Authenticatie wordt niet als document genoemd in deze bron; geen versienummer beschikbaar.*
+</details>
+
+### `ls-dk-0010` — SKILL.md:68 *(§ Profielkeuze)*
+
+> Berichten groter dan 20 MiB moeten via het Grote Berichten koppelvlak worden uitgewisseld.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling Grote Berichten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > VW001 Als partijen niet tot overeenstemming komen MOETEN zij berichten groter dan 20 MiB via het Koppelvlak Grote Berichten afhandelen.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Berichten (Bevragingen of Meldingen) die een grootte hebben van meer dan 20 MiB kunnen op een andere wijze worden uitgewisseld. Hiervoor gelden specifieke afspraken.
+  - *De bron zegt 'kunnen op een andere wijze worden uitgewisseld', niet dat dit verplicht (MUST) is. De claim stelt 'moeten', maar de bron formuleert het als mogelijkheid, niet als verplichting.*
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De brontekst gaat over ebMS2 en vermeldt geen drempelwaarde van 20 MiB voor Grote Berichten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron vermeldt Grote Berichten als onderdeel van Digikoppeling maar specificeert geen grenswaarde van 20 MiB.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *De bron gaat over certificaten en PKIoverheid. Grote Berichten en drempelwaarden worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *De bron gaat niet over Grote Berichten of een drempelwaarde van 20 MiB.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron gaat over ebMS2 best practices; het Grote Berichten koppelvlak en de 20 MiB drempelwaarde worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *De brontekst gaat over WUS Best Practices en bevat geen informatie over Grote Berichten of de 20 MiB drempelwaarde.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *De bron noemt geen drempelwaarde van 20 MiB. Er wordt wel gesproken over grote berichten die niet efficiënt door adapters verwerkt kunnen worden, maar zonder specifieke grenswaarde.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0014` — SKILL.md:96 *(§ Profielkenmerken Matrix)*
+
+> Het profiel osb-rm biedt reliable, asynchrone berichtuitwisseling met signing mogelijk via osb-rm-S.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Reliable Messaging: asynchrone uitwisseling met ontvangst bevestigingen en duplicaateliminatie door de ontvangende message handler. [...] Best Effort – Signed 1 osb-be-s [...] Reliable – Signed 1 osb-rm-s
+  - *De bron bevestigt dat osb-rm asynchroon is met reliable messaging (ontvangstbevestigingen) en dat een signed variant osb-rm-s bestaat.*
+<details><summary>16x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Het osb-rm profiel van ebMS2 wordt niet behandeld in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Het osb-rm profiel wordt niet beschreven in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Het osb-rm profiel en reliable/asynchrone berichtuitwisseling worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Het profiel osb-rm wordt niet besproken in deze bron.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt wel ebMS2 reliable messaging in algemene zin, maar noemt het profiel 'osb-rm' of 'osb-rm-S' niet expliciet als profielnaam.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *ebMS2 osb-rm profiel wordt niet behandeld in deze WUS Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *Het osb-rm profiel en bijbehorende kenmerken worden niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *Het specifieke profiel 'osb-rm' wordt niet bij naam genoemd in de bron. De bron beschrijft ebMS2 en reliable messaging in algemene termen maar noemt geen specifieke profielnamen zoals osb-rm of osb-rm-S.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0017` — SKILL.md:364 *(§ Retry Strategie (ebMS2 Reliable Messaging))*
+
+> Bij het profiel osb-rm geldt duplicate-eliminatie: ontvanger herkent duplicaten op basis van MessageId.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling ebMS2 osb-rm reliable messaging
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Duplicate Elimination is required [...] The ToParty MSH must also filter any duplicate messages based on ebXML MessageId.
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > tns:duplicateElimination = "always"
+  - *De bron toont dat duplicateElimination op 'always' staat in de MessagingCharacteristics. Dit ondersteunt de claim dat duplicate-eliminatie op MessageId van toepassing is, hoewel het mechanisme (MessageId) niet expliciet wordt benoemd.*
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Duplicate-eliminatie op basis van MessageId bij osb-rm wordt niet behandeld in deze Grote Berichten spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Duplicate-eliminatie en MessageId worden niet besproken in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Duplicate-eliminatie en osb-rm reliable messaging worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Duplicate-eliminatie en MessageId worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *ebMS2 osb-rm en duplicate-eliminatie worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *Duplicate-eliminatie op basis van MessageId bij osb-rm wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *Het profiel 'osb-rm' en duplicate-eliminatie op basis van MessageId worden niet specifiek behandeld in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0019` — reference.md:7 *(§ Architectuur)*
+
+> De Digikoppeling-architectuur is gebaseerd op een drielagenmodel dat inhoud, logistiek en transport van elkaar scheidt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling architectuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > De uitwisseling tussen partijen wordt in drie lagen opgedeeld: Inhoud [...] Logistiek [...] Transport [...] Digikoppeling richt zich dus uitsluitend op de logistieke laag.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > De uitwisseling tussen partijen wordt in drie lagen opgedeeld: Inhoud [...] Logistiek [...] Transport [...] Digikoppeling richt zich dus uitsluitend op de logistieke laag.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  > Digikoppeling vormt de logistieke laag voor standaardisatie van communicatie tussen systemen bij overheidsorganisatie op basis van webservice standaarden. Digikoppeling is daardoor een laag die zich bevindt tussen het transportnetwerk (b.v. Diginetwerk of Internet) en de applicatielaag (functionele berichtinhoud).
+  - *De bron bevestigt de scheiding tussen transport, logistiek (Digikoppeling) en applicatielaag (inhoud), maar beschrijft dit niet expliciet als een 'drielagenmodel' met die terminologie.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > De uitwisseling tussen partijen is in drie lagen opgedeeld: Inhoud (gegevens) [...] Logistiek (processen) [...] Transport (techniek): deze laag verzorgt het daadwerkelijke transport van het bericht (TCP/IP). Digikoppeling richt zich uitsluitend op de logistieke laag.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  > De uitwisseling tussen service providers en - requesters is in drie lagen opgedeeld: Inhoud: deze laag bevat afspraken over de inhoud van het uit te wisselen bericht... Logistiek: op deze laag bevinden zich de afspraken betreffende transportprotocollen... Transport: deze laag verzorgt het daadwerkelijke transport van het bericht.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > De uitwisseling tussen partijen wordt in drie lagen opgedeeld: Inhoud: Op deze laag worden de afspraken gemaakt over de inhoud van het uit te wisselen bericht... Logistiek: Op deze laag bevinden zich de afspraken betreffende transportprotocollen... Transport: deze laag verzorgt het daadwerkelijke transport van het bericht.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Om digitale berichten uit te wisselen moeten organisaties op drie niveaus afspraken maken: Over de inhoud en betekenis van berichten (payload en eventuele bijlagen) [...] Over de logistiek (envelop) [...] Over het transport (netwerk)
+<details><summary>10x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Het drielagenmodel (inhoud, logistiek, transport) wordt niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Het drielagenmodel (inhoud, logistiek, transport) wordt niet besproken in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0020` — reference.md:11 *(§ Drielagenmodel)*
+
+> Digikoppeling is payload-agnostisch: het maakt niet uit of het om XML, JSON, PDF of een ander formaat gaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling architectuur inhoudlaag
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Digikoppeling gaat over logistiek, dus over de envelop en niet over de inhoud. [...] Inhoud: Op deze laag worden de afspraken gemaakt de inhoud van het uit te wisselen bericht, dus de structuur, semantiek en waardebereiken. Digikoppeling houdt zich niet met de inhoud bezig, 'heeft geen boodschap aan de boodschap'.
+  - *De bron bevestigt payload-agnosticiteit, al worden geen specifieke formaten (XML, JSON, PDF) opgesomd. De strekking is volledig ondersteund.*
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > Digikoppeling heeft geen boodschap aan de boodschap [...] Merk op dat dit ook een "groot" xml bestand kan zijn, een CAD bestand, een PDF document, een ZIP bestand, et cetera.
+  - *De bron bevestigt dat Digikoppeling payload-agnostisch is en meerdere formaten noemt. JSON wordt niet expliciet vermeld, maar het principe wordt wel onderbouwd.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > Digikoppeling houdt zich niet met de inhoud bezig, 'heeft geen boodschap aan de boodschap'.
+  - *De bron bevestigt dat Digikoppeling payload-agnostisch is, al worden specifieke formaten zoals XML, JSON of PDF niet opgesomd.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  > Digikoppeling houdt zich niet met de inhoud bezig, "heeft geen boodschap aan de boodschap".
+  - *De bron bevestigt dat Digikoppeling payload-agnostisch is, maar noemt geen specifieke formaten zoals XML, JSON of PDF. De strekking klopt, maar de claim is specifieker dan wat de bron zegt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Digikoppeling houdt zich niet met de inhoud bezig, 'heeft geen boodschap aan de boodschap'.
+  - *De bron bevestigt dat Digikoppeling payload-agnostisch is, maar noemt geen specifieke formaten zoals XML, JSON of PDF.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Digikoppeling richt zich op de 'envelop' van het bericht, niet op de inhoud. Daardoor kan iedere organisatie die Digikoppeling gebruikt, de postverzending onafhankelijk van de inhoud inrichten.
+  - *De bron bevestigt dat Digikoppeling zich richt op de envelop en niet de inhoud, wat payload-agnosticiteit impliceert. Specifieke bestandsformaten (XML, JSON, PDF) worden niet benoemd.*
+<details><summary>11x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Payload-agnosticiteit (XML, JSON, PDF, etc.) wordt niet besproken in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Payload-agnosticiteit (XML, JSON, PDF) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Payload-agnosticiteit (XML, JSON, PDF) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0021` — reference.md:15 *(§ Drielagenmodel)*
+
+> Digikoppeling schrijft het gebruik van HTTPS (TLS) voor als transportprotocol.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling transportlaag
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > HTTPS is the required transport protocol. [...] Voor alle profielen wordt twee-zijdig TLS gebruikt op transport niveau (HTTPS).
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS. [...] GB012 PUSH / PULL Het HTTPS transport MOET over poort 443 plaatsvinden.
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  > Een groot aantal ICT leveranciers biedt ondersteuning aan de voor Digikoppeling benodigde open standaarden (WUS, ebMS, HTTPS) in hun producten en dienstverlening.
+  - *HTTPS wordt als basisstandaard genoemd, maar de bron schrijft het niet expliciet voor als verplicht transportprotocol met een MUST-verplichting.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Digikoppeling schrijft voor dat het transport kanaal (internet of diginetwerk) wordt beveiligd via tweezijdig TLS.
+  - *De bron bevestigt dat TLS verplicht is voor het transportkanaal, maar noemt HTTPS niet expliciet. Tweezijdig TLS wordt bevestigd, wat consistent is met de claim.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Voor de authenticatie van de zender en de ontvanger in het berichtenverkeer tussen overheidspartijen worden PKIo-certificaten gebruikt. Het PKIo-certificaat wordt zowel gebruikt om het transport van de berichten veilig te laten verlopen (gebruikmakend van het TLS-protocol) als voor authenticatie.
+  - *De bron bevestigt dat TLS wordt gebruikt voor transport, maar schrijft HTTPS niet expliciet voor als verplichting (MUST). De claim is specifieker dan wat de bron stelt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > tns:TransportProtocol tns:version = "1.1" > HTTP [...] tns:TransportSecurityProtocol tns:version = "1.0" > TLS
+  - *De bron bevestigt HTTP met TLS als transportprotocol voor ebMS2, maar spreekt niet van een algemeen voorschrift voor HTTPS/TLS over alle Digikoppeling koppelvlakken. Het betreft hier de ebMS2 context specifiek.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  > Logistiek: op deze laag bevinden zich de afspraken betreffende transportprotocollen (HTTP), messaging (SOAP), adressering, beveiliging (authenticatie en encryptie) en betrouwbaarheid.
+  - *De bron noemt HTTP als transportprotocol maar niet expliciet HTTPS of TLS als verplichting in deze passage. TLS wordt elders in de bron impliciet aangeduid (bij foutcodes: 'protocolfouten, hebben betrekking op TLS of HTTP fouten') maar niet als expliciete must.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Logistiek: Op deze laag bevinden zich de afspraken betreffende transportprotocollen (HTTP), messaging (SOAP/REST), beveiliging (authenticatie en encryptie) en betrouwbaarheid.
+  - *De bron noemt HTTP als transportprotocol en TLS als vereiste bij Grote Berichten, maar schrijft HTTPS niet expliciet voor als algemeen verplicht transportprotocol voor alle Digikoppeling-varianten.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Voor ophalen van het grote bestand maakt de standaard gebruik van HTTPS-downloads. [...] transportprotocollen (HTTP)
+  - *De bron noemt HTTP als transportprotocol en HTTPS voor grote berichten, maar schrijft dit niet expliciet voor als MUST-vereiste voor alle koppelvlakken. TLS/HTTPS wordt impliciet vereist via beveiliging maar niet als expliciete MUST geformuleerd in dit document.*
+<details><summary>8x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0029` — reference.md:70 *(§ ebMS2)*
+
+> ebMS2 service contract is een CPA (Collaboration Protocol Agreement): een XML-document dat door beide partijen wordt overeengekomen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 koppelvlakstandaard
+
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Een deployment specificatie is niet hetzelfde als een ebXML samenwerkingsprotocol overeenkomst (ook wel aangeduid met een "Collaboration Protocol Profile and Agreement) [ISO 15000-1]. Wel hebben sommige onderdelen van een deployment specificatie gevolgen voor de specifieke invulling van CPA-elementen.
+  - *De bron bevestigt dat een CPA (Collaboration Protocol Agreement) gebruikt wordt en dat beide partijen dit overeenkomen, maar beschrijft het indirect via meerdere verwijzingen naar CPA-elementen en het CPA-register. De definitie als 'XML-document dat door beide partijen wordt overeengekomen' is impliciet aanwezig maar niet letterlijk zo geformuleerd.*
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Bij Digikoppeling op basis van ebMS2 worden certificaten echter ook opgenomen in de CPA's die organisaties uitwisselen.
+  - *De bron bevestigt het bestaan van CPA's als uitgewisseld document bij ebMS2, maar omschrijft de CPA niet volledig als 'XML-document dat door beide partijen wordt overeengekomen'. De kernstelling dat ebMS2 CPA's gebruikt die partijen uitwisselen is ondersteund.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > ebMS: OIN van zender en ontvanger worden vastgelegd als PartyId in het CPA (berichtencontract). De ebMS-berichtenheader wordt gegenereerd op basis van de CPA.
+  - *De bron bevestigt dat CPA een berichtencontract is en dat ebMS gebruik maakt van CPA. De claim dat het een 'XML-document dat door beide partijen wordt overeengekomen' is wordt niet expliciet bevestigd, maar de term 'berichtencontract' impliceert dit deels.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > Een CPA is een formeel xml document om de gebruikte functionele en technische eigenschappen van de ebMS2 protocol-karakteristieken vast te leggen. Het is dus een formele beschrijving voor het vastleggen van de gegevensuitwisseling.
+  - *De bron bevestigt dat een CPA een XML-document is dat door beide partijen wordt overeengekomen voor de ebMS2 gegevensuitwisseling.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Een CPA is een formeel xml-document om de gebruikte functionele en technische eigenschappen van de ebMS2 protocol-karakteristieken vast te leggen. [...] Een CPA moet worden gecreëerd als twee partijen afspreken om van elkaars ebMS2 services gebruik te maken. Beide partijen moeten de CPA importeren
+<details><summary>11x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet ebMS2. CPA wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron vermeldt het CPA-register wel als hulpmiddel, maar beschrijft niet dat het ebMS2 service contract een CPA is of wat de inhoud daarvan is.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *ebMS2 CPA (Collaboration Protocol Agreement) wordt niet behandeld in deze WUS Best Practices bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *CPA (Collaboration Protocol Agreement) als service contract voor ebMS2 wordt niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0031` — reference.md:74 *(§ ebMS2)*
+
+> ebMS2 profiel osb-rm garandeert once-and-only-once (exactly-once) delivery, duplicate-eliminatie en Message Acknowledgements.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling ebMS2 osb-rm profiel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Reliable Messaging Required in this profile. Reliable Messaging profile 2, Once-And-Only-Once Reliable Messaging at the End-To-End level only based upon end-to-end retransmission. In this profile the FromParty MSH (message origination) must request, and the ToParty MSH (message final destination) must send an acknowledgment message. The ToParty MSH must also filter any duplicate messages based ...
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > tns:duplicateElimination = "always" [...] tns:ackRequested = "always"
+  - *De bron bevestigt duplicate-eliminatie en acknowledgements. 'Once-and-only-once' wordt niet met die term benoemd; het osb-rm profielnaam wordt niet als zodanig vermeld.*
+<details><summary>14x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron beschrijft de Grote Berichten koppelvlakstandaard, niet het ebMS2 osb-rm profiel. Once-and-only-once delivery en Message Acknowledgements worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Het ebMS2 osb-rm profiel en eigenschappen als once-and-only-once delivery worden niet beschreven in het beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Once-and-only-once delivery, duplicate-eliminatie en Message Acknowledgements voor osb-rm worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Once-and-only-once delivery en Message Acknowledgements worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *ebMS2 osb-rm profiel en once-and-only-once delivery worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *Once-and-only-once delivery en Message Acknowledgements bij osb-rm worden niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *Het specifieke profiel 'osb-rm' en termen als 'once-and-only-once' of 'exactly-once delivery' worden niet in de bron gebruikt. De bron beschrijft reliable messaging in algemene termen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0032` — reference.md:92 *(§ Grote Berichten)*
+
+> Grote Berichten hanteert een drempelwaarde: berichten groter dan 20 MiB moeten via Grote Berichten worden uitgewisseld.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling Grote Berichten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > VW001 Als partijen niet tot overeenstemming komen MOETEN zij berichten groter dan 20 MiB via het Koppelvlak Grote Berichten afhandelen.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Berichten (Bevragingen of Meldingen) die een grootte hebben van meer dan 20 MiB kunnen op een andere wijze worden uitgewisseld. Hiervoor gelden specifieke afspraken.
+  - *De drempelwaarde van 20 MiB wordt bevestigd. De claim stelt 'moeten' (MUST), maar de bron formuleert dit als 'kunnen', niet als harde verplichting.*
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *De bron behandelt de ebMS2 koppelvlakstandaard en vermeldt nergens een drempelwaarde van 20 MiB voor Grote Berichten. Grote Berichten is een apart Digikoppeling-onderdeel dat niet in deze spec beschreven wordt.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De drempelwaarde van 20 MiB voor Grote Berichten wordt niet genoemd in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *De 20 MiB drempelwaarde voor Grote Berichten wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Grote Berichten en de 20 MiB drempelwaarde worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt het Grote Berichten koppelvlak en de 20 MiB drempelwaarde niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Grote Berichten en de 20 MiB drempelwaarde worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *Een drempelwaarde van 20 MiB wordt niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0033` — reference.md:90 *(§ Grote Berichten)*
+
+> Grote Berichten gebruikt het claim-check patroon: het grote bestand wordt buiten de reguliere berichtenuitwisseling overgedragen, terwijl een referentie via het normale kanaal wordt verstuurd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling Grote Berichten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > De verzender stelt metadata samen over het grote bestand en deelt deze metadata in een Digikoppeling-bericht [in een zgn. stuurbericht]. Uitwisseling van het grote bestand vindt plaats via een PULL of een PUSH principe.
+  - *Het claim-check patroon wordt beschreven: het grote bestand wordt buiten de reguliere berichtenuitwisseling overgedragen, terwijl een referentie (stuurbericht met metadata) via het normale kanaal wordt verstuurd.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > De verzender stelt metadata samen over het grote bestand en deelt deze metadata in een Digikoppeling-bericht [in een zgn. stuurbericht]. Uitwisseling van het grote bestand vindt plaats via een PULL of een PUSH principe.
+  - *De bron beschrijft het claim-check patroon in andere bewoordingen: het grote bestand wordt buiten de reguliere berichtenstroom overgedragen terwijl een stuurbericht met metadata via het normale kanaal wordt verstuurd.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Het principe dat Digikoppeling grote berichten toepast is het 'claim-check' principe. Dit betekent dat het bericht zelf (WUS of ebMS2) alleen een referentie (claim-check) naar het grote bestand bevat. Deze referentie wordt vervolgens gebruikt om het bestand zelf op te halen.
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *Het claim-check patroon voor Grote Berichten wordt niet besproken in deze ebMS2 koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Het claim-check patroon voor Grote Berichten wordt niet beschreven in het beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Het claim-check patroon voor Grote Berichten wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Het claim-check patroon voor Grote Berichten wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt het Grote Berichten koppelvlak en het claim-check patroon niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Grote Berichten en het claim-check patroon worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0035` — reference.md:115 *(§ Grote Berichten)*
+
+> Grote Berichten is altijd een aanvulling op een ander koppelvlak (REST-API, WUS of ebMS2); het reguliere bericht met de claim-check wordt via een van deze protocollen verstuurd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling Grote Berichten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > VW002 Voor de overdracht van metadata MOET gebruik gemaakt worden van Digikoppeling, zoals aangeven in het hoofdstuk Metadata in dit document. [...] De metadata zelf wordt verzonden via een (WUS/ebMS/API) Digikoppeling Koppelvlak
+  - *De bron bevestigt expliciet dat Grote Berichten altijd gecombineerd wordt met een ander koppelvlak (WUS, ebMS of API).*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > De metadata zelf wordt verzonden via het REST-API, ebMS of WUS Koppelvlak... Voorafgaand aan deze actie dient altijd een meta-bericht verstuurd te worden door de verzender. Dit kan met behulp van het REST-API, WUS of ebMS profiel.
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Met WUS of ebMS2 wordt een referentie (link) verstuurd, De referentie wordt gebruikt om een groot bestand te downloaden. [...] De Digikoppeling Koppelvlakstandaard Grote Berichten (KVS GB) maakt gebruik van WUS en ebMS2 voor het verzenden van metadata.
+  - *De bron bevestigt dat Grote Berichten een aanvulling is op WUS of ebMS2. REST-API wordt hier niet expliciet als derde optie genoemd — de bron noemt alleen WUS en ebMS2 in deze context.*
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze ebMS2 koppelvlakstandaard.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron beschrijft niet dat Grote Berichten altijd een aanvulling is op een ander koppelvlak.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *De bron behandelt het Grote Berichten koppelvlak niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Grote Berichten als aanvulling op andere koppelvlakken wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0037` — reference.md:124 *(§ TLS-vereisten)*
+
+> TLS is verplicht voor alle Digikoppeling-communicatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiliging TLS
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Voor alle profielen gelden de volgende eigenschappen: Vertrouwelijkheid en authenticatie van zender en ontvanger wordt als volgt gerealiseerd: Voor Point-to-Point Security, door middel van twee-zijdig TLS op transport-niveau (in het HTTP kanaal). (De toepassing ervan wordt dus ook verplicht verklaard bij gebruik van security op berichtniveau.)
+  - *De bron stelt expliciet dat twee-zijdig TLS verplicht is voor alle profielen. De profieltabel bevestigt ook: 'Voor alle profielen wordt twee-zijdig TLS gebruikt op transport niveau (HTTPS)'.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB006 PUSH / PULL Het HTTP transport MOET beveiligd zijn met TLS.
+  - *De bron bevestigt TLS-verplichting voor bestandsoverdracht bij Grote Berichten. De bron beperkt zich tot de Grote Berichten context.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Digikoppeling schrijft voor dat het transport kanaal (internet of diginetwerk) wordt beveiligd via tweezijdig TLS.
+  - *De bron bevestigt dat TLS verplicht is voor het transportkanaal, maar specificeert niet expliciet dat dit voor 'alle' Digikoppeling-communicatie geldt zonder uitzondering. De claim zegt 'alle', de bron spreekt over het transportkanaal in het algemeen.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Het PKIo-certificaat wordt zowel gebruikt om het transport van de berichten veilig te laten verlopen (gebruikmakend van het TLS-protocol) als voor authenticatie. Bij het gebruik van Digikoppeling wordt tweezijdige authenticatie vereist.
+  - *De bron bevestigt TLS-gebruik voor berichttransport en dat tweezijdige authenticatie vereist is, maar stelt TLS niet expliciet als verplicht voor álle Digikoppeling-communicatie in de zin van een normerende uitspraak.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > TransportProtocol over HTTP met TLS met server certificaat [...] Client Authentication over HTTP met client certificaat. Dit is verplicht.
+  - *De bron bevestigt TLS als verplicht transportprotocol voor ebMS2, maar doet geen uitspraak over alle Digikoppeling-communicatie in het algemeen. De claim is breder dan wat de bron afdekt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Alleen verbindingen waarbij zowel de client als de server over een geldig certificaat beschikken zijn toegestaan (TLS).
+  - *De bron bevestigt TLS-verplichting in de context van Grote Berichten, maar dit is een Best Practices document en geen normatieve koppelvlakstandaard. De claim stelt dat TLS verplicht is voor 'alle Digikoppeling-communicatie', wat breder is dan wat deze bron dekt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Digikoppeling schrijft het gebruik van PKIoverheidcertificaten met een OIN voor om de identiteit van een website of server te controleren (authenticatie). Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen.
+  - *De bron vermeldt beveiligde verbindingen en PKIoverheid-certificaten, maar specificeert TLS niet expliciet als verplicht protocol voor alle communicatie. HTTPS-downloads worden wel genoemd voor Grote Berichten.*
+<details><summary>10x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron bevat geen normatieve vereisten over TLS voor Digikoppeling-communicatie.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *TLS wordt in de bron wel impliciet aangeduid (bij foutcategorieën) maar niet als expliciete verplichting voor alle Digikoppeling-communicatie geformuleerd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0040` — reference.md:130 *(§ TLS-vereisten)*
+
+> TLS003: Mutual TLS (mTLS) is verplicht: zowel client als server moeten zich authenticeren met een PKIoverheid-certificaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS003
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Client and Server authentication is required using HTTPS and TLS. [...] Client-side authentication is required.
+  - *De bron bevestigt mutual TLS (zowel client als server authenticatie) en PKIoverheid-certificaten. De eis staat in secties 5.2.3 en 5.11.4.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB008 PUSH / PULL Zowel de client als de server organisatie MOET zich authentiseren met een PKIoverheid certificaat [PKI CA], [PKIoverheid Certificaten]. De basis voor authenticatie en autorisatie in Digikoppeling is OIN. [...] (2-zijdig TLS).
+  - *De bron bevestigt mutual TLS met PKIoverheid-certificaten.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Digikoppeling schrijft voor dat het transport kanaal (internet of diginetwerk) wordt beveiligd via tweezijdig TLS. Beide partijen wisselen hun publieke sleutels uit en zetten hiermee een tweezijdig versleutelde TLS verbinding op.
+  - *De bron bevestigt tweezijdig TLS (mTLS) en het gebruik van PKIoverheid-certificaten, maar vermeldt niet expliciet dat dit als 'verplicht' (MUST) is vastgelegd in een genummerde standaard TLS003.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Bij het gebruik van Digikoppeling wordt tweezijdige authenticatie vereist. Zender en ontvanger moeten elkaars certificaat vertrouwen en elkaars publieke TLS-sleutel kennen.
+  - *De bron bevestigt tweezijdige authenticatie en certificaatgebruik, maar noemt PKIoverheid niet expliciet als vereiste en gebruikt niet de term 'mTLS'. De claim is specifieker dan wat de bron stelt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > Client Authentication over HTTP met client certificaat. Dit is verplicht. In het client certificaat staat in het subject.Serialnumber de PartyId van de 'client' organisatie.
+  - *De bron bevestigt dat mutual TLS (client én server certificaat) verplicht is en dat het PKIoverheid-certificaten betreft. Echter, de term 'PKIoverheid' wordt in 3.4.16 vermeld: 'Er moet gebruik gemaakt worden van certificaten die voldoen aan de eisen van de PKI Overheid.' De combinatie is aanwezig maar niet zo expliciet als de claim stelt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Alleen verbindingen waarbij zowel de client als de server over een geldig certificaat beschikken zijn toegestaan (TLS).
+  - *De bron bevestigt mutual TLS (beide partijen met certificaat), maar vermeldt 'PKIoverheid-certificaat' niet expliciet in deze zin. Elders wordt OIN-gerelateerde certificaten en PKIoverheid-hiërarchie wel vermeld, maar de specifieke term 'mTLS' of 'Mutual TLS' als verplichting staat niet letterlijk in de bron.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Digikoppeling schrijft het gebruik van PKIoverheidcertificaten met een OIN voor om de identiteit van een website of server te controleren (authenticatie). Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen.
+  - *De bron bevestigt dat beide partijen PKIoverheid-certificaten gebruiken voor authenticatie, wat mTLS impliceert. De term 'mutual TLS' of 'mTLS' wordt echter niet expliciet genoemd, en de verplichting wordt niet in die exacte terminologie gesteld.*
+<details><summary>10x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *TLS003 en mTLS-verplichting met PKIoverheid-certificaten worden niet behandeld in het beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Mutual TLS en PKIoverheid-certificaten als verplichting (TLS003) worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0043` — reference.md:133 *(§ TLS-vereisten)*
+
+> TLS006: Het OIN van de organisatie moet opgenomen zijn in het Subject.SerialNumber-veld van het PKIoverheid-certificaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling beveiligingsstandaard TLS006
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > The use of PKI Overheid certificates is required in which an OIN is used in the Subject.serialNumber.
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Voor de unieke identificatie en authenticatie van deze organisaties wordt het OIN opgenomen in een PKIoverheid certificaat in het zogenaamde Subject.serialNumber-veld door de TSP.
+  - *De bron bevestigt dat het OIN in Subject.serialNumber wordt opgenomen. De claim zegt 'Subject.SerialNumber' (hoofdletter S), de bron zegt 'Subject.serialNumber' — dit is dezelfde veldnaam. De claim is volledig ondersteund voor het OIN-veld. Echter de claim stelt dit als MUST (TLS006-standaard), terwijl de bron de verplichting wel impliceert maar niet als genummerde standaard presenteert. PARTIALLY_SUPPORTED vanwege het ontbreken van de TLS006-standaardnummering.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Een PKIo-certificaat dat gebruikt wordt voor berichtenuitwisseling met Digikoppeling bevat het OIN van de organisatie of organisatieonderdeel. Dit OIN wordt opgeslagen in het Subject.SerialNumber veld van het certificaat.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > In het client certificaat staat in het subject.Serialnumber de PartyId van de 'client' organisatie. [...] Het nummer zal ook gebruikt worden in het cliënt certificaat voor het subject.Serialnumber veld.
+  - *De bron bevestigt expliciet dat het OIN (als PartyId) in het subject.SerialNumber van het certificaat wordt opgenomen.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen.
+  - *De bron bevestigt dat het OIN in het PKIoverheid-certificaat moet worden opgenomen, maar specificeert niet het veld 'Subject.SerialNumber' expliciet.*
+<details><summary>12x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron vermeldt OIN in relatie tot certificaten en autorisatie, maar beschrijft niet specifiek dat het OIN in het Subject.SerialNumber-veld moet worden opgenomen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *TLS006 en het opnemen van het OIN in Subject.SerialNumber worden niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *OIN in Subject.SerialNumber van PKIoverheid-certificaat (TLS006) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *De bron vermeldt dat OIN in certificaten zit en gebruikt wordt, maar specificeert niet het Subject.SerialNumber-veld als de verplichte locatie voor het OIN.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0044` — reference.md:137 *(§ PKIoverheid Certificaten)*
+
+> Alle Digikoppeling-deelnemers moeten PKIoverheid-certificaten gebruiken voor authenticatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling PKIoverheid certificaten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > The use of PKI Overheid certificates is required in which an OIN is used in the Subject.serialNumber. [...] Client-side authentication is required. What client Certificate Authorities are acceptable? PKI overheid maintains a list of approved trusted service providers.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB008 PUSH / PULL Zowel de client als de server organisatie MOET zich authentiseren met een PKIoverheid certificaat [PKI CA], [PKIoverheid Certificaten].
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  > "De Digikoppeling-standaard en in het bijzonder 'Gebruik en achtergrond Digikoppeling-certificaten' sluiten aan bij de PKI.Overheid."
+  - *De bron bevestigt de relatie met PKIoverheid maar legt geen expliciete MUST-verplichting op dat alle deelnemers PKIoverheid-certificaten moeten gebruiken voor authenticatie.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Een belangrijk aspect voor beveiliging van Digikoppeling is de juiste identificatie, authenticatie en autorisatie van organisaties. Voor Digikoppeling is daarbij gekozen om certificaten toe te passen die voldoen aan de eisen van PKIoverheid.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Voor de authenticatie van de zender en de ontvanger in het berichtenverkeer tussen overheidspartijen worden PKIo-certificaten gebruikt.
+  - *De bron bevestigt gebruik van PKIo-certificaten voor authenticatie, maar stelt dit niet expliciet als MUST-verplichting voor alle Digikoppeling-deelnemers, en noemt 'PKIoverheid' niet letterlijk (alleen 'PKIo').*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > Er moet gebruik gemaakt worden van certificaten die voldoen aan de eisen van de PKI Overheid.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Ten behoeve van Digikoppeling grote berichten dient gebruik gemaakt te worden van OIN gerelateerde certificaten.
+  - *De bron spreekt van 'OIN gerelateerde certificaten' en verwijst naar 'certificaat-hierarchie (root-certificaat van Staat der Nederlanden)', wat naar PKIoverheid verwijst, maar de term 'PKIoverheid-certificaten' als expliciete verplichting staat niet letterlijk in de bron.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Digikoppeling schrijft het gebruik van PKIoverheidcertificaten met een OIN voor om de identiteit van een website of server te controleren (authenticatie). Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen.
+<details><summary>9x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *PKIoverheid-certificaten als verplichting voor alle deelnemers worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0045` — reference.md:147 *(§ OIN-identificatie)*
+
+> Het OIN wordt opgenomen in het PKIoverheid-certificaat (Subject.SerialNumber) en wordt gebruikt voor adressering en routering van berichten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling OIN-identificatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > The use of PKI Overheid certificates is required in which an OIN is used in the Subject.serialNumber. [...] Partners who are going to use ebMS for the first time must use an OIN (Organisatie Identificatie Nummer) for identification.
+  - *De bron bevestigt OIN in Subject.SerialNumber en gebruik voor identificatie. Het gebruik voor 'adressering en routering van berichten' is niet expliciet zo beschreven; de bron noemt OIN primair in de context van PartyId voor identificatie van partijen.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  > GB008 [...] De basis voor authenticatie en autorisatie in Digikoppeling is OIN. GB009 PUSH / PULL De server organisatie MOET het transport autoriseren op basis van het OIN van een valide client certificaat.
+  - *De bron bevestigt OIN in het certificaat voor authenticatie en autorisatie, maar beschrijft niet expliciet het Subject.SerialNumber-veld of het gebruik van OIN voor routering en adressering van berichten.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Voor de unieke identificatie en authenticatie van deze organisaties wordt het OIN opgenomen in een PKIoverheid certificaat in het zogenaamde Subject.serialNumber-veld door de TSP. Identificatie van organisaties vindt voor Digikoppeling plaats aan de hand van het OIN dat is opgenomen in het certificaat.
+  - *De bron bevestigt OIN in Subject.serialNumber en gebruik voor identificatie/authenticatie. De claim noemt ook 'adressering en routering van berichten'; de bron vermeldt dit aspect niet expliciet — alleen authenticatie en autorisatie worden benoemd. Daarom PARTIALLY_SUPPORTED.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Een PKIo-certificaat dat gebruikt wordt voor berichtenuitwisseling met Digikoppeling bevat het OIN van de organisatie of organisatieonderdeel. Dit OIN wordt opgeslagen in het Subject.SerialNumber veld van het certificaat. [...] Adresseren en Routeren vindt plaats op het niveau van de berichtheader. Voor het routeren kan gebruik gemaakt worden van het OIN, het opgegeven endpointadres of beide.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > Het nummer zal ook gebruikt worden in het cliënt certificaat voor het subject.Serialnumber veld. [...] De PartyId is de (logische) aanduiding waarmee de organisatie geïdentificeerd wordt.
+  - *De bron bevestigt dat OIN in Subject.SerialNumber staat en gebruikt wordt voor identificatie. Het gebruik voor 'adressering en routering' wordt niet expliciet zo benoemd in dit document.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Autorisatie kan vervolgens op basis van een OIN uit dit geldige certificaat ingericht worden.
+  - *De bron bevestigt dat OIN in certificaten zit en voor autorisatie gebruikt wordt, en ook voor adressering in URLs. Het specifieke Subject.SerialNumber-veld wordt echter niet vermeld, en 'routering van berichten' als expliciet gebruik staat niet letterlijk in de bron.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Voor het opzetten van een beveiligde verbinding tussen servers en voor de ondertekening en versleuteling van berichten moet het OIN van de organisatie in de PKIoverheidcertificaten worden opgenomen. Elke overheidsorganisatie die digitaal zaken doet kan een uniek Organisatieidentificatienummer (OIN) krijgen.
+  - *De bron bevestigt dat het OIN in het PKIoverheid-certificaat moet worden opgenomen en voor authenticatie wordt gebruikt. Adressering en routering via OIN worden impliciet vermeld (adresseringsinformatie voor routering in de ebMS2/WUS-secties), maar het specifieke veld 'Subject.SerialNumber' wordt niet expliciet benoemd.*
+<details><summary>10x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron noemt het OIN-register wel als hulpmiddel maar beschrijft niet dat het OIN in Subject.SerialNumber wordt opgenomen of wordt gebruikt voor adressering en routering.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *OIN in PKIoverheid-certificaat voor adressering en routering wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0046` — reference.md:149 *(§ OIN-identificatie)*
+
+> Het OIN-stelsel wordt beheerd door Logius.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > OIN stands for Organisatie Identificatie Nummer and is maintained by Logius in the COR (Centrale OIN Raadpleegvoorziening).
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  > "Bij de Digikoppeling horen de volgende ondersteunende hulpmiddelen en ICT voorzieningen: Digikoppeling OIN Register en het hieraan gekoppelde CPA-register" en de gehele bron is gepubliceerd door Logius als beheerder van Digikoppeling.
+  - *De bron bevestigt impliciet dat Logius het OIN-register beheert als onderdeel van de Digikoppeling-voorzieningen, maar een expliciete zin 'Het OIN-stelsel wordt beheerd door Logius' ontbreekt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > Om certificaten te kunnen bestellen, moet de organisatie een identificerend nummer hebben: het OIN. Dit nummer wordt verkregen bij de beheerorganisatie van Digikoppeling volgens de procedure die is beschreven op de website van Logius.
+  - *De bron noemt Logius als beheerorganisatie van Digikoppeling en OIN-uitgever, wat het beheer door Logius impliceert. Het OIN-stelsel als zodanig wordt niet expliciet 'beheerd door Logius' genoemd; het is een indirecte bevestiging.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  > Als de organisatie nog geen OIN heeft moet een nummer aangevraagd worden bij Logius. De COR (De Centrale OIN Raadpleegvoorziening) wordt gebruikt om informatie vast te leggen over de organisatie en het OIN.
+  - *De bron noemt Logius als de instantie waar OIN aangevraagd wordt, wat impliceert dat Logius het OIN-stelsel beheert, maar 'beheer door Logius' wordt niet expliciet zo geformuleerd.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Logius biedt ondersteuning bij aansluiten en gebruik door middel van: Verstrekken van het benodigde Organisatieidentificatienummer (OIN)
+  - *De bron stelt dat Logius OIN-nummers verstrekt, wat beheer impliceert, maar het 'OIN-stelsel' als zodanig en expliciet beheer ervan door Logius wordt niet met die terminologie benoemd.*
+<details><summary>12x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron vermeldt het OIN in de context van certificaten en autorisatie, maar zegt niets over het beheer van het OIN-stelsel door Logius.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  - *Logius als beheerder van het OIN-stelsel wordt niet vermeld in deze bron (de bron vermeldt Logius als auteur van het document, maar niet als beheerder van het OIN-stelsel).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *OIN-stelsel en beheer door Logius worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *Het OIN-stelsel en het beheer ervan door Logius wordt niet als zodanig besproken in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0047` — reference.md:150 *(§ OIN-identificatie)*
+
+> Sub-OIN's zijn mogelijk voor organisatieonderdelen of specifieke systemen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** MAY  ·  **Scope:** OIN-stelsel
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > The number is unique and allows identification of partners, even if they are not themselves legal entities, but departments or units of larger organizations.
+  - *De bron bevestigt dat OIN gebruikt kan worden voor afdelingen/onderdelen van grotere organisaties, wat de richting van sub-OINs ondersteunt. Maar de term 'sub-OIN' wordt niet gebruikt en het mechanisme van sub-OINs is niet expliciet beschreven.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  > In specifieke gevallen kan autorisatie op een gedetailleerder niveau noodzakelijk zijn. Voor overheidsorganisaties is het bijvoorbeeld mogelijk om een subOIN aan te vragen.
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Het SubOIN is een afgeleide van het OIN en is opgesteld volgens de OIN-nummersystematiek en wordt gebruikt voor een organisatieonderdeel, samenwerkingsverband of voorziening. SubOIN's kunnen worden gebruikt om fijnmazig te identificeren. (Aan een OIN kunnen meerdere SubOIN's gekoppeld worden).
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *Sub-OIN's worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *Sub-OIN's voor organisatieonderdelen of systemen worden niet beschreven in het beheermodel. De impactmatrix noemt wel OIN-nummers maar niet sub-OIN's.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *Sub-OIN's worden niet als concept vermeld. Wel wordt gesproken over deel-organisaties met eigen OIN's, maar niet over sub-OIN's specifiek.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  - *Sub-OIN's worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  - *Sub-OIN's worden niet vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  - *Sub-OIN's worden niet vermeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+### `ls-dk-0050` — reference.md:159 *(§ Berichtniveau-beveiliging)*
+
+> Berichtniveau-beveiliging is essentieel wanneer er niet-vertrouwde intermediairs in de keten zitten, omdat TLS alleen de point-to-point verbinding beveiligt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Digikoppeling berichtniveau-beveiliging
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/ebms](https://gitdocumentatie.logius.nl/publicatie/dk/ebms)
+  > Voor End-to-End Security, door middel van signing (ondertekening) en (optioneel) encryptie (versleuteling) op bericht-niveau in combinatie met (point-to-point) twee-zijdig TLS in het HTTP kanaal. [...] op basis van Reliable Messaging of Best Effort wordt een bericht beveiligd tussen de uiteindelijke Consumer en de uiteindelijke Provider, ook wanneer er zich intermediairs bevinden in het pad tus...
+  - *De bron stelt expliciet dat berichtniveau-beveiliging nodig is wanneer er intermediairs aanwezig zijn, omdat TLS alleen point-to-point werkt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpadres](https://gitdocumentatie.logius.nl/publicatie/dk/bpadres)
+  > Het versleutelen van berichtinhoud (berichtenniveau versleuteling) kan worden toegepast indien de intermediair niet vertrouwd wordt.
+  - *De bron bevestigt dat berichtniveau-encryptie relevant is bij niet-vertrouwde intermediairs, en dat TLS point-to-point is (impliciet via de uitleg over knooppunten). De claim zegt 'SHOULD' (essentieel), de bron zegt 'kan' (MAY). Gedeeltelijke ondersteuning voor de redenering, niet voor de normering.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpwus](https://gitdocumentatie.logius.nl/publicatie/dk/bpwus)
+  > Indien het bericht ondertekend en versleuteld is, hoeven gateway 1 en gateway 2 het bericht niet te valideren of ontcijferen. Zolang de addressing informatie niet veranderd wordt, is de meegestuurde 'signature' nog steeds valide.
+  - *De bron bevestigt impliciet het belang van berichtniveau-beveiliging bij intermediairs (gateways hoeven niet te ontcijferen), maar formuleert niet expliciet dat TLS alleen point-to-point beveiligt of dat berichtniveau-beveiliging 'essentieel' is bij niet-vertrouwde intermediairs als normatieve aanbeveling.*
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpgb](https://gitdocumentatie.logius.nl/publicatie/dk/bpgb)
+  > Bij transparante intermediairs vindt geen tussentijdse opslag van het grote bestand plaats bij de intermediair... Bij Niet-transparante intermediairs is in Digikoppeling-termen de intermediair te zien als een endpoint.
+  - *De bron bespreekt intermediairs en het verschil tussen transparante en niet-transparante varianten, wat de stelling over TLS als point-to-point beveiliging indirect ondersteunt. De claim over berichtniveau-beveiliging als essentieel bij niet-vertrouwde intermediairs wordt echter niet expliciet gemaakt in de bron.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/watisdk](https://gitdocumentatie.logius.nl/publicatie/dk/watisdk)
+  > Een transparante intermediair stuurt berichten door naar het eindpunt (ontvanger) zonder de berichten te bewerken. Een transparante intermediair is zelf dus geen eindpunt in Digikoppeling. Het versleutelen van berichtinhoud (berichtenniveau versleuteling) kan worden toegepast indien de intermediair niet vertrouwd wordt.
+<details><summary>11x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/architectuur](https://gitdocumentatie.logius.nl/publicatie/dk/architectuur)
+  - *Aangeleverde brontekst was leeg of onbruikbaar; alleen een redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/restapi](https://gitdocumentatie.logius.nl/publicatie/dk/restapi)
+  - *De aangeleverde brontekst is leeg/alleen een redirect-melding.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/wus](https://gitdocumentatie.logius.nl/publicatie/dk/wus)
+  - *Brontekst is enkel een redirect-melding, geen inhoudelijke documentatie beschikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gb](https://gitdocumentatie.logius.nl/publicatie/dk/gb)
+  - *De bron beschrijft de Grote Berichten koppelvlakstandaard. Berichtniveau-beveiliging in relatie tot niet-vertrouwde intermediairs wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beveilig](https://gitdocumentatie.logius.nl/publicatie/dk/beveilig)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/idauth](https://gitdocumentatie.logius.nl/publicatie/dk/idauth)
+  - *aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding ontvangen*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/oin](https://gitdocumentatie.logius.nl/publicatie/dk/oin)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/beheer](https://gitdocumentatie.logius.nl/publicatie/dk/beheer)
+  - *De bron behandelt het onderwerp van berichtniveau-beveiliging bij niet-vertrouwde intermediairs niet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert](https://gitdocumentatie.logius.nl/publicatie/dk/gbachtcert)
+  - *De bron gaat niet in op de verhouding tussen TLS (point-to-point) en berichtniveau-beveiliging bij niet-vertrouwde intermediairs. Dit onderwerp wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/bpebms](https://gitdocumentatie.logius.nl/publicatie/dk/bpebms)
+  - *Het concept van niet-vertrouwde intermediairs en de beperking van TLS tot point-to-point beveiliging als argument voor berichtniveau-beveiliging wordt niet behandeld in dit document.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/actueel](https://gitdocumentatie.logius.nl/publicatie/dk/actueel)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/dk/roadmap](https://gitdocumentatie.logius.nl/publicatie/dk/roadmap)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+</details>
+
+</details>

--- a/skills/ls-egov/audit.md
+++ b/skills/ls-egov/audit.md
@@ -1,0 +1,295 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-egov — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 3 | 8% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 0 | 0% |
+| UNGROUNDED | 1 | 3% |
+| NO_SOURCE | 31 | 86% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 1 | 3% |
+
+*Geverifieerd met sonnet, 2 calls, $0.1270.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (3)
+
+### `ls-egov-0019` — SKILL.md:115 *(§ Samenhang Standaarden)*
+
+> NLCIUS heeft de Forum Standaardisatie status 'verplicht' (pas-toe-of-leg-uit).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NLCIUS - Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
+  - *De bron gaat over Peppol BIS, niet over NLCIUS. De status van NLCIUS staat niet in deze bron. NLCIUS wordt wel genoemd als gerelateerde standaard, maar zonder statusaanduiding.*
+
+### `ls-egov-0021` — SKILL.md:107 *(§ Samenhang Standaarden)*
+
+> De Basisfactuur Rijk is gebaseerd op Peppol BIS Billing 3.0, NLCIUS (NL-specifieke invulling EN 16931) en UBL-OHNL.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisfactuur Rijk - samenhang standaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
+  - *De bron behandelt Peppol BIS als standaard in het algemeen. De Basisfactuur Rijk en de specifieke samenstelling daarvan (Peppol BIS Billing 3.0, NLCIUS, UBL-OHNL) worden niet in deze bron beschreven.*
+
+### `ls-egov-0022` — SKILL.md:111 *(§ Samenhang Standaarden)*
+
+> De Basisorder Rijk is gebaseerd op Peppol BIS Order 3.0 en UBL 2.1 Order.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisorder Rijk - samenhang standaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
+  - *De Basisorder Rijk en de specifieke grondslag daarvan worden niet in deze bron behandeld.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (1)
+
+### `ls-egov-0023` — SKILL.md:232 *(§ Foutafhandeling)*
+
+> De Terugmelden-API gebruikt application/problem+json conform RFC 9457 voor foutresponses.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Terugmelden-API - foutafhandeling
+
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
+  - *De bron is RFC 9457 (Problem Details for HTTP APIs), een generieke IETF-specificatie. De Terugmelden-API wordt nergens in deze bron genoemd. De bron beschrijft wát application/problem+json is en hoe het werkt, maar kan niet bevestigen of ontkennen dat de Terugmelden-API dit formaat gebruikt.*
+
+## NO_SOURCE — geen kandidaat-bron gevonden (31)
+
+### `ls-egov-0001` — SKILL.md:34 *(§ Versiemodel)*
+
+> De E-Government standaarden hebben momenteel alleen werkversies. Er zijn nog geen vastgestelde versies gepubliceerd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Government standaarden (Logius) versiemodel
+
+
+### `ls-egov-0002` — SKILL.md:31 *(§ Versiemodel)*
+
+> Vastgestelde versies (DEF) worden gepubliceerd op gitdocumentatie.logius.nl; werkversies (draft) worden gepubliceerd op logius-standaarden.github.io.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden publicatiekanalen
+
+
+### `ls-egov-0003` — SKILL.md:51 *(§ Terugmelden-API (in ontwikkeling))*
+
+> De Terugmelden-API is een beoogde REST API voor het indienen en opvragen van terugmeldingen; de repository bevat nog geen uitgewerkte specificatie en de API is in conceptfase.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelden-API
+
+
+### `ls-egov-0004` — SKILL.md:51 *(§ Terugmelden-API (in ontwikkeling))*
+
+> De bestaande koppelvlakspecificatie voor terugmelden is de Digimelding-Koppelvlakspecificatie (SOAP/WUS).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding / Terugmelden
+
+
+### `ls-egov-0005` — SKILL.md:59 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Facturen aan de Rijksoverheid die de verplichte velden missen worden automatisch afgewezen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk
+
+
+### `ls-egov-0006` — SKILL.md:63 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet een uniek factuurnummer bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
+
+
+### `ls-egov-0007` — SKILL.md:64 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet een factuurdatum bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
+
+
+### `ls-egov-0008` — SKILL.md:65 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet een factuurtypeaanduiding (factuur, creditnota, etc.) bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
+
+
+### `ls-egov-0009` — SKILL.md:66 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet een valutacode bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
+
+
+### `ls-egov-0010` — SKILL.md:70 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet naam en adresgegevens van de leverancier bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+
+
+### `ls-egov-0011` — SKILL.md:71 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet een KvK-nummer of vergelijkbaar identificatienummer van de leverancier bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+
+
+### `ls-egov-0012` — SKILL.md:72 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet een BTW-identificatienummer van de leverancier bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+
+
+### `ls-egov-0013` — SKILL.md:73 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet bankgegevens (IBAN en eventueel BIC) van de leverancier bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+
+
+### `ls-egov-0014` — SKILL.md:76 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet het OIN (Overheids Identificatie Nummer) of vergelijkbaar identificatienummer van de ontvangende organisatie bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Ontvanger
+
+
+### `ls-egov-0015` — SKILL.md:80 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet per regelitem een omschrijving van het geleverde product of dienst, hoeveelheid en eenheid, prijs per eenheid, totaalbedrag per regel, BTW-percentage en BTW-bedrag bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Regelitems
+
+
+### `ls-egov-0016` — SKILL.md:87 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een basisfactuur Rijk moet een ordernummer (inkoopordernummer van de overheidsorganisatie) bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Order- en referentie-informatie
+
+
+### `ls-egov-0017` — SKILL.md:97 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Bijlagen bij de basisfactuur Rijk zijn gemaximeerd op 9 bijlagen per factuur.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Basisfactuur Rijk - Bijlagen
+
+
+### `ls-egov-0018` — SKILL.md:98 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> De totale grootte van alle bijlagen bij de basisfactuur Rijk mag niet groter zijn dan 20 MB.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Basisfactuur Rijk - Bijlagen
+
+
+### `ls-egov-0024` — SKILL.md:262 *(§ Foutafhandeling)*
+
+> Bij afwijzing van een basisfactuur ontvangt de leverancier een e-mail met de specifieke ontbrekende velden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisfactuur Rijk - foutafhandeling
+
+
+### `ls-egov-0025` — SKILL.md:275 *(§ Basisfactuur Validatie (Schematron))*
+
+> Het repo basisfactuur-rijk bevat een Schematron bestand met validatieregels en voorbeeld-XML's.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisfactuur Rijk - validatie
+
+
+### `ls-egov-0026` — reference.md:23 *(§ Terugmelding & Digimelding)*
+
+> Digimelding is de centrale voorziening waarmee terugmeldingen op basisregistraties worden ingediend en afgehandeld, en fungeert als koppelpunt tussen melder en bronhouder.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding
+
+
+### `ls-egov-0027` — reference.md:29 *(§ Technische Architectuur: Annotatie-framework)*
+
+> De berichtenarchitectuur van Digimelding is gebaseerd op een annotatie-framework dat terugmeldingen structureert als hiërarchische annotaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding - technische architectuur
+
+
+### `ls-egov-0028` — reference.md:42 *(§ Technische Architectuur: Annotatie-framework)*
+
+> Elke leaf-annotatie in het Digimelding annotatie-framework refereert terug naar het UUID van de root-annotatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding - annotatie-framework
+
+
+### `ls-egov-0029` — reference.md:90 *(§ E-Procurement)*
+
+> Elektronisch factureren (e-invoicing) is verplicht voor leveranciers aan de Rijksoverheid conform EU-richtlijn 2014/55/EU.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** E-Procurement - e-invoicing
+
+
+### `ls-egov-0030` — reference.md:92 *(§ E-Procurement)*
+
+> E-Procurement gebruikt het Peppol-netwerk als transportlaag voor berichten tussen overheid en leveranciers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Procurement - infrastructuur
+
+
+### `ls-egov-0031` — reference.md:97 *(§ E-Procurement)*
+
+> E-Procurement dekt circa 90% van alle overheidsfacturen (standaard inkoop- en dienstverleningsfacturen).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Procurement - bereik
+
+
+### `ls-egov-0032` — reference.md:105 *(§ E-Procurement)*
+
+> NLCIUS is de Nederlandse invulling (Core Invoice Usage Specification) van de Europese norm EN 16931.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NLCIUS
+
+
+### `ls-egov-0033` — reference.md:77 *(§ Basisorder Rijk)*
+
+> De Basisorder Rijk is gebaseerd op UBL 2.1 Order-berichttype en sluit aan op Peppol-orderberichten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisorder Rijk
+
+
+### `ls-egov-0034` — reference.md:66 *(§ Best Practices voor Leveranciers)*
+
+> Leveranciers dienen facturen te valideren tegen het NLCIUS-validatieschema voordat deze worden ingediend.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Basisfactuur Rijk - best practices leveranciers
+
+
+### `ls-egov-0035` — reference.md:65 *(§ Best Practices voor Leveranciers)*
+
+> Facturen voor de Rijksoverheid dienen te worden aangeleverd in UBL 2.1 XML-formaat voor optimale automatische verwerking.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Basisfactuur Rijk - best practices leveranciers
+
+
+### `ls-egov-0036` — reference.md:93 *(§ E-Procurement)*
+
+> E-Procurement vereist naleving van de Europese norm EN 16931 voor elektronische facturering.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** E-Procurement - compliance
+
+
+## GROUNDED — minstens één bron ondersteunt de claim (1)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-egov-0020` — SKILL.md:115 *(§ Samenhang Standaarden)*
+
+> Peppol BIS heeft de Forum Standaardisatie status 'aanbevolen', niet verplicht.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Peppol BIS - Forum Standaardisatie
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
+  > Aanbevolen [...] Status 'Aanbevolen' betekent dat dit een gangbare of opkomende standaard is waarvan het Forum Standaardisatie het gebruik aanbeveelt.
+  - *De bron vermeldt expliciet 'Aanbevolen' als status van Peppol BIS, niet 'Verplicht (Pas toe of leg uit)'.*
+
+</details>

--- a/skills/ls-egov/audit.md
+++ b/skills/ls-egov/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-egov — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,58 +7,72 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 3 | 8% |
+| UNSUPPORTED_ASSERTION | 3 | 5% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 0 | 0% |
-| UNGROUNDED | 1 | 3% |
-| NO_SOURCE | 31 | 86% |
+| PARTIALLY_GROUNDED | 1 | 2% |
+| UNGROUNDED | 1 | 2% |
+| NO_SOURCE | 51 | 88% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 1 | 3% |
+| GROUNDED | 2 | 3% |
 
-*Geverifieerd met sonnet, 2 calls, $0.1270.*
+*Geverifieerd met sonnet, 4 calls, $0.2186.*
 
 ## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (3)
 
-### `ls-egov-0019` — SKILL.md:115 *(§ Samenhang Standaarden)*
+### `ls-egov-0023` — SKILL.md:107 *(§ Samenhang Standaarden)*
 
-> NLCIUS heeft de Forum Standaardisatie status 'verplicht' (pas-toe-of-leg-uit).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NLCIUS - Forum Standaardisatie
-
-- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
-  - *De bron gaat over Peppol BIS, niet over NLCIUS. De status van NLCIUS staat niet in deze bron. NLCIUS wordt wel genoemd als gerelateerde standaard, maar zonder statusaanduiding.*
-
-### `ls-egov-0021` — SKILL.md:107 *(§ Samenhang Standaarden)*
-
-> De Basisfactuur Rijk is gebaseerd op Peppol BIS Billing 3.0, NLCIUS (NL-specifieke invulling EN 16931) en UBL-OHNL.
+> Basisfactuur Rijk is gebaseerd op Peppol BIS Billing 3.0 en NLCIUS (NL-specifieke invulling EN 16931) en UBL-OHNL.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisfactuur Rijk - samenhang standaarden
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
-  - *De bron behandelt Peppol BIS als standaard in het algemeen. De Basisfactuur Rijk en de specifieke samenstelling daarvan (Peppol BIS Billing 3.0, NLCIUS, UBL-OHNL) worden niet in deze bron beschreven.*
+  - *De bron beschrijft Peppol BIS algemeen en noemt NLCIUS als gerelateerde standaard, maar geeft geen informatie over 'Basisfactuur Rijk' of de specifieke technische grondslag daarvan (Peppol BIS Billing 3.0, NLCIUS, UBL-OHNL).*
 
-### `ls-egov-0022` — SKILL.md:111 *(§ Samenhang Standaarden)*
+### `ls-egov-0024` — SKILL.md:111 *(§ Samenhang Standaarden)*
 
-> De Basisorder Rijk is gebaseerd op Peppol BIS Order 3.0 en UBL 2.1 Order.
+> Basisorder Rijk is gebaseerd op Peppol BIS Order 3.0 en UBL 2.1 Order.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisorder Rijk - samenhang standaarden
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
-  - *De Basisorder Rijk en de specifieke grondslag daarvan worden niet in deze bron behandeld.*
+  - *De bron bevat geen informatie over 'Basisorder Rijk' of de grondslag daarvan (Peppol BIS Order 3.0, UBL 2.1 Order).*
+
+### `ls-egov-0027` — SKILL.md:115 *(§ Samenhang Standaarden)*
+
+> De overige e-government standaarden (Digimelding, Terugmelding, e-procurement) staan niet op de lijst van Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie - e-government standaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
+  - *De bron behandelt uitsluitend Peppol BIS en geeft geen informatie over de lijststatus van Digimelding, Terugmelding of andere e-government standaarden.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De bron gaat uitsluitend over NLCIUS. Digimelding, Terugmelding en e-procurement worden niet besproken.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+
+### `ls-egov-0040` — SKILL.md:266 *(§ Foutafhandeling)*
+
+> De huidige operationele interface voor terugmelden is SOAP/WUS, beschreven in de Digimelding-Koppelvlakspecificatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding koppelvlak
+
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/logius-standaarden/Digimelding-Koppelvlakspecificatie](https://github.com/logius-standaarden/Digimelding-Koppelvlakspecificatie)
+  > Digimelding Koppelvlakspecificatie gepubliceerde versie: https://gitdocumentatie.logius.nl/publicatie/digimelding/koppelvlak/
+  - *De brontekst is uitsluitend de GitHub-repositorypagina (README/navigatie). Deze bevestigt dat er een Digimelding-Koppelvlakspecificatie bestaat en gepubliceerd is, maar de aangeleverde tekst bevat geen inhoudelijke informatie over het gebruikte protocol (SOAP/WUS). Het bestaan van de spec wordt ondersteund; de claim dat SOAP/WUS de operationele interface is, kan op basis van deze brontekst niet worden bevestigd of ontkend.*
 
 ## UNGROUNDED — geen bron ondersteunt de claim (1)
 
-### `ls-egov-0023` — SKILL.md:232 *(§ Foutafhandeling)*
+### `ls-egov-0028` — SKILL.md:232 *(§ Foutafhandeling)*
 
 > De Terugmelden-API gebruikt application/problem+json conform RFC 9457 voor foutresponses.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Terugmelden-API - foutafhandeling
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Terugmelden-API foutafhandeling
 
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc9457.txt](https://www.rfc-editor.org/rfc/rfc9457.txt)
-  - *De bron is RFC 9457 (Problem Details for HTTP APIs), een generieke IETF-specificatie. De Terugmelden-API wordt nergens in deze bron genoemd. De bron beschrijft wát application/problem+json is en hoe het werkt, maar kan niet bevestigen of ontkennen dat de Terugmelden-API dit formaat gebruikt.*
+  - *De bron is RFC 9457, die het algemene 'problem details' formaat definieert. De bron bevat geen informatie over de Terugmelden-API. De claim gaat over een specifieke Nederlandse overheids-API die RFC 9457 zou moeten gebruiken — dat valt buiten het bereik van deze specificatie.*
 
-## NO_SOURCE — geen kandidaat-bron gevonden (31)
+## NO_SOURCE — geen kandidaat-bron gevonden (51)
 
 ### `ls-egov-0001` — SKILL.md:34 *(§ Versiemodel)*
 
@@ -69,227 +83,381 @@
 
 ### `ls-egov-0002` — SKILL.md:31 *(§ Versiemodel)*
 
-> Vastgestelde versies (DEF) worden gepubliceerd op gitdocumentatie.logius.nl; werkversies (draft) worden gepubliceerd op logius-standaarden.github.io.
+> Vastgestelde versies (DEF) zijn officieel goedgekeurd en gepubliceerd op gitdocumentatie.logius.nl.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden publicatiekanalen
 
 
-### `ls-egov-0003` — SKILL.md:51 *(§ Terugmelden-API (in ontwikkeling))*
+### `ls-egov-0003` — SKILL.md:32 *(§ Versiemodel)*
 
-> De Terugmelden-API is een beoogde REST API voor het indienen en opvragen van terugmeldingen; de repository bevat nog geen uitgewerkte specificatie en de API is in conceptfase.
+> Werkversies (draft) zijn werk-in-uitvoering en gepubliceerd op logius-standaarden.github.io.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelden-API
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden publicatiekanalen
 
 
 ### `ls-egov-0004` — SKILL.md:51 *(§ Terugmelden-API (in ontwikkeling))*
 
+> De Terugmelden-API is een beoogde REST API voor het indienen en opvragen van terugmeldingen. De repository bevat nog geen uitgewerkte specificatie; de API is in conceptfase.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelden-API (in ontwikkeling)
+
+
+### `ls-egov-0005` — SKILL.md:51 *(§ Terugmelden-API (in ontwikkeling))*
+
 > De bestaande koppelvlakspecificatie voor terugmelden is de Digimelding-Koppelvlakspecificatie (SOAP/WUS).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding / Terugmelden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding koppelvlak
 
 
-### `ls-egov-0005` — SKILL.md:59 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0006` — SKILL.md:59 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Facturen aan de Rijksoverheid die de verplichte velden missen worden automatisch afgewezen.
+> De Basisfactuur Rijk definieert de minimum data-eisen waaraan facturen aan de Rijksoverheid moeten voldoen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisfactuur Rijk
+
+
+### `ls-egov-0007` — SKILL.md:59 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Facturen aan de Rijksoverheid die verplichte velden missen worden automatisch afgewezen.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk
 
 
-### `ls-egov-0006` — SKILL.md:63 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0008` — SKILL.md:62 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Een basisfactuur Rijk moet een uniek factuurnummer bevatten.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
-
-
-### `ls-egov-0007` — SKILL.md:64 *(§ Basisfactuur Rijk: Verplichte Elementen)*
-
-> Een basisfactuur Rijk moet een factuurdatum bevatten.
+> Een Basisfactuur Rijk moet een uniek factuurnummer bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
 
 
-### `ls-egov-0008` — SKILL.md:65 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0009` — SKILL.md:63 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Een basisfactuur Rijk moet een factuurtypeaanduiding (factuur, creditnota, etc.) bevatten.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
-
-
-### `ls-egov-0009` — SKILL.md:66 *(§ Basisfactuur Rijk: Verplichte Elementen)*
-
-> Een basisfactuur Rijk moet een valutacode bevatten.
+> Een Basisfactuur Rijk moet een factuurdatum bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
 
 
-### `ls-egov-0010` — SKILL.md:70 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0010` — SKILL.md:64 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Een basisfactuur Rijk moet naam en adresgegevens van de leverancier bevatten.
+> Een Basisfactuur Rijk moet een factuurtypeaanduiding (factuur, creditnota, etc.) bevatten.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
-
-
-### `ls-egov-0011` — SKILL.md:71 *(§ Basisfactuur Rijk: Verplichte Elementen)*
-
-> Een basisfactuur Rijk moet een KvK-nummer of vergelijkbaar identificatienummer van de leverancier bevatten.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
 
 
-### `ls-egov-0012` — SKILL.md:72 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0011` — SKILL.md:65 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Een basisfactuur Rijk moet een BTW-identificatienummer van de leverancier bevatten.
+> Een Basisfactuur Rijk moet een valutacode bevatten.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Factuuridentificatie
 
 
-### `ls-egov-0013` — SKILL.md:73 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0012` — SKILL.md:69 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Een basisfactuur Rijk moet bankgegevens (IBAN en eventueel BIC) van de leverancier bevatten.
+> Een Basisfactuur Rijk moet naam en adresgegevens van de leverancier bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
 
 
-### `ls-egov-0014` — SKILL.md:76 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0013` — SKILL.md:70 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Een basisfactuur Rijk moet het OIN (Overheids Identificatie Nummer) of vergelijkbaar identificatienummer van de ontvangende organisatie bevatten.
+> Een Basisfactuur Rijk moet een KvK-nummer of vergelijkbaar identificatienummer van de leverancier bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+
+
+### `ls-egov-0014` — SKILL.md:71 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een Basisfactuur Rijk moet een BTW-identificatienummer van de leverancier bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+
+
+### `ls-egov-0015` — SKILL.md:72 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een Basisfactuur Rijk moet bankgegevens van de leverancier (IBAN en eventueel BIC) bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Leverancieridentificatie
+
+
+### `ls-egov-0016` — SKILL.md:75 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een Basisfactuur Rijk moet het OIN (Overheids Identificatie Nummer) of vergelijkbaar van de ontvangende overheidsorganisatie bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Ontvanger
 
 
-### `ls-egov-0015` — SKILL.md:80 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0017` — SKILL.md:79 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Een basisfactuur Rijk moet per regelitem een omschrijving van het geleverde product of dienst, hoeveelheid en eenheid, prijs per eenheid, totaalbedrag per regel, BTW-percentage en BTW-bedrag bevatten.
+> Een Basisfactuur Rijk moet per regelitem een omschrijving van het geleverde product of de dienst bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Regelitems
 
 
-### `ls-egov-0016` — SKILL.md:87 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0018` — SKILL.md:80 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Een basisfactuur Rijk moet een ordernummer (inkoopordernummer van de overheidsorganisatie) bevatten.
+> Een Basisfactuur Rijk moet per regelitem hoeveelheid en eenheid, prijs per eenheid, totaalbedrag, BTW-percentage en BTW-bedrag bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Regelitems
+
+
+### `ls-egov-0019` — SKILL.md:86 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Een Basisfactuur Rijk moet een ordernummer (inkoopordernummer van de overheidsorganisatie) bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Order- en referentie-informatie
 
 
-### `ls-egov-0017` — SKILL.md:97 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+### `ls-egov-0020` — SKILL.md:96 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Bijlagen bij de basisfactuur Rijk zijn gemaximeerd op 9 bijlagen per factuur.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Basisfactuur Rijk - Bijlagen
-
-
-### `ls-egov-0018` — SKILL.md:98 *(§ Basisfactuur Rijk: Verplichte Elementen)*
-
-> De totale grootte van alle bijlagen bij de basisfactuur Rijk mag niet groter zijn dan 20 MB.
+> Een Basisfactuur Rijk mag maximaal 9 bijlagen bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Basisfactuur Rijk - Bijlagen
 
 
-### `ls-egov-0024` — SKILL.md:262 *(§ Foutafhandeling)*
+### `ls-egov-0021` — SKILL.md:97 *(§ Basisfactuur Rijk: Verplichte Elementen)*
 
-> Bij afwijzing van een basisfactuur ontvangt de leverancier een e-mail met de specifieke ontbrekende velden.
+> De totale grootte van alle bijlagen bij een Basisfactuur Rijk mag niet groter zijn dan 20 MB.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisfactuur Rijk - foutafhandeling
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Basisfactuur Rijk - Bijlagen
 
 
-### `ls-egov-0025` — SKILL.md:275 *(§ Basisfactuur Validatie (Schematron))*
+### `ls-egov-0022` — SKILL.md:98 *(§ Basisfactuur Rijk: Verplichte Elementen)*
+
+> Bijlagen bij de Basisfactuur Rijk moeten voldoen aan ondersteunde formaten conform Peppol-specificaties (PDF, afbeeldingen, etc.).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - Bijlagen
+
+
+### `ls-egov-0029` — SKILL.md:246 *(§ Foutafhandeling)*
+
+> HTTP 201 geeft aan dat een terugmelding succesvol is aangemaakt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelden-API HTTP statuscodes
+
+
+### `ls-egov-0030` — SKILL.md:247 *(§ Foutafhandeling)*
+
+> HTTP 400 bij de Terugmelden-API betekent dat een verplicht veld ontbreekt of een ongeldige waarde is meegegeven.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelden-API HTTP statuscodes
+
+
+### `ls-egov-0031` — SKILL.md:248 *(§ Foutafhandeling)*
+
+> HTTP 401 bij de Terugmelden-API betekent dat authenticatie vereist is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelden-API HTTP statuscodes
+
+
+### `ls-egov-0032` — SKILL.md:249 *(§ Foutafhandeling)*
+
+> HTTP 403 bij de Terugmelden-API betekent dat het OIN niet geautoriseerd is voor de betreffende registratie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelden-API HTTP statuscodes
+
+
+### `ls-egov-0033` — SKILL.md:251 *(§ Foutafhandeling)*
+
+> HTTP 422 bij de Terugmelden-API betekent een validatiefout (bijv. ongeldig BSN-formaat).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelden-API HTTP statuscodes
+
+
+### `ls-egov-0034` — SKILL.md:256 *(§ Foutafhandeling)*
+
+> Facturen worden automatisch afgewezen wanneer het ordernummer ontbreekt of onjuist is.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - afwijzingsredenen
+
+
+### `ls-egov-0035` — SKILL.md:257 *(§ Foutafhandeling)*
+
+> Facturen worden automatisch afgewezen wanneer een verplicht veld ontbreekt (KvK-nummer, BTW-ID, IBAN, of factuurdatum).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - afwijzingsredenen
+
+
+### `ls-egov-0036` — SKILL.md:258 *(§ Foutafhandeling)*
+
+> Facturen worden automatisch afgewezen wanneer de BTW-berekening inconsistent is (regeltotalen kloppen niet met factuurtotaal).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - afwijzingsredenen
+
+
+### `ls-egov-0037` — SKILL.md:259 *(§ Foutafhandeling)*
+
+> Facturen worden automatisch afgewezen wanneer bijlagen te groot zijn (maximaal 9 bijlagen, totaal max 20 MB).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - afwijzingsredenen
+
+
+### `ls-egov-0038` — SKILL.md:260 *(§ Foutafhandeling)*
+
+> Facturen worden automatisch afgewezen wanneer het UBL-formaat ongeldig is (XML voldoet niet aan NLCIUS-validatieschema).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - afwijzingsredenen
+
+
+### `ls-egov-0039` — SKILL.md:262 *(§ Foutafhandeling)*
+
+> Bij afwijzing van een factuur ontvangt de leverancier een e-mail met de specifieke ontbrekende velden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisfactuur Rijk - afwijzingsproces
+
+
+### `ls-egov-0041` — SKILL.md:275 *(§ Foutafhandeling)*
 
 > Het repo basisfactuur-rijk bevat een Schematron bestand met validatieregels en voorbeeld-XML's.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisfactuur Rijk - validatie
 
 
-### `ls-egov-0026` — reference.md:23 *(§ Terugmelding & Digimelding)*
+### `ls-egov-0042` — reference.md:11 *(§ Terugmelding & Digimelding)*
+
+> Terugmelding is een melding dat gegevens in een basisregistratie mogelijk onjuist zijn. Burgers, bedrijven en overheidsorganisaties kunnen een terugmelding indienen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Terugmelding - begrip
+
+
+### `ls-egov-0043` — reference.md:23 *(§ Terugmelding & Digimelding)*
 
 > Digimelding is de centrale voorziening waarmee terugmeldingen op basisregistraties worden ingediend en afgehandeld, en fungeert als koppelpunt tussen melder en bronhouder.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding - begrip
 
 
-### `ls-egov-0027` — reference.md:29 *(§ Technische Architectuur: Annotatie-framework)*
+### `ls-egov-0044` — reference.md:29 *(§ Technische Architectuur: Annotatie-framework)*
 
 > De berichtenarchitectuur van Digimelding is gebaseerd op een annotatie-framework dat terugmeldingen structureert als hiërarchische annotaties.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding - technische architectuur
 
 
-### `ls-egov-0028` — reference.md:42 *(§ Technische Architectuur: Annotatie-framework)*
+### `ls-egov-0045` — reference.md:41 *(§ Technische Architectuur: Annotatie-framework)*
 
-> Elke leaf-annotatie in het Digimelding annotatie-framework refereert terug naar het UUID van de root-annotatie.
+> Een root-annotatie is de initiële terugmelding aangemaakt door de melder en bevat het gegeven, de registratie en de motivatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding - annotatie-framework
-
-
-### `ls-egov-0029` — reference.md:90 *(§ E-Procurement)*
-
-> Elektronisch factureren (e-invoicing) is verplicht voor leveranciers aan de Rijksoverheid conform EU-richtlijn 2014/55/EU.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** E-Procurement - e-invoicing
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding annotatie-framework
 
 
-### `ls-egov-0030` — reference.md:92 *(§ E-Procurement)*
+### `ls-egov-0046` — reference.md:42 *(§ Technische Architectuur: Annotatie-framework)*
 
-> E-Procurement gebruikt het Peppol-netwerk als transportlaag voor berichten tussen overheid en leveranciers.
+> Leaf-annotaties zijn vervolgberichten die aan de root-annotatie worden gehangen en refereren terug naar het UUID van de root-annotatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Procurement - infrastructuur
-
-
-### `ls-egov-0031` — reference.md:97 *(§ E-Procurement)*
-
-> E-Procurement dekt circa 90% van alle overheidsfacturen (standaard inkoop- en dienstverleningsfacturen).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Procurement - bereik
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding annotatie-framework
 
 
-### `ls-egov-0032` — reference.md:105 *(§ E-Procurement)*
+### `ls-egov-0047` — reference.md:43 *(§ Technische Architectuur: Annotatie-framework)*
 
-> NLCIUS is de Nederlandse invulling (Core Invoice Usage Specification) van de Europese norm EN 16931.
+> Elke annotatie (root of leaf) bevat een annotatiebasis met metadata zoals tijdstip, auteur, en berichttype.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NLCIUS
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digimelding annotatie-framework
 
 
-### `ls-egov-0033` — reference.md:77 *(§ Basisorder Rijk)*
+### `ls-egov-0048` — reference.md:63 *(§ Best Practices voor Leveranciers)*
+
+> Voor basisfacturen aan de Rijksoverheid moet altijd het juiste inkoopordernummer worden gebruikt; een fout ordernummer leidt tot afwijzing.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - best practices leveranciers
+
+
+### `ls-egov-0049` — reference.md:65 *(§ Best Practices voor Leveranciers)*
+
+> Leveranciers dienen facturen aan de Rijksoverheid te leveren in UBL 2.1 XML-formaat voor optimale automatische verwerking.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Basisfactuur Rijk - best practices leveranciers
+
+
+### `ls-egov-0050` — reference.md:66 *(§ Best Practices voor Leveranciers)*
+
+> Leveranciers dienen de factuur te valideren tegen het NLCIUS-validatieschema voordat deze wordt ingediend.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Basisfactuur Rijk - best practices leveranciers
+
+
+### `ls-egov-0051` — reference.md:67 *(§ Best Practices voor Leveranciers)*
+
+> BTW-bedragen op een Basisfactuur moeten consistent zijn op regel- en factuurniveau.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Basisfactuur Rijk - best practices leveranciers
+
+
+### `ls-egov-0052` — reference.md:77 *(§ Basisorder Rijk)*
 
 > De Basisorder Rijk is gebaseerd op UBL 2.1 Order-berichttype en sluit aan op Peppol-orderberichten.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Basisorder Rijk
 
 
-### `ls-egov-0034` — reference.md:66 *(§ Best Practices voor Leveranciers)*
+### `ls-egov-0053` — reference.md:90 *(§ E-Procurement)*
 
-> Leveranciers dienen facturen te valideren tegen het NLCIUS-validatieschema voordat deze worden ingediend.
+> Elektronisch factureren (e-invoicing) is verplicht voor leveranciers aan de Rijksoverheid conform EU-richtlijn 2014/55/EU.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Basisfactuur Rijk - best practices leveranciers
-
-
-### `ls-egov-0035` — reference.md:65 *(§ Best Practices voor Leveranciers)*
-
-> Facturen voor de Rijksoverheid dienen te worden aangeleverd in UBL 2.1 XML-formaat voor optimale automatische verwerking.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Basisfactuur Rijk - best practices leveranciers
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** E-Procurement - elektronisch factureren
 
 
-### `ls-egov-0036` — reference.md:93 *(§ E-Procurement)*
+### `ls-egov-0054` — reference.md:93 *(§ E-Procurement)*
 
 > E-Procurement vereist naleving van de Europese norm EN 16931 voor elektronische facturering.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** E-Procurement - compliance
 
 
-## GROUNDED — minstens één bron ondersteunt de claim (1)
+### `ls-egov-0055` — reference.md:97 *(§ E-Procurement)*
+
+> De Basisfactuur Rijk dekt circa 90% van alle overheidsfacturen (standaard inkoop- en dienstverleningsfacturen).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Procurement - bereik
+
+
+### `ls-egov-0056` — reference.md:98 *(§ E-Procurement)*
+
+> De resterende 10% van overheidsfacturen betreft uitzonderingsgevallen zoals creditnota's met afwijkende structuren of specifieke sectorvereisten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Procurement - bereik
+
+
+### `ls-egov-0057` — reference.md:105 *(§ E-Procurement)*
+
+> NLCIUS is de Nederlandse invulling (Core Invoice Usage Specification) van de Europese norm EN 16931.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Procurement - ondersteunde standaarden
+
+
+### `ls-egov-0058` — reference.md:104 *(§ E-Procurement)*
+
+> Peppol BIS 3 is een Europese factuurstandaard via het Peppol-netwerk.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Procurement - ondersteunde standaarden
+
+
+## GROUNDED — minstens één bron ondersteunt de claim (2)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `ls-egov-0020` — SKILL.md:115 *(§ Samenhang Standaarden)*
+### `ls-egov-0025` — SKILL.md:115 *(§ Samenhang Standaarden)*
 
-> Peppol BIS heeft de Forum Standaardisatie status 'aanbevolen', niet verplicht.
+> NLCIUS heeft bij Forum Standaardisatie de status 'verplicht' (pas-toe-of-leg-uit).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Peppol BIS - Forum Standaardisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie - NLCIUS
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  > Verplicht ('Pas toe leg uit')
+  - *De status van NLCIUS wordt expliciet als 'Verplicht (Pas toe of leg uit)' vermeld op de pagina.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
+  - *De bron gaat over Peppol BIS, niet over NLCIUS. De status van NLCIUS bij Forum Standaardisatie wordt niet behandeld.*
+
+### `ls-egov-0026` — SKILL.md:115 *(§ Samenhang Standaarden)*
+
+> Peppol BIS heeft bij Forum Standaardisatie de status 'aanbevolen', niet verplicht.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie - Peppol BIS
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis](https://www.forumstandaardisatie.nl/open-standaarden/peppol-bis)
-  > Aanbevolen [...] Status 'Aanbevolen' betekent dat dit een gangbare of opkomende standaard is waarvan het Forum Standaardisatie het gebruik aanbeveelt.
-  - *De bron vermeldt expliciet 'Aanbevolen' als status van Peppol BIS, niet 'Verplicht (Pas toe of leg uit)'.*
+  > Aanbevolen [...] 'Aanbevolen' betekent dat dit een gangbare of opkomende standaard is waarvan het Forum Standaardisatie het gebruik aanbeveelt.
+  - *De bron toont expliciet de status 'Aanbevolen' voor Peppol BIS, niet 'Verplicht (Pas toe of leg uit)'.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De bron vermeldt Peppol BIS alleen als een gerelateerde standaard ('Relatie met andere standaarden Peppol BIS'), maar geeft geen informatie over de lijststatus van Peppol BIS bij Forum Standaardisatie.*
 
 </details>

--- a/skills/ls-fsc/audit.md
+++ b/skills/ls-fsc/audit.md
@@ -1,0 +1,811 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-fsc — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 31 | 70% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 0 | 0% |
+| UNGROUNDED | 11 | 25% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 1 | 2% |
+| GROUNDED | 1 | 2% |
+
+*Geverifieerd met sonnet, 15 calls, $0.9454.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (31)
+
+### `ls-fsc-0002` — SKILL.md:29 *(§ Versiemodel)*
+
+> FSC kent twee publicatiekanalen: een vastgestelde versie (DEF) op gitdocumentatie.logius.nl en een werkversie (draft) op logius-standaarden.github.io.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - versiemodel
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0004` — SKILL.md:39 *(§ Repositories)*
+
+> fsc-logging heeft een vastgestelde versie v1.1.0 gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/logging/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** fsc-logging
+
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/fsc-regulated-area](https://logius-standaarden.github.io/fsc-regulated-area)
+  - *Bron status: unsupported*
+<details><summary>15x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-core](https://github.com/logius-standaarden/fsc-core)
+  - *De brontekst vermeldt 'https://gitdocumentatie.logius.nl/publicatie/fsc/logging/' als publicatielocatie, maar noemt geen versienummer (v1.1.0) of vaststellingsstatus.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-core](https://logius-standaarden.github.io/fsc-core)
+  - *De bron is de FSC Core spec en behandelt fsc-logging niet als gepubliceerde standaard met versienummer. Er is alleen een verwijzing: 'It is RECOMMENDED to use FSC Core with the following extensions, each specified in a dedicated RFC: FSC Logging, keep a log of requests to Services.' Geen publicatie-URL of versienummer voor fsc-logging.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-logging](https://github.com/logius-standaarden/fsc-logging)
+  - *De brontekst is de GitHub-repositorypagina van fsc-logging en bevat geen versie-informatie, geen release-tags, en geen verwijzingen naar gitdocumentatie.logius.nl/publicatie/fsc/logging/. Publicatie-metadata staat niet in de GitHub repo-indexpagina.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-logging](https://logius-standaarden.github.io/fsc-logging)
+  - *De bron vermeldt wel 'Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/logging/' maar noemt geen versienummer v1.1.0. Het document is een draft, niet een vastgestelde versie. Versienummer ontbreekt volledig in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-properties](https://github.com/logius-standaarden/fsc-properties)
+  - *De bron vermeldt gitdocumentatie.logius.nl/publicatie/fsc/logging/ maar geeft geen versienummer. De claim over versie v1.1.0 kan niet worden geverifieerd.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-properties](https://logius-standaarden.github.io/fsc-properties)
+  - *De brontekst gaat over de FSC Properties extension en bevat geen informatie over fsc-logging of enige versie daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-regulated-area](https://github.com/logius-standaarden/fsc-regulated-area)
+  - *De brontekst vermeldt de URL https://gitdocumentatie.logius.nl/publicatie/fsc/logging/ maar geeft geen versienummer (v1.1.0) of publicatiedatum.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract)
+  - *De brontekst bevat geen informatie over fsc-logging of een versie v1.1.0 daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-external-contract](https://logius-standaarden.github.io/fsc-external-contract)
+  - *De bron verwijst naar de Transaction log extensie maar noemt geen versienummer of publicatie-URL voor fsc-logging.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-extensie-template](https://github.com/logius-standaarden/fsc-extensie-template)
+  - *De brontekst bevat geen informatie over fsc-logging of versies daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-extensie-template](https://logius-standaarden.github.io/fsc-extensie-template)
+  - *De brontekst bevat geen informatie over fsc-logging of versie v1.1.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-test-suite](https://github.com/logius-standaarden/fsc-test-suite)
+  - *De brontekst maakt geen melding van fsc-logging, een versienummer v1.1.0, of een publicatielocatie. De bron gaat uitsluitend over de FSC Test Suite.*
+</details>
+
+### `ls-fsc-0006` — SKILL.md:54 *(§ Stap 1: Contract aanmaken)*
+
+> De consumer maakt een Contract aan met daarin een ServiceConnectionGrant, dat specificeert welke service de consumer wil afnemen en bij welke provider.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract flow
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0007` — SKILL.md:58 *(§ Stap 2: Contract ondertekenen door consumer)*
+
+> De consumer ondertekent het contract cryptografisch met zijn eigen certificaat; de handtekening bevat de certificate thumbprint (SHA-256).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract ondertekening
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0008` — SKILL.md:62 *(§ Stap 3: Contract verzenden naar provider)*
+
+> Het ondertekende contract wordt via de Manager API (POST /contracts) naar de Manager van de provider gestuurd.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract flow
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0009` — SKILL.md:66 *(§ Stap 4: Contract ondertekenen door provider)*
+
+> De provider accepteert een contract via PUT /contracts/{hash}/accept; na ondertekening door provider is het contract geldig en hebben beide partijen een ondertekend exemplaar.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract flow
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0010` — SKILL.md:70 *(§ Stap 5: Access token verkrijgen)*
+
+> De consumer vraagt een access token aan bij de Manager van de provider via het OAuth 2.0 Client Credentials grant (grant_type=client_credentials, scope=<GrantHash>, client_id=<PeerID>).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - token aanvraag
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0012` — SKILL.md:82 *(§ Stap 5: Access token verkrijgen)*
+
+> De scope-parameter in de token-aanvraag bevat de hash van het specifieke Grant dat de consumer wil gebruiken.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - token aanvraag
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0013` — SKILL.md:83 *(§ Stap 5: Access token verkrijgen)*
+
+> De client_id in de token-aanvraag is het PeerID van de consumer, afgeleid uit het certificaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - token aanvraag
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0014` — SKILL.md:85 *(§ Stap 5: Access token verkrijgen)*
+
+> De Manager valideert de token-aanvraag, controleert of er een geldig contract bestaat met het opgegeven grant, en geeft een JWT access token terug.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Manager tokenuitgifte
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0016` — SKILL.md:101 *(§ Stap 7: Validatie en doorsturen door Inway)*
+
+> De Inway extraheert het JWT uit de Fsc-Authorization header, valideert de handtekening, controleert de claims (aud, svc, gth, gid, cnf), en verifieert dat het certificaat van de verbinding overeenkomt met de cnf thumbprint.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway validatie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0017` — SKILL.md:174 *(§ Access Token (JWT))*
+
+> Het FSC access token bevat de claim sub (PeerID van de consumer), iss (PeerID van de provider), svc (servicenaam), aud (URL van de Inway), gth (Grant Hash), gid (Group ID), cnf (certificate thumbprint), exp en nbf.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - JWT access token claims
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0018` — SKILL.md:184 *(§ Access Token (JWT))*
+
+> De cnf claim bindt het token aan het specifieke certificaat van de consumer via x5t#S256 (SHA-256 thumbprint), waardoor token-diefstal wordt voorkomen (certificate-bound tokens).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - JWT access token
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0019` — SKILL.md:244 *(§ Poorten)*
+
+> FSC definieert poort 443 voor dataverkeer (service-aanroepen tussen Outway en Inway) en poort 8443 voor managementverkeer (contractbeheer, tokenuitgifte, peer-discovery).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - netwerkconfiguratie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0024` — SKILL.md:260 *(§ Transactie-ID)*
+
+> Elk FSC-verzoek krijgt een uniek transaction_id mee via de Fsc-Transaction-Id HTTP header, doorgegeven door alle componenten in de keten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - logging extensie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0026` — SKILL.md:284 *(§ Logging per component)*
+
+> De Outway logt uitgaande verzoeken met direction: out; de Inway logt inkomende verzoeken met direction: in. Beide componenten loggen dezelfde transaction_id voor correlatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - logging per component
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0028` — SKILL.md:479 *(§ Inway Error Codes)*
+
+> De Inway retourneert HTTP 401 met ERROR_CODE_ACCESS_TOKEN_MISSING als de Fsc-Authorization header ontbreekt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0029` — SKILL.md:480 *(§ Inway Error Codes)*
+
+> De Inway retourneert HTTP 401 met ERROR_CODE_ACCESS_TOKEN_INVALID als de token handtekening ongeldig is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0030` — SKILL.md:481 *(§ Inway Error Codes)*
+
+> De Inway retourneert HTTP 401 met ERROR_CODE_ACCESS_TOKEN_EXPIRED als het token verlopen is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0031` — SKILL.md:482 *(§ Inway Error Codes)*
+
+> De Inway retourneert HTTP 403 met ERROR_CODE_WRONG_GROUP_ID_IN_TOKEN als de Group ID in het token niet overeenkomt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0032` — SKILL.md:483 *(§ Inway Error Codes)*
+
+> De Inway retourneert HTTP 404 met ERROR_CODE_SERVICE_NOT_FOUND als de service niet geregistreerd is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0033` — SKILL.md:484 *(§ Inway Error Codes)*
+
+> De Inway retourneert HTTP 502 met ERROR_CODE_SERVICE_UNREACHABLE als de achterliggende service onbereikbaar is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0034` — SKILL.md:496 *(§ Foutafhandeling)*
+
+> De Outway geeft 405 ERROR_CODE_METHOD_UNSUPPORTED bij een niet-ondersteunde CONNECT methode.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Outway error codes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0035` — SKILL.md:455 *(§ Contract Aanmaken en Ondertekenen (curl))*
+
+> De contract-signatures zijn JWS tokens (RFC7515) die een hash van de contract-content bevatten, ondertekend met het PKIoverheid-certificaat. De JWS payload bevat contract_content_hash, type en signed_at.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract ondertekening
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+
+### `ls-fsc-0036` — reference.md:11 *(§ Peer)*
+
+> Een Peer is een actor (organisatie) die deelneemt aan het FSC-netwerk en wordt uniek geïdentificeerd door een PeerID, afgeleid uit het subject van het X.509-certificaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - architectuur
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0037` — reference.md:15 *(§ Group)*
+
+> Een Group is een logisch systeem van een Peer, bestaande uit een combinatie van Inways, Outways en een Manager. Een Peer kan meerdere Groups hebben voor verschillende omgevingen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - architectuur
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0038` — reference.md:19 *(§ Inway)*
+
+> De Inway is een reverse proxy die inkomende verbindingen van andere Peers afhandelt en het Fsc-Authorization JWT access token valideert voor doorsturen naar de achterliggende service.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway component
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0039` — reference.md:29 *(§ Outway)*
+
+> De Outway is een forward proxy die een access token verkrijgt bij de Manager van de aanbieder via OAuth 2.0 Client Credentials en het token toevoegt als Fsc-Authorization header.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Outway component
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0040` — reference.md:39 *(§ Manager)*
+
+> De Manager fungeert als OAuth 2.0 Authorization Server voor het uitgeven van access tokens en beheert contracten (aanmaken, ondertekenen, accepteren, intrekken).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Manager component
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0041` — reference.md:49 *(§ Directory)*
+
+> De Directory is een speciale Manager die als centraal register voor service- en peer-discovery fungeert. Peers publiceren services via een ServicePublicationGrant in een contract.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Directory component
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0044` — reference.md:78 *(§ Certificate Thumbprints)*
+
+> Contracten bevatten Certificate Thumbprints (SHA-256 hashes van de DER-encoded certificaten) van de ondertekenaars. De thumbprint wordt ook opgenomen in access tokens via de cnf claim.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - trust model
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+## UNGROUNDED — geen bron ondersteunt de claim (11)
+
+### `ls-fsc-0001` — SKILL.md:23 *(§ Federated Service Connectivity (FSC))*
+
+> FSC is vereist bij Digikoppeling REST-API (v3.0.1+; huidige publicatie v4.0.0); geen afzonderlijke vermelding op het Forum Standaardisatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - toepassingsgebied
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v2.0.0'). Inhoudelijke verificatie is niet mogelijk.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0011` — SKILL.md:81 *(§ Stap 5: Access token verkrijgen)*
+
+> De parameter grant_type in de token-aanvraag is altijd client_credentials.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - token aanvraag
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0015` — SKILL.md:89 *(§ Stap 6: Verzoek via Outway naar Inway)*
+
+> Het access token wordt meegegeven in de Fsc-Authorization header als Bearer token bij het HTTP-verzoek van de Outway naar de Inway.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - Outway naar Inway
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0020` — SKILL.md:249 *(§ HTTP-vereisten)*
+
+> HTTP/1.1 is verplicht als minimale versie voor alle FSC-verbindingen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - HTTP-vereisten
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0021` — SKILL.md:250 *(§ HTTP-vereisten)*
+
+> HTTP/2 is optioneel en mag worden ondersteund als aanvulling op HTTP/1.1 bij FSC-verbindingen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** FSC - HTTP-vereisten
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0022` — SKILL.md:251 *(§ HTTP-vereisten)*
+
+> TLS is verplicht voor FSC-verbindingen; de minimale TLS-versie wordt bepaald door de Group Rules (in de praktijk minimaal TLS 1.2).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - HTTP-vereisten
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0023` — SKILL.md:252 *(§ HTTP-vereisten)*
+
+> mTLS is verplicht voor FSC-verbindingen: zowel client als server presenteren een certificaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - HTTP-vereisten
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0025` — SKILL.md:270 *(§ Logvelden)*
+
+> Elk FSC transactielog bevat minimaal de velden transaction_id, direction, grant_hash, source, destination, timestamp en service.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - logging extensie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0027` — SKILL.md:496 *(§ Foutafhandeling)*
+
+> De Fsc-Error-Code header wordt altijd meegegeven bij foutresponses van de Inway, naast de HTTP status code.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - foutafhandeling
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0042` — reference.md:66 *(§ mTLS met X.509-certificaten)*
+
+> Alle verbindingen tussen FSC-componenten worden beveiligd met mutual TLS (mTLS); beide partijen presenteren een X.509-certificaat en valideren het certificaat van de tegenpartij.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - trust model
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+### `ls-fsc-0043` — reference.md:70 *(§ Trust Anchors)*
+
+> Alle Peers moeten certificaten gebruiken die zijn uitgegeven onder een gedeelde Trust Anchor (root- of intermediate-certificaat).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - trust model
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+</details>
+
+## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (1)
+
+### `ls-fsc-0003` — SKILL.md:38 *(§ Repositories)*
+
+> fsc-core heeft een vastgestelde versie v2.0.0 gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/core/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** fsc-core
+
+**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md: 'fsc-core: gepubliceerde versie v2.0.0 vs tag 1.1.0-rc'. GitHub-bronnen (logius-standaarden.github.io) tonen een oudere versie; gitdocumentatie.logius.nl is leidend. 'De skill gebruikt versienummers van gitdocumentatie.logius.nl als bron van waarheid voor vastgestelde (DEF) versies.'
+
+- **CONTRADICTED** (high) — [https://logius-standaarden.github.io/fsc-core](https://logius-standaarden.github.io/fsc-core)
+  > Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/core/ Previous version: https://gitdocumentatie.logius.nl/publicatie/fsc/core/1.1.0/
+  - *De bron vermeldt als vorige versie '1.1.0', niet v2.0.0. Er is geen aanwijzing dat v2.0.0 bestaat of gepubliceerd is. De huidige versie in de bron is een draft zonder versienummer, en de enige genoemde gepubliceerde versie is 1.1.0.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/fsc-regulated-area](https://logius-standaarden.github.io/fsc-regulated-area)
+  - *Bron status: unsupported*
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-core](https://github.com/logius-standaarden/fsc-core)
+  - *De brontekst vermeldt alleen de URL 'https://gitdocumentatie.logius.nl/publicatie/fsc/core/' als publicatielocatie, maar geeft geen versienummer (v2.0.0) of vaststellingsstatus. Versie-metadata staat niet in de GitHub-repo-pagina.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-logging](https://github.com/logius-standaarden/fsc-logging)
+  - *De aangeleverde brontekst is de GitHub-repositorypagina van fsc-logging, niet fsc-core. Er is geen informatie over fsc-core v2.0.0 of gitdocumentatie.logius.nl/publicatie/fsc/core/ in deze bron.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-logging](https://logius-standaarden.github.io/fsc-logging)
+  - *De bron gaat over FSC Logging, niet over FSC Core. Versie-informatie over fsc-core v2.0.0 staat niet in deze tekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-properties](https://github.com/logius-standaarden/fsc-properties)
+  - *De bron (fsc-properties repo) vermeldt de publicatie-URL gitdocumentatie.logius.nl/publicatie/fsc/core/ maar geeft geen versienummer. De claim over versie v2.0.0 is niet te verifiëren uit deze brontekst.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-properties](https://logius-standaarden.github.io/fsc-properties)
+  - *De brontekst gaat over de FSC Properties extension en bevat geen informatie over versies of publicaties van fsc-core.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-regulated-area](https://github.com/logius-standaarden/fsc-regulated-area)
+  - *De brontekst vermeldt de URL https://gitdocumentatie.logius.nl/publicatie/fsc/core/ maar geeft geen versienummer (v2.0.0) of publicatiedatum. De bron is de GitHub-repository van fsc-regulated-area, niet van fsc-core zelf.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract)
+  - *De brontekst is de GitHub-repositorypagina van fsc-external-contract. Er staat geen informatie over fsc-core of een versie v2.0.0 daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-external-contract](https://logius-standaarden.github.io/fsc-external-contract)
+  - *De bron beschrijft FSC External Contract Reference en verwijst naar FSC Core als normatieve basis, maar noemt geen versienummer van FSC Core en bevat geen URL naar gitdocumentatie.logius.nl/publicatie/fsc/core/.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-extensie-template](https://github.com/logius-standaarden/fsc-extensie-template)
+  - *De brontekst (GitHub repo fsc-extensie-template) bevat geen informatie over versies van fsc-core of publicaties op gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-extensie-template](https://logius-standaarden.github.io/fsc-extensie-template)
+  - *De brontekst behandelt uitsluitend richtlijnen voor het schrijven van FSC-extensies. Er is geen vermelding van fsc-core versienummers of publicatie-URLs.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-test-suite](https://github.com/logius-standaarden/fsc-test-suite)
+  - *De brontekst (de FSC Test Suite README op GitHub) vermeldt nergens een versienummer van fsc-core, laat staan een gepubliceerde v2.0.0 op gitdocumentatie.logius.nl. De bron beschrijft alleen de test suite zelf.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (1)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-fsc-0005` — SKILL.md:42 *(§ Repositories)*
+
+> fsc-external-contract heeft een consultatieversie (CV v1.0.0) gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/ext/; nog niet definitief vastgesteld.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** fsc-external-contract
+
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/fsc-regulated-area](https://logius-standaarden.github.io/fsc-regulated-area)
+  - *Bron status: unsupported*
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/fsc-external-contract](https://logius-standaarden.github.io/fsc-external-contract)
+  > FSC - External Contract Reference 1.0.0 Logius Standard Consultation version January 19, 2026 This version: https://gitdocumentatie.logius.nl/publicatie/fsc/ext/1.0.0/ Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/ext/
+  - *De bron bevestigt dat het om versie 1.0.0 gaat met de status 'Consultation version' (consultatieversie), gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/ext/. De statusomschrijving 'This is a proposed recommendation approved by TO' bevestigt dat het nog geen definitief vastgestelde standaard is.*
+<details><summary>14x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-core](https://github.com/logius-standaarden/fsc-core)
+  - *De brontekst noemt geen 'fsc-external-contract' repository of publicatie. Er is geen verwijzing naar gitdocumentatie.logius.nl/publicatie/fsc/ext/ of een consultatieversie. De vermelde FSC-repositories en publicaties in de bron bevatten dit onderdeel niet.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-core](https://logius-standaarden.github.io/fsc-core)
+  - *De bron maakt geen melding van fsc-external-contract, een consultatieversie daarvan, of een publicatie op gitdocumentatie.logius.nl/publicatie/fsc/ext/.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-logging](https://github.com/logius-standaarden/fsc-logging)
+  - *De brontekst betreft fsc-logging, niet fsc-external-contract. Er is geen informatie over een consultatieversie of gitdocumentatie.logius.nl/publicatie/fsc/ext/ in deze bron.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-logging](https://logius-standaarden.github.io/fsc-logging)
+  - *FSC External Contract wordt niet genoemd in deze brontekst over FSC Logging.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-properties](https://github.com/logius-standaarden/fsc-properties)
+  - *De bron vermeldt fsc-external-contract noch de URL gitdocumentatie.logius.nl/publicatie/fsc/ext/ — dit repo behandelt uitsluitend fsc-properties.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-properties](https://logius-standaarden.github.io/fsc-properties)
+  - *De brontekst gaat over de FSC Properties extension en bevat geen informatie over fsc-external-contract of enige versie daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-regulated-area](https://github.com/logius-standaarden/fsc-regulated-area)
+  - *fsc-external-contract wordt niet genoemd in de brontekst. De FSC-repositories en publicaties die worden opgesomd zijn: fsc-core, fsc-logging, fsc-properties, fsc-regulated-area en fsc-test-suite. Geen verwijzing naar een external-contract extensie of bijbehorende publicatie-URL.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract)
+  - *De brontekst is de GitHub-repositorypagina van fsc-external-contract en vermeldt 'No releases published'. Er staat geen informatie over een consultatieversie CV v1.0.0 of publicatie op gitdocumentatie.logius.nl. Het ontbreken van releases is consistent met 'nog niet definitief vastgesteld', maar bevestigt de specifieke claim over CV v1.0.0 en de publicatie-URL niet.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-extensie-template](https://github.com/logius-standaarden/fsc-extensie-template)
+  - *De brontekst bevat geen informatie over fsc-external-contract of consultatieversies.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-extensie-template](https://logius-standaarden.github.io/fsc-extensie-template)
+  - *De brontekst bevat geen informatie over fsc-external-contract of een consultatieversie CV v1.0.0.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-test-suite](https://github.com/logius-standaarden/fsc-test-suite)
+  - *De brontekst maakt geen melding van fsc-external-contract, een consultatieversie, of een publicatielocatie op gitdocumentatie.logius.nl. De bron gaat uitsluitend over de FSC Test Suite.*
+</details>
+
+</details>

--- a/skills/ls-fsc/audit.md
+++ b/skills/ls-fsc/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-fsc — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,805 +7,600 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 31 | 70% |
+| UNSUPPORTED_ASSERTION | 4 | 11% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 0 | 0% |
-| UNGROUNDED | 11 | 25% |
+| PARTIALLY_GROUNDED | 11 | 29% |
+| UNGROUNDED | 2 | 5% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
-| KNOWN_DISCREPANCY | 1 | 2% |
-| GROUNDED | 1 | 2% |
+| KNOWN_DISCREPANCY | 2 | 5% |
+| GROUNDED | 19 | 50% |
 
-*Geverifieerd met sonnet, 15 calls, $0.9454.*
+*Geverifieerd met sonnet, 10 calls, $0.9168.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (31)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (4)
 
-### `ls-fsc-0002` — SKILL.md:29 *(§ Versiemodel)*
+### `ls-fsc-0008` — SKILL.md:42 *(§ Repositories)*
 
-> FSC kent twee publicatiekanalen: een vastgestelde versie (DEF) op gitdocumentatie.logius.nl en een werkversie (draft) op logius-standaarden.github.io.
+> fsc-external-contract heeft een consultatieversie CV v1.0.0 op gitdocumentatie.logius.nl/publicatie/fsc/ext/.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - versiemodel
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** fsc-external-contract
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0004` — SKILL.md:39 *(§ Repositories)*
-
-> fsc-logging heeft een vastgestelde versie v1.1.0 gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/logging/.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** fsc-logging
-
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/fsc-regulated-area](https://logius-standaarden.github.io/fsc-regulated-area)
-  - *Bron status: unsupported*
-<details><summary>15x NOT_FOUND (klap uit)</summary>
+<details><summary>8x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *fsc-external-contract wordt niet vermeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *De bron behandelt fsc-external-contract niet.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-core](https://github.com/logius-standaarden/fsc-core)
-  - *De brontekst vermeldt 'https://gitdocumentatie.logius.nl/publicatie/fsc/logging/' als publicatielocatie, maar noemt geen versienummer (v1.1.0) of vaststellingsstatus.*
+  - *fsc-external-contract wordt in de brontekst niet genoemd. De FSC-repositories en publicaties die worden opgesomd zijn: fsc-core, fsc-logging, fsc-properties, fsc-regulated-area en fsc-test-suite. Geen verwijzing naar een 'ext'-publicatie of consultatieversie.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-core](https://logius-standaarden.github.io/fsc-core)
-  - *De bron is de FSC Core spec en behandelt fsc-logging niet als gepubliceerde standaard met versienummer. Er is alleen een verwijzing: 'It is RECOMMENDED to use FSC Core with the following extensions, each specified in a dedicated RFC: FSC Logging, keep a log of requests to Services.' Geen publicatie-URL of versienummer voor fsc-logging.*
+  - *De bron maakt geen enkele melding van fsc-external-contract, een consultatieversie CV v1.0.0, of de URL gitdocumentatie.logius.nl/publicatie/fsc/ext/.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-logging](https://github.com/logius-standaarden/fsc-logging)
-  - *De brontekst is de GitHub-repositorypagina van fsc-logging en bevat geen versie-informatie, geen release-tags, en geen verwijzingen naar gitdocumentatie.logius.nl/publicatie/fsc/logging/. Publicatie-metadata staat niet in de GitHub repo-indexpagina.*
+  - *De aangeleverde brontekst bevat geen informatie over fsc-external-contract of een consultatieversie CV v1.0.0.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-logging](https://logius-standaarden.github.io/fsc-logging)
-  - *De bron vermeldt wel 'Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/logging/' maar noemt geen versienummer v1.1.0. Het document is een draft, niet een vastgestelde versie. Versienummer ontbreekt volledig in de brontekst.*
+  - *De bron behandelt FSC Logging en verwijst niet naar fsc-external-contract of een consultatieversie daarvan.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-properties](https://github.com/logius-standaarden/fsc-properties)
-  - *De bron vermeldt gitdocumentatie.logius.nl/publicatie/fsc/logging/ maar geeft geen versienummer. De claim over versie v1.1.0 kan niet worden geverifieerd.*
+  - *fsc-external-contract wordt in deze brontekst (fsc-properties repository) niet vermeld. Er is geen verwijzing naar een consultatieversie of de URL gitdocumentatie.logius.nl/publicatie/fsc/ext/.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-properties](https://logius-standaarden.github.io/fsc-properties)
-  - *De brontekst gaat over de FSC Properties extension en bevat geen informatie over fsc-logging of enige versie daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-regulated-area](https://github.com/logius-standaarden/fsc-regulated-area)
-  - *De brontekst vermeldt de URL https://gitdocumentatie.logius.nl/publicatie/fsc/logging/ maar geeft geen versienummer (v1.1.0) of publicatiedatum.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract)
-  - *De brontekst bevat geen informatie over fsc-logging of een versie v1.1.0 daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-external-contract](https://logius-standaarden.github.io/fsc-external-contract)
-  - *De bron verwijst naar de Transaction log extensie maar noemt geen versienummer of publicatie-URL voor fsc-logging.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-extensie-template](https://github.com/logius-standaarden/fsc-extensie-template)
-  - *De brontekst bevat geen informatie over fsc-logging of versies daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-extensie-template](https://logius-standaarden.github.io/fsc-extensie-template)
-  - *De brontekst bevat geen informatie over fsc-logging of versie v1.1.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-test-suite](https://github.com/logius-standaarden/fsc-test-suite)
-  - *De brontekst maakt geen melding van fsc-logging, een versienummer v1.1.0, of een publicatielocatie. De bron gaat uitsluitend over de FSC Test Suite.*
+  - *De brontekst betreft de FSC Properties extension. Er is geen vermelding van fsc-external-contract, een consultatieversie CV v1.0.0, of de bijbehorende publicatie-URL.*
 </details>
 
-### `ls-fsc-0006` — SKILL.md:54 *(§ Stap 1: Contract aanmaken)*
-
-> De consumer maakt een Contract aan met daarin een ServiceConnectionGrant, dat specificeert welke service de consumer wil afnemen en bij welke provider.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract flow
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0007` — SKILL.md:58 *(§ Stap 2: Contract ondertekenen door consumer)*
-
-> De consumer ondertekent het contract cryptografisch met zijn eigen certificaat; de handtekening bevat de certificate thumbprint (SHA-256).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract ondertekening
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0008` — SKILL.md:62 *(§ Stap 3: Contract verzenden naar provider)*
+### `ls-fsc-0011` — SKILL.md:62 *(§ Stap 3: Contract verzenden naar provider)*
 
 > Het ondertekende contract wordt via de Manager API (POST /contracts) naar de Manager van de provider gestuurd.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract flow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Service Connectivity Flow
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *De bron beschrijft het mechanisme van contractuitwisseling via de Manager maar specificeert het endpoint 'POST /contracts' niet expliciet bij naam. De OpenAPI Specification wordt wel gerefereerd maar niet afgedrukt in de brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *Manager API POST /contracts is een FSC Core-onderwerp; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *De specifieke Manager API endpoint POST /contracts wordt niet vermeld in deze bron. De bron beschrijft wel contracttransmissie maar noemt geen specifieke endpoints.*
+</details>
+
+### `ls-fsc-0012` — SKILL.md:66 *(§ Stap 4: Contract ondertekenen door provider)*
+
+> De provider accepteert het contract via PUT /contracts/{hash}/accept; na ondertekening door beide partijen is het contract geldig.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Service Connectivity Flow
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *De bron beschrijft het acceptatieproces conceptueel (accept signatures, contract states) maar het specifieke endpoint 'PUT /contracts/{hash}/accept' wordt niet bij naam genoemd in de aangeleverde tekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *PUT /contracts/{hash}/accept is een FSC Core-onderwerp; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *De specifieke PUT /contracts/{hash}/accept endpoint wordt niet vermeld in deze bron.*
+</details>
+
+### `ls-fsc-0025` — SKILL.md:284 *(§ Logging per component)*
+
+> De Outway logt uitgaande verzoeken met direction: out; de Inway logt inkomende verzoeken met direction: in. Beide gebruiken dezelfde transaction_id voor correlatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Logging Extensie / logging per component
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *Direction-velden (out/in) voor Outway en Inway logging vallen buiten het bereik van fsc-core.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *De bron beschrijft dat zowel Outway als Inway schrijven naar de TransactionLog en dezelfde TransactionID gebruiken, maar de specifieke direction-waarden 'out' en 'in' worden niet vermeld in de brontekst.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *Direction 'out' voor Outway en 'in' voor Inway worden niet beschreven in deze bron. De bron toont alleen DIRECTION_INCOMING in het voorbeeld.*
 </details>
 
-### `ls-fsc-0009` — SKILL.md:66 *(§ Stap 4: Contract ondertekenen door provider)*
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (11)
 
-> De provider accepteert een contract via PUT /contracts/{hash}/accept; na ondertekening door provider is het contract geldig en hebben beide partijen een ondertekend exemplaar.
+### `ls-fsc-0003` — SKILL.md:27 *(§ Versiemodel)*
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract flow
+> FSC kent twee publicatiekanalen: een vastgestelde versie (DEF) op gitdocumentatie.logius.nl en een werkversie (draft) op logius-standaarden.github.io.
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC versiemodel
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > This is the definitive version of this document. [...] Latest editor's draft: https://logius-standaarden.github.io/fsc-core/
+  - *De bron bevestigt het onderscheid definitieve versie (gitdocumentatie.logius.nl) en werkversie (logius-standaarden.github.io). De aanduiding 'DEF' als label wordt niet expliciet gebruikt; de claim over twee kanalen wordt wel ondersteund.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > This version: https://gitdocumentatie.logius.nl/publicatie/fsc/logging/1.1.0/ Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/logging/ Latest editor's draft: https://logius-standaarden.github.io/fsc-logging/
+  - *De bron bevestigt indirect het bestaan van beide kanalen (gitdocumentatie.logius.nl voor vastgestelde versie, logius-standaarden.github.io voor werkversie) via de URL-vermeldingen, maar maakt de claim over 'twee publicatiekanalen als DEF/draft' niet expliciet.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > This version: https://gitdocumentatie.logius.nl/publicatie/fsc/ext/1.0.0/ Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/ext/ Latest editor's draft: https://logius-standaarden.github.io/fsc-external-contract/
+  - *De bron bevestigt de twee URL-patronen (gitdocumentatie.logius.nl voor gepubliceerde versie, logius-standaarden.github.io voor werkversie), maar de termen 'DEF' en 'draft' worden niet expliciet gebruikt. De claim gaat over het algemene FSC versiemodel; deze bron toont het patroon alleen voor fsc-ext.*
+
+### `ls-fsc-0004` — SKILL.md:32 *(§ Versiemodel)*
+
+> FSC heeft vastgestelde versies voor fsc-core en fsc-logging.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC versiemodel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > FSC - Core 2.0.0 Logius Standard Definitive version April 21, 2026 [...] It is RECOMMENDED to use FSC Core with the following extensions, each specified in a dedicated RFC: FSC Logging, keep a log of requests to Services.
+  - *De bron bevestigt een vastgestelde versie voor fsc-core (v2.0.0). Voor fsc-logging vermeldt de bron alleen dat het een extensie is in een 'dedicated RFC', maar geeft geen versiestatus of publicatielocatie van fsc-logging.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > FSC - Logging 1.1.0 Logius Standard Definitive version April 21, 2026
+  - *De bron bevestigt dat fsc-logging een vastgestelde versie heeft (v1.1.0). De claim over fsc-core met een vastgestelde versie wordt niet bevestigd in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
+  - *Deze bron gaat over fsc-external-contract, niet over fsc-core of fsc-logging. Er is geen informatie over vastgestelde versies van die modules.*
 
-### `ls-fsc-0010` — SKILL.md:70 *(§ Stap 5: Access token verkrijgen)*
+### `ls-fsc-0015` — SKILL.md:101 *(§ Stap 7: Validatie en doorsturen door Inway)*
 
-> De consumer vraagt een access token aan bij de Manager van de provider via het OAuth 2.0 Client Credentials grant (grant_type=client_credentials, scope=<GrantHash>, client_id=<PeerID>).
+> De Inway extraheert het JWT uit de `Fsc-Authorization` header, valideert de handtekening, controleert claims (aud, svc, gth, gid, cnf), verifieert het certificaat via de cnf-thumbprint, en stuurt het verzoek door.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - token aanvraag
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Inway validatieproces
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The request MUST be authorized if the access token meets the following conditions: The access token is signed by the same Peer that owns Inway. The access token is used by an Outway that uses the X.509 certificate to which the access token is bound [...] The Service specified in the access token is known to the Inway. The Group ID specified in the claim gid of the access token matches the Group...
+  - *De bron bevestigt validatie van handtekening, cnf-thumbprint, svc en gid. De claim noemt ook 'aud' en 'gth' als gevalideerde claims, maar de bron vermeldt deze niet expliciet als validatiecriteria in de Inway-sectie. Gedeeltelijk ondersteund.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *JWT-validatie door de Inway inclusief claims als aud, svc, gth, gid, cnf is een FSC Core-onderwerp.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
+  - *Het Inway validatieproces (JWT extractie, claims controle aud/svc/gth/gid/cnf) wordt niet beschreven in deze bron.*
 
-### `ls-fsc-0012` — SKILL.md:82 *(§ Stap 5: Access token verkrijgen)*
+### `ls-fsc-0018` — SKILL.md:244 *(§ Poorten)*
 
-> De scope-parameter in de token-aanvraag bevat de hash van het specifieke Grant dat de consumer wil gebruiken.
+> FSC definieert poort 443 voor dataverkeer (service-aanroepen tussen Outway en Inway) en poort 8443 voor managementverkeer (communicatie tussen Managers en tussen Outways en Managers).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - token aanvraag
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC netwerkconfiguratie
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The ports used by FSC components MUST be 443 or 8443. Port 443 is RECOMMENDED for data traffic i.e. HTTP requests to a Service. Port 8443 is RECOMMENDED for management traffic i.e. submitting/signing Contracts.
+  - *De bron bevestigt poort 443 voor dataverkeer en 8443 voor managementverkeer. De claim zegt 8443 is voor 'communicatie tussen Managers en tussen Outways en Managers', terwijl de bron zegt 'management traffic: Directory, Manager' — Outways worden niet expliciet bij 8443 vermeld. Licht onduidelijk voor het Outway-deel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *Poortconfiguratie (443 en 8443) is een FSC Core-onderwerp; niet behandeld in deze Logging-bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
+  - *Poorten 443 en 8443 worden niet vermeld in deze bron.*
 
-### `ls-fsc-0013` — SKILL.md:83 *(§ Stap 5: Access token verkrijgen)*
-
-> De client_id in de token-aanvraag is het PeerID van de consumer, afgeleid uit het certificaat.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - token aanvraag
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0014` — SKILL.md:85 *(§ Stap 5: Access token verkrijgen)*
-
-> De Manager valideert de token-aanvraag, controleert of er een geldig contract bestaat met het opgegeven grant, en geeft een JWT access token terug.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Manager tokenuitgifte
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0016` — SKILL.md:101 *(§ Stap 7: Validatie en doorsturen door Inway)*
-
-> De Inway extraheert het JWT uit de Fsc-Authorization header, valideert de handtekening, controleert de claims (aud, svc, gth, gid, cnf), en verifieert dat het certificaat van de verbinding overeenkomt met de cnf thumbprint.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway validatie
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0017` — SKILL.md:174 *(§ Access Token (JWT))*
-
-> Het FSC access token bevat de claim sub (PeerID van de consumer), iss (PeerID van de provider), svc (servicenaam), aud (URL van de Inway), gth (Grant Hash), gid (Group ID), cnf (certificate thumbprint), exp en nbf.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - JWT access token claims
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0018` — SKILL.md:184 *(§ Access Token (JWT))*
-
-> De cnf claim bindt het token aan het specifieke certificaat van de consumer via x5t#S256 (SHA-256 thumbprint), waardoor token-diefstal wordt voorkomen (certificate-bound tokens).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - JWT access token
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0019` — SKILL.md:244 *(§ Poorten)*
-
-> FSC definieert poort 443 voor dataverkeer (service-aanroepen tussen Outway en Inway) en poort 8443 voor managementverkeer (contractbeheer, tokenuitgifte, peer-discovery).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - netwerkconfiguratie
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0024` — SKILL.md:260 *(§ Transactie-ID)*
-
-> Elk FSC-verzoek krijgt een uniek transaction_id mee via de Fsc-Transaction-Id HTTP header, doorgegeven door alle componenten in de keten.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - logging extensie
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0026` — SKILL.md:284 *(§ Logging per component)*
-
-> De Outway logt uitgaande verzoeken met direction: out; de Inway logt inkomende verzoeken met direction: in. Beide componenten loggen dezelfde transaction_id voor correlatie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - logging per component
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0028` — SKILL.md:479 *(§ Inway Error Codes)*
-
-> De Inway retourneert HTTP 401 met ERROR_CODE_ACCESS_TOKEN_MISSING als de Fsc-Authorization header ontbreekt.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0029` — SKILL.md:480 *(§ Inway Error Codes)*
-
-> De Inway retourneert HTTP 401 met ERROR_CODE_ACCESS_TOKEN_INVALID als de token handtekening ongeldig is.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0030` — SKILL.md:481 *(§ Inway Error Codes)*
-
-> De Inway retourneert HTTP 401 met ERROR_CODE_ACCESS_TOKEN_EXPIRED als het token verlopen is.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0031` — SKILL.md:482 *(§ Inway Error Codes)*
-
-> De Inway retourneert HTTP 403 met ERROR_CODE_WRONG_GROUP_ID_IN_TOKEN als de Group ID in het token niet overeenkomt.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0032` — SKILL.md:483 *(§ Inway Error Codes)*
-
-> De Inway retourneert HTTP 404 met ERROR_CODE_SERVICE_NOT_FOUND als de service niet geregistreerd is.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0033` — SKILL.md:484 *(§ Inway Error Codes)*
-
-> De Inway retourneert HTTP 502 met ERROR_CODE_SERVICE_UNREACHABLE als de achterliggende service onbereikbaar is.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway error codes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0034` — SKILL.md:496 *(§ Foutafhandeling)*
-
-> De Outway geeft 405 ERROR_CODE_METHOD_UNSUPPORTED bij een niet-ondersteunde CONNECT methode.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Outway error codes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0035` — SKILL.md:455 *(§ Contract Aanmaken en Ondertekenen (curl))*
-
-> De contract-signatures zijn JWS tokens (RFC7515) die een hash van de contract-content bevatten, ondertekend met het PKIoverheid-certificaat. De JWS payload bevat contract_content_hash, type en signed_at.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - contract ondertekening
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-
-### `ls-fsc-0036` — reference.md:11 *(§ Peer)*
-
-> Een Peer is een actor (organisatie) die deelneemt aan het FSC-netwerk en wordt uniek geïdentificeerd door een PeerID, afgeleid uit het subject van het X.509-certificaat.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - architectuur
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0037` — reference.md:15 *(§ Group)*
-
-> Een Group is een logisch systeem van een Peer, bestaande uit een combinatie van Inways, Outways en een Manager. Een Peer kan meerdere Groups hebben voor verschillende omgevingen.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - architectuur
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0038` — reference.md:19 *(§ Inway)*
-
-> De Inway is een reverse proxy die inkomende verbindingen van andere Peers afhandelt en het Fsc-Authorization JWT access token valideert voor doorsturen naar de achterliggende service.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Inway component
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0039` — reference.md:29 *(§ Outway)*
-
-> De Outway is een forward proxy die een access token verkrijgt bij de Manager van de aanbieder via OAuth 2.0 Client Credentials en het token toevoegt als Fsc-Authorization header.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Outway component
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0040` — reference.md:39 *(§ Manager)*
-
-> De Manager fungeert als OAuth 2.0 Authorization Server voor het uitgeven van access tokens en beheert contracten (aanmaken, ondertekenen, accepteren, intrekken).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Manager component
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0041` — reference.md:49 *(§ Directory)*
-
-> De Directory is een speciale Manager die als centraal register voor service- en peer-discovery fungeert. Peers publiceren services via een ServicePublicationGrant in een contract.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - Directory component
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0044` — reference.md:78 *(§ Certificate Thumbprints)*
-
-> Contracten bevatten Certificate Thumbprints (SHA-256 hashes van de DER-encoded certificaten) van de ondertekenaars. De thumbprint wordt ook opgenomen in access tokens via de cnf claim.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC - trust model
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-## UNGROUNDED — geen bron ondersteunt de claim (11)
-
-### `ls-fsc-0001` — SKILL.md:23 *(§ Federated Service Connectivity (FSC))*
-
-> FSC is vereist bij Digikoppeling REST-API (v3.0.1+; huidige publicatie v4.0.0); geen afzonderlijke vermelding op het Forum Standaardisatie.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - toepassingsgebied
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v2.0.0'). Inhoudelijke verificatie is niet mogelijk.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0011` — SKILL.md:81 *(§ Stap 5: Access token verkrijgen)*
-
-> De parameter grant_type in de token-aanvraag is altijd client_credentials.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - token aanvraag
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0015` — SKILL.md:89 *(§ Stap 6: Verzoek via Outway naar Inway)*
-
-> Het access token wordt meegegeven in de Fsc-Authorization header als Bearer token bij het HTTP-verzoek van de Outway naar de Inway.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - Outway naar Inway
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0020` — SKILL.md:249 *(§ HTTP-vereisten)*
+### `ls-fsc-0019` — SKILL.md:249 *(§ HTTP-vereisten)*
 
 > HTTP/1.1 is verplicht als minimale versie voor alle FSC-verbindingen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - HTTP-vereisten
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC netwerkconfiguratie / HTTP-vereisten
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The Manager MUST support HTTP/1.1[RFC9112]. The Manager MAY support HTTP/2[RFC9113]. The protocol used between the Inway and Outway can be either HTTP/1.1[RFC9112] or HTTP/2[RFC9113].
+  - *HTTP/1.1 is verplicht voor de Manager. Voor Inway/Outway kan het HTTP/1.1 of HTTP/2 zijn — MUST voor HTTP/1.1 geldt alleen voor de Manager, niet voor alle FSC-verbindingen als zodanig. De claim zegt 'alle FSC-verbindingen', wat te breed is.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *HTTP/1.1 als minimale versie is een FSC Core-vereiste; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *HTTP/1.1 als minimale versie wordt niet vermeld in deze bron.*
+
+### `ls-fsc-0020` — SKILL.md:250 *(§ HTTP-vereisten)*
+
+> HTTP/2 is optioneel en mag worden ondersteund als aanvulling op HTTP/1.1 in FSC-verbindingen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** FSC netwerkconfiguratie / HTTP-vereisten
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The Manager MAY support HTTP/2[RFC9113]. The protocol used between the Inway and Outway can be either HTTP/1.1[RFC9112] or HTTP/2[RFC9113].
+  - *Voor de Manager is HTTP/2 optioneel (MAY). Voor Inway/Outway is HTTP/2 een gelijkwaardige optie naast HTTP/1.1. De claim zegt 'als aanvulling op HTTP/1.1', maar de bron presenteert het als alternatief voor Inway/Outway, niet puur als aanvulling.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *HTTP/2 ondersteuning is een FSC Core-onderwerp; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *HTTP/2 wordt niet vermeld in deze bron.*
+
+### `ls-fsc-0021` — SKILL.md:251 *(§ HTTP-vereisten)*
+
+> TLS is verplicht voor alle FSC-verbindingen; de minimale TLS-versie wordt bepaald door de Group Rules (in de praktijk minimaal TLS 1.2).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC netwerkconfiguratie / HTTP-vereisten
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The TLS versions used between Peers in a Group MUST be defined in the additional Group Rules & Restrictions.
+  - *TLS is verplicht en de versie wordt bepaald door Group Rules — dit klopt. De toevoeging 'in de praktijk minimaal TLS 1.2' staat niet in de bron; de bron laat dit open aan de Group.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *TLS-versievereisten zijn een FSC Core-onderwerp; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *TLS-vereisten en minimale TLS-versie worden niet vermeld in deze bron.*
+
+### `ls-fsc-0024` — SKILL.md:270 *(§ Logvelden)*
+
+> Elk FSC transactielog bevat minimaal: transaction_id, direction, grant_hash, source, destination, timestamp en service.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC Logging Extensie
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > The fields that a log record MUST contain are described in the OpenAPI Specification
+  - *De bron stelt dat de verplichte velden in de OpenAPI Specification staan, maar somt ze niet op in de tekstuele bron. De velden grant_hash, source, destination en service_name worden wel indirect vermeld via de access token mapping (3.1.1), maar timestamp en direction worden niet expliciet als verplichte log record velden benoemd in de tekst.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > "transaction_id" : "019a7dea-9048-7c4d-9e66-4d3f75a18f58" , "direction" : "DIRECTION_INCOMING" , "grant_hash" : "$1$4$+PQI7we01qIfEwq4O5UioLKzjGBgRva6F5+bUfDlKxUjcY5yX1MRsn6NKquDbL8VcklhYO9sk18rHD6La3w/mg" , "source" : {...} , "destination" : {...} , "service_name" : "random_service_name" , "created_at" : 1672527600
+  - *Het transactielog voorbeeld toont transaction_id, direction, grant_hash, source, destination, service_name en created_at. De claim noemt 'timestamp' (gedekt door created_at) en 'service' (gedekt door service_name). Alle genoemde velden zijn aanwezig, maar dit is de extensie-spec; de claim stelt dat dit de minimale vereisten zijn in de Logging Extensie zelf (buiten scope van deze bron).*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *Logging-velden zoals transaction_id, direction, grant_hash, source, destination worden niet beschreven in fsc-core.*
+
+### `ls-fsc-0027` — SKILL.md:455 *(§ Contract Aanmaken en Ondertekenen (curl))*
+
+> JWS signature-waarden (RFC7515) bevatten een hash van de contract-content, ondertekend met het PKIoverheid-certificaat; de JWS payload bevat contract_content_hash, type (accept/reject/revoke) en signed_at.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC contract signatures
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "The JWS Payload as defined in section 2 of [RFC7515], MUST contain a hash of the contract.content as described in the section Content Hash, one of the signature types described in the signature type section and a Unix timestamp of the sign date. JWS Payload example: { "contract_content_hash": "--------", "type": "accept", "signed_at": 1672527600 }"
+  - *De bron bevestigt dat de JWS payload contract_content_hash, type (accept/reject/revoke) en signed_at bevat, en dat JWS gebaseerd is op RFC7515. De claim vermeldt echter specifiek 'PKIoverheid-certificaat', terwijl de bron alleen spreekt van X.509-certificaten uitgegeven door de Trust Anchor van de Group — PKIoverheid wordt nergens expliciet genoemd.*
+
+### `ls-fsc-0031` — reference.md:15 *(§ Group)*
+
+> Een Group is een logisch systeem van een Peer, bestaande uit een combinatie van Inways, Outways en een Manager. Een Peer kan meerdere Groups hebben.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC architectuur / Group
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "Group: System of Peers using Inways, Outways and Managers that confirm to the FSC specification to make use of each other's Services." en "Organizations can participate in multiple Groups at the same time."
+  - *De bron beschrijft een Group als een systeem van meerdere Peers (niet één Peer), en bevestigt dat een organisatie in meerdere Groups kan participeren. De claim stelt echter dat een Group bestaat uit 'een combinatie van Inways, Outways en een Manager' van één Peer — dat is een onjuiste weergave. Een Group omvat meerdere Peers, elk met eigen componenten. De claim 'Een Peer kan meerdere Groups hebben' is correct ondersteund.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *De definitie van een Group is een FSC Core-onderwerp; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *Het concept Group (combinatie van Inways, Outways en Manager) wordt niet gedefinieerd in deze bron, al wordt 'gid' (Group ID) wel gebruikt in het JWT voorbeeld.*
+
+### `ls-fsc-0038` — reference.md:78 *(§ Certificate Thumbprints)*
+
+> Contracten bevatten Certificate Thumbprints (SHA-256 hashes van DER-encoded certificaten) van de ondertekenaars; de thumbprint wordt ook opgenomen in access tokens via de `cnf` claim.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC trust model / Certificate Thumbprints
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "Public Key thumbprints are used in FSC contracts [...] Certificate thumbprints are used in the certificate-bound access tokens section 3 of [RFC8705]. [...] The cnf.x5t#S256 claim MUST contain the certificate thumbprint of the X.509 certificate provided by the client requesting the token"
+  - *De bron bevestigt dat access tokens certificate thumbprints bevatten via de cnf claim (x5t#S256). Echter: de claim stelt dat contracten 'Certificate Thumbprints (SHA-256 hashes van DER-encoded certificaten)' bevatten — dit is onjuist. De bron stelt expliciet dat contracten Public Key Thumbprints gebruiken (niet Certificate Thumbprints), zodat certificaatvernieuwing zonder sleutelrotatie het contract niet ongeldig maakt. Dit is een gedeeltelijke tegenstelling voor het contract-gedeelte van de claim.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > "cnf" : { "x5t#S256" : "06QekfpQ2IkYWhXyZqz3T1llvPEqDYYO0UyETSr7QdU" }
+  - *De bron bevestigt dat de cnf claim met x5t#S256 thumbprint in access tokens wordt opgenomen. Het deel over Certificate Thumbprints in contracten zelf (SHA-256 hashes van DER-encoded certificaten van ondertekenaars) wordt niet beschreven in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *Certificate Thumbprints in contracten en de cnf-claim in access tokens zijn FSC Core-onderwerpen. De Logging-bron vermeldt accessToken.gth als grant_hash mapping maar behandelt thumbprints in contracten of cnf-claim niet.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (2)
+
+### `ls-fsc-0002` — SKILL.md:23 *(§ Federated Service Connectivity (FSC))*
+
+> FSC is vereist bij Digikoppeling REST-API (v3.0.1+; huidige publicatie v4.0.0).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Digikoppeling REST-API / FSC
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *Deze bron is de FSC Core spec zelf; zij bevat geen verwijzingen naar Digikoppeling REST-API of versievereisten daarbinnen.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *De bron beschrijft FSC Logging; Digikoppeling REST-API vereisten staan hier niet in.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *Digikoppeling REST-API wordt niet genoemd in deze bron.*
 </details>
 
-### `ls-fsc-0021` — SKILL.md:250 *(§ HTTP-vereisten)*
+### `ls-fsc-0026` — SKILL.md:399 *(§ Contract Aanmaken en Ondertekenen (curl))*
 
-> HTTP/2 is optioneel en mag worden ondersteund als aanvulling op HTTP/1.1 bij FSC-verbindingen.
+> De Manager API POST /contracts verwacht `content` (verplicht) en `signature` (JWS string); de Manager berekent en valideert de signature op basis van het certificaat waarmee de mTLS-verbinding is opgezet.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** FSC - HTTP-vereisten
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC Manager API / contract aanmaken
 
-<details><summary>3x NOT_FOUND (klap uit)</summary>
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *De bron beschrijft de werking van de Manager API op conceptueel niveau en vermeldt validatieregels voor Contracts en signatures, maar specificeert niet de exacte request body parameters (content + signature) van POST /contracts. De claim dat de Manager de signature valideert op basis van het mTLS-certificaat is deels aantoonbaar (zie signature validatie sectie 4.4.1.3), maar de specifieke API-parameterstructuur staat niet in de brontekst.*
 
+## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (2)
+
+### `ls-fsc-0005` — SKILL.md:32 *(§ Versiemodel)*
+
+> fsc-external-contract heeft een consultatieversie (CV); de overige modules (fsc-properties, fsc-regulated-area, fsc-extensie-template) hebben alleen werkversies.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC versiemodel
+
+**Erkend in conflicts.md** *(§ Details fsc-external-contract)*: conflicts.md stelt expliciet: 'Dit is een CV (Consultatieversie), geen DEF-versie — het document is nog niet definitief vastgesteld.' De CONTRADICTED-verdict op de ext-publicatie is dus een gedocumenteerde keuze.
+
+- **CONTRADICTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > This is the definitive version of this document. Edits resulting from consultations have been applied.
+  - *De claim stelt dat fsc-external-contract een consultatieversie (CV) heeft, maar de bron is expliciet een 'definitive version' (vastgestelde versie), niet een consultatieversie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
+  - *De bron behandelt fsc-external-contract, fsc-properties, fsc-regulated-area en fsc-extensie-template niet.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
+  - *De bron behandelt fsc-external-contract, fsc-properties, fsc-regulated-area en fsc-extensie-template niet.*
 
-### `ls-fsc-0022` — SKILL.md:251 *(§ HTTP-vereisten)*
+### `ls-fsc-0006` — SKILL.md:38 *(§ Repositories)*
 
-> TLS is verplicht voor FSC-verbindingen; de minimale TLS-versie wordt bepaald door de Group Rules (in de praktijk minimaal TLS 1.2).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - HTTP-vereisten
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0023` — SKILL.md:252 *(§ HTTP-vereisten)*
-
-> mTLS is verplicht voor FSC-verbindingen: zowel client als server presenteren een certificaat.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - HTTP-vereisten
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0025` — SKILL.md:270 *(§ Logvelden)*
-
-> Elk FSC transactielog bevat minimaal de velden transaction_id, direction, grant_hash, source, destination, timestamp en service.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - logging extensie
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0027` — SKILL.md:496 *(§ Foutafhandeling)*
-
-> De Fsc-Error-Code header wordt altijd meegegeven bij foutresponses van de Inway, naast de HTTP status code.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - foutafhandeling
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0042` — reference.md:66 *(§ mTLS met X.509-certificaten)*
-
-> Alle verbindingen tussen FSC-componenten worden beveiligd met mutual TLS (mTLS); beide partijen presenteren een X.509-certificaat en valideren het certificaat van de tegenpartij.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - trust model
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-### `ls-fsc-0043` — reference.md:70 *(§ Trust Anchors)*
-
-> Alle Peers moeten certificaten gebruiken die zijn uitgegeven onder een gedeelde Trust Anchor (root- of intermediate-certificaat).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC - trust model
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-</details>
-
-## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (1)
-
-### `ls-fsc-0003` — SKILL.md:38 *(§ Repositories)*
-
-> fsc-core heeft een vastgestelde versie v2.0.0 gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/core/.
+> fsc-core vastgestelde versie is v2.0.0, gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/core/.
 
 **Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** fsc-core
 
-**Erkend in conflicts.md** *(§ Discrepanties)*: conflicts.md: 'fsc-core: gepubliceerde versie v2.0.0 vs tag 1.1.0-rc'. GitHub-bronnen (logius-standaarden.github.io) tonen een oudere versie; gitdocumentatie.logius.nl is leidend. 'De skill gebruikt versienummers van gitdocumentatie.logius.nl als bron van waarheid voor vastgestelde (DEF) versies.'
+**Erkend in conflicts.md** *(§ Details fsc-core)*: conflicts.md: 'Enige tag: 1.1.0-rc ... terwijl de gepubliceerde versie inmiddels v2.0.0 is.' En: 'De gepubliceerde versie op gitdocumentatie.logius.nl is leidend voor DEF-versies.' De CONTRADICTED van logius-standaarden.github.io is hiermee verklaard.
 
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > FSC - Core 2.0.0 Logius Standard Definitive version April 21, 2026 This version: https://gitdocumentatie.logius.nl/publicatie/fsc/core/2.0.0/ Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/core/
 - **CONTRADICTED** (high) — [https://logius-standaarden.github.io/fsc-core](https://logius-standaarden.github.io/fsc-core)
-  > Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/core/ Previous version: https://gitdocumentatie.logius.nl/publicatie/fsc/core/1.1.0/
-  - *De bron vermeldt als vorige versie '1.1.0', niet v2.0.0. Er is geen aanwijzing dat v2.0.0 bestaat of gepubliceerd is. De huidige versie in de bron is een draft zonder versienummer, en de enige genoemde gepubliceerde versie is 1.1.0.*
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/fsc-regulated-area](https://logius-standaarden.github.io/fsc-regulated-area)
-  - *Bron status: unsupported*
-<details><summary>14x NOT_FOUND (klap uit)</summary>
+  > Previous version: https://gitdocumentatie.logius.nl/publicatie/fsc/core/1.1.0/
+  - *De bron vermeldt de vorige gepubliceerde versie als 1.1.0, niet als v2.0.0. De huidige versie in de bron is een draft zonder versienummer. Er is geen aanwijzing dat v2.0.0 bestaat of gepubliceerd is.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *De bron gaat over fsc-logging, niet over fsc-core. Versie-informatie van fsc-core staat hier niet in.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-core](https://github.com/logius-standaarden/fsc-core)
-  - *De brontekst vermeldt alleen de URL 'https://gitdocumentatie.logius.nl/publicatie/fsc/core/' als publicatielocatie, maar geeft geen versienummer (v2.0.0) of vaststellingsstatus. Versie-metadata staat niet in de GitHub-repo-pagina.*
+  - *De brontekst is de GitHub repository-pagina van fsc-core. Er staat geen versienummer (v2.0.0) vermeld. Alleen de publicatie-URL wordt genoemd: 'https://gitdocumentatie.logius.nl/publicatie/fsc/core/' — zonder versieaanduiding.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-logging](https://github.com/logius-standaarden/fsc-logging)
-  - *De aangeleverde brontekst is de GitHub-repositorypagina van fsc-logging, niet fsc-core. Er is geen informatie over fsc-core v2.0.0 of gitdocumentatie.logius.nl/publicatie/fsc/core/ in deze bron.*
+  - *De aangeleverde brontekst betreft de GitHub-repo fsc-logging (CC-BY-4.0 licentietekst en repo-metadata). Er staat geen informatie over fsc-core versienummers of publicatie-URLs.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-logging](https://logius-standaarden.github.io/fsc-logging)
-  - *De bron gaat over FSC Logging, niet over FSC Core. Versie-informatie over fsc-core v2.0.0 staat niet in deze tekst.*
+  - *De bron behandelt FSC Logging, niet FSC Core. Er wordt geen versienummer of publicatiestatus van fsc-core vermeld.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-properties](https://github.com/logius-standaarden/fsc-properties)
-  - *De bron (fsc-properties repo) vermeldt de publicatie-URL gitdocumentatie.logius.nl/publicatie/fsc/core/ maar geeft geen versienummer. De claim over versie v2.0.0 is niet te verifiëren uit deze brontekst.*
+  - *De brontekst (GitHub repository pagina van fsc-properties) vermeldt de publicatie URL gitdocumentatie.logius.nl/publicatie/fsc/core/ maar geeft geen versienummer. Versie-metadata zoals 'v2.0.0' staat niet in deze bron.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-properties](https://logius-standaarden.github.io/fsc-properties)
-  - *De brontekst gaat over de FSC Properties extension en bevat geen informatie over versies of publicaties van fsc-core.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-regulated-area](https://github.com/logius-standaarden/fsc-regulated-area)
-  - *De brontekst vermeldt de URL https://gitdocumentatie.logius.nl/publicatie/fsc/core/ maar geeft geen versienummer (v2.0.0) of publicatiedatum. De bron is de GitHub-repository van fsc-regulated-area, niet van fsc-core zelf.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract)
-  - *De brontekst is de GitHub-repositorypagina van fsc-external-contract. Er staat geen informatie over fsc-core of een versie v2.0.0 daarvan.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-external-contract](https://logius-standaarden.github.io/fsc-external-contract)
-  - *De bron beschrijft FSC External Contract Reference en verwijst naar FSC Core als normatieve basis, maar noemt geen versienummer van FSC Core en bevat geen URL naar gitdocumentatie.logius.nl/publicatie/fsc/core/.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-extensie-template](https://github.com/logius-standaarden/fsc-extensie-template)
-  - *De brontekst (GitHub repo fsc-extensie-template) bevat geen informatie over versies van fsc-core of publicaties op gitdocumentatie.logius.nl.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-extensie-template](https://logius-standaarden.github.io/fsc-extensie-template)
-  - *De brontekst behandelt uitsluitend richtlijnen voor het schrijven van FSC-extensies. Er is geen vermelding van fsc-core versienummers of publicatie-URLs.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-test-suite](https://github.com/logius-standaarden/fsc-test-suite)
-  - *De brontekst (de FSC Test Suite README op GitHub) vermeldt nergens een versienummer van fsc-core, laat staan een gepubliceerde v2.0.0 op gitdocumentatie.logius.nl. De bron beschrijft alleen de test suite zelf.*
+  - *De brontekst betreft de FSC Properties extension specificatie. Er wordt nergens gerefereerd aan een versienummer van fsc-core (v2.0.0) of de publicatie-URL van fsc-core.*
 </details>
 
-## GROUNDED — minstens één bron ondersteunt de claim (1)
+## GROUNDED — minstens één bron ondersteunt de claim (19)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `ls-fsc-0005` — SKILL.md:42 *(§ Repositories)*
+### `ls-fsc-0001` — SKILL.md:23 *(§ Federated Service Connectivity (FSC))*
 
-> fsc-external-contract heeft een consultatieversie (CV v1.0.0) gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/ext/; nog niet definitief vastgesteld.
+> FSC gebruikt mTLS, OAuth 2.0 client_credentials en cryptografisch ondertekende contracten.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** fsc-external-contract
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC algemeen
 
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/fsc-regulated-area](https://logius-standaarden.github.io/fsc-regulated-area)
-  - *Bron status: unsupported*
-- **SUPPORTED** (high) — [https://logius-standaarden.github.io/fsc-external-contract](https://logius-standaarden.github.io/fsc-external-contract)
-  > FSC - External Contract Reference 1.0.0 Logius Standard Consultation version January 19, 2026 This version: https://gitdocumentatie.logius.nl/publicatie/fsc/ext/1.0.0/ Latest published version: https://gitdocumentatie.logius.nl/publicatie/fsc/ext/
-  - *De bron bevestigt dat het om versie 1.0.0 gaat met de status 'Consultation version' (consultatieversie), gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/ext/. De statusomschrijving 'This is a proposed recommendation approved by TO' bevestigt dat het nog geen definitief vastgestelde standaard is.*
-<details><summary>14x NOT_FOUND (klap uit)</summary>
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > All connections between Peers leverage mTLS and contracts are cryptographically signed. [...] Access tokens are obtained using the Client Credentials flow section 4,4 of [RFC6749].
+  - *De bron bevestigt mTLS, cryptografisch ondertekende contracten én OAuth 2.0 client_credentials flow expliciet.*
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *Deze bron beschrijft de FSC Logging extensie, niet FSC Core. mTLS, OAuth 2.0 client_credentials en cryptografisch ondertekende contracten zijn FSC Core-onderwerpen die hier niet worden behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *De brontekst (fsc-external-contract extensie) beschrijft delegatie via externe contractreferenties. mTLS, OAuth 2.0 client_credentials en cryptografisch ondertekende contracten worden niet in deze bron behandeld.*
+
+### `ls-fsc-0007` — SKILL.md:39 *(§ Repositories)*
+
+> fsc-logging vastgestelde versie is v1.1.0, gepubliceerd op gitdocumentatie.logius.nl/publicatie/fsc/logging/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** fsc-logging
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > FSC - Logging 1.1.0 Logius Standard Definitive version April 21, 2026 This version: https://gitdocumentatie.logius.nl/publicatie/fsc/logging/1.1.0/
+<details><summary>7x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
-  - *Aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding).*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen redirect-melding)*
+  - *De bron vermeldt fsc-logging alleen als aanbevolen extensie, zonder versienummer of publicatielocatie.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-core](https://github.com/logius-standaarden/fsc-core)
-  - *De brontekst noemt geen 'fsc-external-contract' repository of publicatie. Er is geen verwijzing naar gitdocumentatie.logius.nl/publicatie/fsc/ext/ of een consultatieversie. De vermelde FSC-repositories en publicaties in de bron bevatten dit onderdeel niet.*
+  - *De brontekst vermeldt wel de publicatie-URL voor fsc-logging ('https://gitdocumentatie.logius.nl/publicatie/fsc/logging/'), maar geen versienummer (v1.1.0).*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-core](https://logius-standaarden.github.io/fsc-core)
-  - *De bron maakt geen melding van fsc-external-contract, een consultatieversie daarvan, of een publicatie op gitdocumentatie.logius.nl/publicatie/fsc/ext/.*
+  - *De bron behandelt alleen FSC Core. FSC Logging wordt enkel kort vermeld als aanbevolen extensie ('FSC Logging, keep a log of requests to Services'), maar er is geen informatie over versienummers of publicatie-URL's van fsc-logging.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-logging](https://github.com/logius-standaarden/fsc-logging)
-  - *De brontekst betreft fsc-logging, niet fsc-external-contract. Er is geen informatie over een consultatieversie of gitdocumentatie.logius.nl/publicatie/fsc/ext/ in deze bron.*
+  - *De aangeleverde brontekst bevat alleen de GitHub-repo pagina van fsc-logging met licentietekst en algemene repo-metadata. Versienummers of publicatie-URLs voor fsc-logging staan niet in de aangeleverde tekst.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-logging](https://logius-standaarden.github.io/fsc-logging)
-  - *FSC External Contract wordt niet genoemd in deze brontekst over FSC Logging.*
+  - *De bron vermeldt wel de URL gitdocumentatie.logius.nl/publicatie/fsc/logging/ als 'Latest published version', maar noemt geen versienummer (v1.1.0). Publicatiemetadata met specifieke versienummers staat niet in de spec zelf.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-properties](https://github.com/logius-standaarden/fsc-properties)
-  - *De bron vermeldt fsc-external-contract noch de URL gitdocumentatie.logius.nl/publicatie/fsc/ext/ — dit repo behandelt uitsluitend fsc-properties.*
+  - *De brontekst vermeldt de publicatie URL gitdocumentatie.logius.nl/publicatie/fsc/logging/ maar geeft geen versienummer. Versie 'v1.1.0' wordt nergens in de bron genoemd.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-properties](https://logius-standaarden.github.io/fsc-properties)
-  - *De brontekst gaat over de FSC Properties extension en bevat geen informatie over fsc-external-contract of enige versie daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-regulated-area](https://github.com/logius-standaarden/fsc-regulated-area)
-  - *fsc-external-contract wordt niet genoemd in de brontekst. De FSC-repositories en publicaties die worden opgesomd zijn: fsc-core, fsc-logging, fsc-properties, fsc-regulated-area en fsc-test-suite. Geen verwijzing naar een external-contract extensie of bijbehorende publicatie-URL.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/fsc-external-contract](https://github.com/logius-standaarden/fsc-external-contract)
-  - *De brontekst is de GitHub-repositorypagina van fsc-external-contract en vermeldt 'No releases published'. Er staat geen informatie over een consultatieversie CV v1.0.0 of publicatie op gitdocumentatie.logius.nl. Het ontbreken van releases is consistent met 'nog niet definitief vastgesteld', maar bevestigt de specifieke claim over CV v1.0.0 en de publicatie-URL niet.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-extensie-template](https://github.com/logius-standaarden/fsc-extensie-template)
-  - *De brontekst bevat geen informatie over fsc-external-contract of consultatieversies.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/fsc-extensie-template](https://logius-standaarden.github.io/fsc-extensie-template)
-  - *De brontekst bevat geen informatie over fsc-external-contract of een consultatieversie CV v1.0.0.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/fsc-test-suite](https://github.com/logius-standaarden/fsc-test-suite)
-  - *De brontekst maakt geen melding van fsc-external-contract, een consultatieversie, of een publicatielocatie op gitdocumentatie.logius.nl. De bron gaat uitsluitend over de FSC Test Suite.*
+  - *De brontekst betreft de FSC Properties extension. Er is geen vermelding van fsc-logging, versie v1.1.0, of een publicatie-URL voor logging.*
 </details>
+
+### `ls-fsc-0009` — SKILL.md:54 *(§ Stap 1: Contract aanmaken)*
+
+> De consumer maakt een Contract aan met daarin een ServiceConnectionGrant dat specificeert welke service de consumer wil afnemen en bij welke provider.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Service Connectivity Flow
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The Service consumer creates a Contract with a Service Connection Grant. This Grant contains the details of the Service and the consumer.
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > The Manager of the API consumer creates a ServiceConnectionGrant containing the Property delegation.connection.external_contract_reference ... Contract Transmission : The Manager of the API consumer creates a Contract containing the ServiceConnectionGrant and transmits it to the Manager of the API provider.
+  - *De bron beschrijft de ServiceConnectionGrant in de context van de External Contract extensie. De kern van de claim (consumer maakt Contract met ServiceConnectionGrant aan) wordt bevestigd, al is dit de delegatie-variant.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *Contracts en ServiceConnectionGrants zijn FSC Core-onderwerpen; de Logging-extensiebron behandelt dit niet.*
+
+### `ls-fsc-0010` — SKILL.md:58 *(§ Stap 2: Contract ondertekenen door consumer)*
+
+> De consumer ondertekent het contract cryptografisch met zijn eigen certificaat; de handtekening bevat de certificate thumbprint (SHA-256).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Service Connectivity Flow
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The JWS MUST specify the certificate thumbprint of the keypair used to create the digital signature using the x5t#S256 section 4.1.8 of [RFC7515] field of the JOSE Header [...] Within FSC both Certificate thumbprints and Public Key thumbprints uses the sha256 thumbprint.
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > "cnf" : { "x5t#S256" : "06QekfpQ2IkYWhXyZqz3T1llvPEqDYYO0UyETSr7QdU" }
+  - *De bron toont de cnf/x5t#S256 thumbprint in het access token voorbeeld, maar beschrijft niet expliciet dat de consumer het contract cryptografisch ondertekent met zijn certificaat. De signing van het contract zelf wordt niet beschreven in deze extensie-spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *Cryptografisch ondertekenen van contracten met certificate thumbprint is een FSC Core-onderwerp.*
+
+### `ls-fsc-0013` — SKILL.md:70 *(§ Stap 5: Access token verkrijgen)*
+
+> De consumer vraagt een access token aan bij de Manager van de provider via OAuth 2.0 Client Credentials grant (grant_type=client_credentials, scope=<GrantHash>, client_id=<PeerID>).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Service Connectivity Flow / token aanvraag
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > Access tokens are obtained using the Client Credentials flow section 4,4 of [RFC6749]. [...] GrantHash of a Service Connection grant or Delegated Service Connection grant provided in the scope field. PeerID of the Peer making the request in the client_id field client_credentials in the grant_type field.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *OAuth 2.0 Client Credentials token-aanvraag bij de Manager is een FSC Core-onderwerp.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *OAuth 2.0 Client Credentials grant, grant_type=client_credentials, scope=<GrantHash>, client_id=<PeerID> worden niet beschreven in deze bron.*
+
+### `ls-fsc-0014` — SKILL.md:89 *(§ Stap 6: Verzoek via Outway naar Inway)*
+
+> Het access token wordt meegegeven in de `Fsc-Authorization` header bij verzoeken van de Outway naar de Inway.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC Service Connectivity Flow
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The Outway MUST include an access token in the HTTP header Fsc-Authorization when proxying the HTTP request to the Inway.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *De `Fsc-Authorization` header is een FSC Core-onderwerp. De Logging-bron vermeldt alleen de `Fsc-Transaction-Id` header.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *De `Fsc-Authorization` header wordt niet genoemd in deze bron.*
+
+### `ls-fsc-0016` — SKILL.md:170 *(§ Access Token (JWT))*
+
+> Het JWT access token bevat de claims: sub (PeerID consumer), iss (PeerID provider), svc (servicenaam), aud (URL Inway), gth (Grant Hash), gid (Group ID), cnf (x5t#S256 thumbprint), exp en nbf.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC access token (JWT)
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > gth(string): The hash of the Grant [...] gid(string): The ID of the Group sub(string): [...] iss(string): [...] svc(string): Name of the Service aud(string): [...] URI of the Inway providing the Service [...] exp(int): Expiration time [...] nbf(int): Not before [...] cnf(object): x5t#S256(string): The thumbprint of the certificate
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > accessToken.gth --> logRecord.grant_hash accessToken.sub --> logRecord.source.outway_peer_id accessToken.iss --> logRecord.destination.service_peer_id accessToken.svc --> logRecord.service_name
+  - *De bron bevestigt indirect de claims sub, iss, svc en gth door ze als velden uit het access token te benoemen in de logging-mapping. Claims aud, gid, cnf, exp en nbf worden in deze bron niet vermeld.*
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > "gid" : "fsc.group.example.id" , "gth" : "$1$3$n4kellB6p2..." , "sub" : "12345678901234567890" , "iss" : "12345678901234567891" , "svc" : "test" , "aud" : "https://inway.organization-b.open-fsc.localhost:443" , "exp" : 1493726400 , "nbf" : 1493722800 , "cnf" : { "x5t#S256" : "06QekfpQ2IkYWhXyZqz3T1llvPEqDYYO0UyETSr7QdU" }
+  - *Het JWT voorbeeld in de bron bevat alle genoemde claims (sub, iss, svc, aud, gth, gid, cnf, exp, nbf). Echter bevat het ook de prp claim die de claim niet noemt. De claim is inhoudelijk correct voor de genoemde claims.*
+
+### `ls-fsc-0017` — SKILL.md:184 *(§ Access Token (JWT))*
+
+> De `cnf` claim bindt het token aan het specifieke certificaat van de consumer, waardoor token-diefstal wordt voorkomen (certificate-bound tokens).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC access token / certificate binding
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > The access token is a certificate-bound access token as specified in section 3 of [RFC8705] [...] cnf(object): x5t#S256(string): The thumbprint of the certificate that is allowed to use the access token.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *Certificate-bound tokens via de cnf-claim zijn een FSC Core-onderwerp; de Logging-bron behandelt dit niet inhoudelijk.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *De bron toont de cnf claim in het JWT voorbeeld maar beschrijft niet expliciet het doel van certificate binding of het voorkomen van token-diefstal.*
+
+### `ls-fsc-0022` — SKILL.md:252 *(§ HTTP-vereisten)*
+
+> mTLS is verplicht: zowel client als server presenteren een certificaat bij FSC-verbindingen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC netwerkconfiguratie / HTTP-vereisten
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > Connections between Inways, Outways, Managers of a Group are mTLS connections based on X.509 certificates [...] The Outway MUST use mTLS when connecting to Inways [...] The Inway MUST only accept connections from Outways using mTLS [...] The Manager MUST only accept mTLS connections from other external Managers
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *mTLS-verplichting is een FSC Core-onderwerp; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *mTLS als verplichting wordt niet beschreven in deze bron.*
+
+### `ls-fsc-0023` — SKILL.md:260 *(§ Transactie-ID)*
+
+> Elk FSC-verzoek krijgt een uniek transaction_id mee via de `Fsc-Transaction-Id` HTTP header, dat door alle componenten wordt doorgegeven.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Logging Extensie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > The Outway will generate a unique ID for the Transaction and write a record to the TransactionLog before proxying the request to the Inway. [...] The Outway proxies the request to the Inway and includes the TransactionID in the HTTP header Fsc-Transaction-Id. The Inway reads the unique ID from the request.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  - *De FSC Logging extensie en Fsc-Transaction-Id header worden niet beschreven in deze brontekst (fsc-core). De bron verwijst alleen naar FSC Logging als aanbevolen extensie zonder details.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *De `Fsc-Transaction-Id` header wordt niet vermeld in deze bron.*
+
+### `ls-fsc-0028` — SKILL.md:496 *(§ Foutafhandeling)*
+
+> De `Fsc-Error-Code` header wordt altijd meegegeven bij foutresponses van de Inway, naast de HTTP status code.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC Inway foutafhandeling
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "In case of an error within the scope of FSC these components MUST return the HTTP header Fsc-Error-Code which MUST contain the code specifying the error."
+  - *De bron vermeldt dit voor Inway en Outway (beide hebben een 'single endpoint which proxies HTTP requests'). Sectie 4.7.2.2 bevestigt specifiek voor de Inway de verplichting tot het foutafhandelingsformaat.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *De bron introduceert foutcodes voor Inway (TRANSACTION_LOG_WRITE_ERROR, INVALID_LOG_RECORD_ID, MISSING_LOG_RECORD_ID) maar vermeldt de `Fsc-Error-Code` header niet expliciet als verplichte header bij foutresponses.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *De `Fsc-Error-Code` header wordt niet vermeld in deze bron.*
+
+### `ls-fsc-0029` — SKILL.md:496 *(§ Foutafhandeling)*
+
+> De Outway geeft HTTP 405 met ERROR_CODE_METHOD_UNSUPPORTED bij een niet-ondersteunde CONNECT methode.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Outway foutafhandeling
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "ERROR_CODE_METHOD_UNSUPPORTED 405 The Outway received a request with an HTTP Method that is not supported. The CONNECT method is not supported."
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *HTTP 405 met ERROR_CODE_METHOD_UNSUPPORTED is een FSC Core-foutcode voor de Outway; de Logging-bron introduceert andere Outway-foutcodes maar niet deze.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *HTTP 405 en ERROR_CODE_METHOD_UNSUPPORTED worden niet vermeld in deze bron.*
+
+### `ls-fsc-0030` — reference.md:11 *(§ Peer)*
+
+> Een Peer wordt uniek geïdentificeerd door een PeerID, afgeleid uit het subject van het X.509-certificaat dat de Peer gebruikt voor mTLS-verbindingen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC architectuur / Peer
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "Each Peer MUST have a unique identifier within the Group, this identifier is called the PeerID. The PeerID is determined by at least one element from the subject field section 4.1.2.6 of [RFC5280] of an X.509 certificate."
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *PeerID en X.509-certificaat-afleiding zijn FSC Core-onderwerpen; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *PeerID en de afleiding ervan uit het X.509-certificaat subject worden niet beschreven in deze bron.*
+
+### `ls-fsc-0032` — reference.md:19 *(§ Inway)*
+
+> De Inway is een reverse proxy die inkomende verbindingen van andere Peers afhandelt, het Fsc-Authorization JWT valideert, en bij succesvolle validatie het verzoek doorstuurt naar de achterliggende service.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC architectuur / Inway
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "The Inway is used by Peers to offer a Service to other Peers. The Inway is a Reverse proxy that handles incoming connections from Outways and routes the request to the correct Service. [...] The Inway MUST validate the access token provided in the HTTP Fsc-Authorization. [...] The Inway MUST proxy the HTTP request to the Service specified in the field svc of the access token."
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > The Inway also writes a log record containing the unique ID to its own TransactionLog before proxying the request to the Service.
+  - *De bron bevestigt dat de Inway proxying doet naar de service. JWT-validatie en Fsc-Authorization worden niet in deze Logging-bron behandeld; die zijn FSC Core-onderwerpen.*
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > The Inway MUST include External Contract Reference properties in the Transaction Log records as additional_data when the Logging extension is used.
+  - *De bron noemt de Inway alleen in de context van transaction logging. De beschrijving van Inway als reverse proxy die JWT valideert staat niet in deze bron; die is in FSC Core.*
+
+### `ls-fsc-0033` — reference.md:29 *(§ Outway)*
+
+> De Outway is een forward proxy die uitgaande verbindingen beheert: verwerft een access token via OAuth 2.0 Client Credentials bij de Manager van de aanbieder, voegt het toe als Fsc-Authorization header, en stuurt via mTLS naar de Inway.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC architectuur / Outway
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "The Outway is used by Peers to connect to a Service. The Outway functions as a forwarding proxy [...] Access tokens are obtained using the Client Credentials flow section 4,4 of [RFC6749]. [...] The Outway MUST include an access token in the HTTP header Fsc-Authorization when proxying the HTTP request to the Inway. [...] The Outway MUST use mTLS when connecting to Inways with an X.509 certific...
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > The Outway will generate a unique ID for the Transaction and write a record to the TransactionLog before proxying the request to the Inway.
+  - *De bron bevestigt dat de Outway verzoeken proxiet naar de Inway, maar OAuth 2.0 Client Credentials token-aanvraag en Fsc-Authorization header zijn FSC Core-onderwerpen die hier niet worden behandeld.*
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > The Outway MUST include External Contract Reference properties in the Transaction Log records as additional_data when the Logging extension is used.
+  - *De bron noemt de Outway alleen voor transaction logging. De beschrijving van Outway als forward proxy met OAuth 2.0 token acquisitie staat niet in deze bron.*
+
+### `ls-fsc-0034` — reference.md:39 *(§ Manager)*
+
+> De Manager fungeert als OAuth 2.0 Authorization Server voor het uitgeven van access tokens en beheert het aanmaken, ondertekenen, accepteren en intrekken van Contracts.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC architectuur / Manager
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "The Manager is responsible for: [...] Providing access tokens [...] Receiving Contracts [...] Validating Contracts [...] Receiving Contract signatures (accept, reject, revoke) [...] Validating Contract signatures"
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  > A Peer can request the records of the TransactionLog through the Manager of a Peer. The Manager returns only logs records that involve the Peer requesting the log records.
+  - *De bron bevestigt de Manager-rol voor het verstrekken van TransactionLog-records. De OAuth 2.0 Authorization Server-rol en contractbeheer zijn FSC Core-onderwerpen die hier niet worden behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *De Manager als OAuth 2.0 Authorization Server wordt niet beschreven in deze bron. De Manager wordt wel genoemd als component dat Contracts aanmaakt en verzendt.*
+
+### `ls-fsc-0035` — reference.md:49 *(§ Directory)*
+
+> De Directory is een speciale Manager die fungeert als centraal register voor service- en peer-discovery; Peers publiceren hun services via een ServicePublicationGrant in een contract.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC architectuur / Directory
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "The Directory is a Manager chosen by the Group to act as a Directory. The Directory is used by Peers to: Discover Services, Discover Peers, Publish Services, Register themselves" en "Service publication is accomplished by offering a Contract to the Directory which contains one or more (Delegated)ServicePublicationGrants"
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  > The Contract is received by the Peer acting as Directory... Grant Creation : The Manager of the API provider creates a ServicePublicationGrant... Service Publication : The Service is now published in the Directory on behalf of the delegator organization
+  - *De bron bevestigt dat de Directory services registreert via ServicePublicationGrants in contracten. De omschrijving van Directory als 'speciale Manager voor service- en peer-discovery' staat niet expliciet in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *De Directory als centraal register en ServicePublicationGrants zijn FSC Core-onderwerpen; niet behandeld in deze Logging-bron.*
+
+### `ls-fsc-0036` — reference.md:66 *(§ mTLS met X.509-certificaten)*
+
+> Alle verbindingen tussen FSC-componenten worden beveiligd met mutual TLS (mTLS); beide partijen presenteren een X.509-certificaat en valideren het certificaat van de tegenpartij.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC trust model / mTLS
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "Connections between Managers, Inways, Outways use Mutual Transport Layer Security (mTLS) with X.509 certificates." en "The Inway MUST only accept connections from Outways using mTLS with an X.509 certificate signed by the chosen TA of the Group."
+  - *De bron bevestigt mTLS voor alle componenten. Dat beide partijen het certificaat van de tegenpartij valideren, volgt direct uit de definitie van mTLS en wordt impliciet bevestigd door de eis dat certificaten door de TA ondertekend moeten zijn.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *mTLS-verplichting voor alle verbindingen is een FSC Core-onderwerp; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *mTLS als verplichting voor alle verbindingen tussen FSC-componenten wordt niet beschreven in deze bron.*
+
+### `ls-fsc-0037` — reference.md:70 *(§ Trust Anchors)*
+
+> Alle Peers moeten certificaten gebruiken die zijn uitgegeven onder een gedeelde Trust Anchor.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** FSC trust model / Trust Anchors
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/core](https://gitdocumentatie.logius.nl/publicatie/fsc/core)
+  > "Every Peer in a Group MUST accept the same TA(s) that are defined in the Trust Anchor List defined by the Group." en "Components in the Group are configured to accept the same (Sub-) Certificate Authorities (CA) as defined in the Trust Anchors list (TA)."
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging)
+  - *Trust Anchors en gedeelde CA-vereisten zijn FSC Core-onderwerpen; niet behandeld in deze Logging-bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/fsc/ext](https://gitdocumentatie.logius.nl/publicatie/fsc/ext)
+  - *Trust Anchors en de verplichting om certificaten onder een gedeelde Trust Anchor te gebruiken worden niet vermeld in deze bron.*
 
 </details>

--- a/skills/ls-iam/audit.md
+++ b/skills/ls-iam/audit.md
@@ -1,0 +1,938 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-iam — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 8 | 12% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 10 | 15% |
+| UNGROUNDED | 29 | 44% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 19 | 29% |
+
+*Geverifieerd met sonnet, 16 calls, $2.1815.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (8)
+
+### `ls-iam-0017` — SKILL.md:98 *(§ Betrouwbaarheidsniveaus (Levels of Assurance))*
+
+> Het OIDC NL GOV profiel definieert drie betrouwbaarheidsniveaus (Laag, Substantieel, Hoog) conform de eIDAS-verordening.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC NL GOV profiel - betrouwbaarheidsniveaus
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron definieert geen drie betrouwbaarheidsniveaus (Laag, Substantieel, Hoog) zelf. Het profiel verwijst naar eIDAS LoA-waarden en gebruikt 'substantial' en 'high' als voorbeelden, maar definieert geen drie niveaus als eigen onderdeel van het profiel. De eIDAS-niveaus worden als extern gegeven behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Betrouwbaarheidsniveaus conform eIDAS worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel, niet het OIDC NL GOV profiel. Betrouwbaarheidsniveaus conform eIDAS worden niet gedefinieerd.*
+</details>
+
+### `ls-iam-0025` — SKILL.md:139 *(§ AuthZEN NL GOV)*
+
+> Het AuthZEN NL GOV profiel specificeert een architectuur voor geëxternaliseerde autorisatie via een centraal PDP.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV profiel
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De brontekst betreft het OIDC NL GOV profiel. AuthZEN wordt nergens in de bron genoemd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *AuthZEN NL GOV profiel wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. AuthZEN en geëxternaliseerde autorisatie via een PDP worden niet besproken.*
+</details>
+
+### `ls-iam-0026` — SKILL.md:156 *(§ Evaluation endpoint)*
+
+> Het AuthZEN evaluation endpoint is POST /access/v1/evaluation met Content-Type application/json.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV profiel - evaluation endpoint
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *AuthZEN en het evaluation endpoint komen niet voor in deze brontekst.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Het AuthZEN evaluation endpoint wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. Het AuthZEN evaluation endpoint wordt niet besproken.*
+</details>
+
+### `ls-iam-0027` — SKILL.md:163 *(§ Request formaat)*
+
+> Een AuthZEN autorisatieverzoek bestaat uit vier elementen: subject, action, resource en context (optioneel).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV profiel - request formaat
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *AuthZEN autorisatieverzoekformaat (subject, action, resource, context) wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *AuthZEN autorisatieverzoek-elementen worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. AuthZEN autorisatieverzoeken worden niet besproken.*
+</details>
+
+### `ls-iam-0028` — SKILL.md:197 *(§ Response formaat)*
+
+> Het PDP retourneert een `decision` (boolean: true voor toestaan, false voor weigeren) en optioneel een `context` met aanvullende informatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV profiel - response formaat
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *PDP-responses en het AuthZEN decision-formaat komen niet voor in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *AuthZEN PDP response formaat wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. AuthZEN PDP responses worden niet besproken.*
+</details>
+
+### `ls-iam-0029` — SKILL.md:223 *(§ Authorization Decision Log)*
+
+> De ADL-werkversie volgt sinds april 2026 een OpenTelemetry-vorm op basis van het AuthZEN-informatiemodel.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Authorization Decision Log
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL (Authorization Decision Log) en OpenTelemetry worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Authorization Decision Log en OpenTelemetry worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. De ADL-werkversie en OpenTelemetry worden niet besproken.*
+</details>
+
+### `ls-iam-0033` — SKILL.md:234 *(§ Record-velden)*
+
+> Het ADL `status` veld kent drie waarden: `Unset` (default, ook bij denial), `Ok`, of `Error` (PDP kon geen beslissing produceren).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Authorization Decision Log - status
+
+- **NOT_FOUND** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
+  - *De W3C Trace Context spec behandelt geen statuswaarden zoals `Unset`, `Ok` of `Error`. Dit zijn OpenTelemetry-concepten voor span-status, niet gedefinieerd in deze specificatie.*
+
+### `ls-iam-0046` — reference.md:63 *(§ OIN Structuur)*
+
+> Een OIN bestaat uit 20 cijfers waarbij de eerste 8 cijfers de organisatie identificeren en de resterende cijfers een volgnummer zijn.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel - structuur
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron vermeldt OIN niet als afkorting in de glossary, maar geeft geen structuurbeschrijving (20 cijfers, eerste 8 voor organisatie-ID). De OIN-structuur wordt niet behandeld in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *OIN-structuur (20 cijfers) wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De structuur van een OIN (20 cijfers, eerste 8 voor organisatie, rest volgnummer) wordt niet beschreven in deze bron.*
+</details>
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (10)
+
+### `ls-iam-0008` — SKILL.md:62 *(§ Verplichte beveiligingseisen)*
+
+> Implicit grant en Resource Owner Password Credentials zijn expliciet verboden vanwege bekende beveiligingsrisico's.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** OAuth-NL-profiel - grant types
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > Therefore, the Implicit Flow and Hybrid Flow MUST NOT be used. Also, the IETF OAuth Working Group is removing support for the Implicit Flow from the OAuth 2.1 specification [OAuth2.1] for the same reasons.
+  - *De bron verbiedt expliciet de Implicit Flow (MUST NOT). Resource Owner Password Credentials wordt niet expliciet vermeld in de bron. Alleen het Implicit Flow verbod is gedekt.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Implicit grant en Resource Owner Password Credentials worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron noemt implicit grant wel in de discovery response ('response_types_supported': ['code', 'token']) en in de grant_types_supported lijst, maar verbiedt deze grant types niet expliciet. Resource Owner Password Credentials wordt nergens vermeld. Er is geen MUST NOT voor deze grant types.*
+
+### `ls-iam-0015` — SKILL.md:76 *(§ Client authenticatie)*
+
+> mTLS is toegestaan (MAY) per het OAuth NL profiel als gelijkwaardig alternatief voor client authenticatie per het OIDC NL GOV profiel, bij voorkeur met PKIoverheid-certificaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth-NL-profiel / OIDC NL GOV - client authenticatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > Confidential Clients, as defined in Section 4.1, MUST authenticate to the OpenID Provider using either: a JWT assertion [...] using only the private_key_jwt method [...]; or mutually authenticated TLS, as specified in [RFC8705]. [...] In case PKIoverheid certificates are used, the certificate and entire certificate chain up until the root certificate MUST be included
+  - *De bron bevestigt mTLS als toegestaan alternatief (MAY in de zin van een van beide opties). De verwijzing naar PKIoverheid-certificaten staat in de context van public keys/JWK, niet specifiek als voorkeur voor mTLS client authenticatie. 'Bij voorkeur met PKIoverheid-certificaat' voor mTLS client auth is niet expliciet gesteld in de bron.*
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > In addition to private_key_jwt , the client authentication method tls_client_auth [rfc8705] MAY also be used. [...] In case the Authorization Server, Resource Server and client are not operated under responsibility of the same organisation, each party MUST use PKIoverheid certificates with OIN.
+  - *De bron bevestigt dat mTLS (tls_client_auth) MAY worden gebruikt als alternatief, en dat PKIoverheid-certificaten verplicht zijn tussen verschillende organisaties. De claim stelt echter 'bij voorkeur met PKIoverheid-certificaat' als een SHOULD/voorkeur, terwijl de bron PKIoverheid MUST stelt voor cross-organisatie situaties. Bovendien is de gelijkwaardigheid met het OIDC NL GOV profiel niet in deze bron bevestigd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *mTLS als alternatief voor client authenticatie wordt niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0016` — SKILL.md:94 *(§ OpenID Connect NL GOV Profiel)*
+
+> Het OIDC NL GOV profiel bouwt voort op OpenID Connect Core 1.0 en het iGov-profiel.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC NL GOV profiel
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > This profile is based upon the 'International Government Assurance Profile (iGov) for OpenID Connect 1.0' [OpenID.iGov] as published by the OpenID Foundation. It should be considered a fork of this profile [...] This profile builds on top of, and inherits all properties of, the NL GOV Assurance profile for OAuth 2.0 [OAuth2.NLGov].
+  - *De bron bevestigt dat het profiel voortbouwt op iGov en op OAuth2.NLGov. OpenID Connect Core 1.0 wordt als basis gebruikt maar de bron zegt het profiel bouwt 'op' het iGov-profiel en OAuth2.NLGov, niet expliciet 'op OpenID Connect Core 1.0' direct. Indirect klopt het wel — iGov zelf bouwt op Core. De claim is grotendeels gedekt.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron beschrijft het OAuth-NL beheermodel, niet het OIDC NL GOV profiel of diens relatie met OpenID Connect Core 1.0 of het iGov-profiel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron is het OAuth NL profiel. Het OIDC NL GOV profiel en zijn relatie met OpenID Connect Core 1.0 worden hier niet beschreven.*
+
+### `ls-iam-0019` — SKILL.md:110 *(§ Verplichte claims in het ID Token)*
+
+> Het ID Token MOET minimaal de claims sub, iss, aud, exp, iat en nonce bevatten per het OIDC NL GOV profiel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token claims
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > iss REQUIRED [...] aud REQUIRED [...] sub REQUIRED [...] nonce REQUIRED [...] exp, iat, nbf REQUIRED. The expiration, issued at, and not before timestamps indicate when the token expires, was issued and becomes valid
+  - *De bron bevestigt sub, iss, aud, exp, iat en nonce als REQUIRED in het ID Token (sectie 5.2.2). nbf is ook REQUIRED. De claim stelt 'minimaal sub, iss, aud, exp, iat en nonce', wat klopt — al mist de claim nbf en jti (ook REQUIRED per de bron). De genoemde claims zijn allemaal gedekt; de claim is correct maar niet volledig ten opzichte van wat de bron vereist.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *ID Token claims worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. ID Token claims per het OIDC NL GOV profiel komen niet aan bod.*
+
+### `ls-iam-0021` — SKILL.md:124 *(§ ID Token validatie)*
+
+> Bij het valideren van een OIDC ID Token MOETEN de JWS handtekening, iss, aud, nonce, exp, iat, acr en jti worden geverifieerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > All Clients MUST validate the signature of an ID Token before accepting it. Clients MUST verify the following in received ID tokens: iss [...] aud [...] nonce [...] exp, iat, nbf [...] acr [...] represents
+  - *De bron bevestigt JWS handtekening, iss, aud, nonce, exp/iat, en acr als te valideren velden. De claim noemt ook 'jti', maar de bron schrijft jti-validatie niet expliciet voor als verificatieplicht voor clients — jti is een REQUIRED veld in het ID Token (voor de OP), maar niet expliciet als client-validatieverplichting opgesomd. nbf wordt wel genoemd maar de claim heeft 'exp, iat' zonder nbf. De claim noemt niet 'represents' terwijl de bron dat wel verplicht stelt.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *ID Token validatie wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. ID Token validatie per OIDC NL GOV profiel wordt niet beschreven.*
+
+### `ls-iam-0024` — SKILL.md:133 *(§ ID Token validatie)*
+
+> De `jti` claim MOET uniek zijn; bewaar voldoende lang om hergebruik te detecteren.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > jti REQUIRED . A unique identifier for the token, which can be used to prevent reuse of the token. The value of jti MUST uniquely identify the ID Token between sender and receiver for at least 12 months.
+  - *De bron bevestigt dat jti uniek MOET zijn (minimaal 12 maanden). De claim dat clients jti voldoende lang moeten bewaren om hergebruik te detecteren is impliciet aanwezig maar niet als expliciete client-verplichting geformuleerd — de bron formuleert jti als OP-verplichting bij het aanmaken van het token.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > jti a unique identifier generated by the client for this authentication. This identifier MUST contain at least 128 bits of entropy and MUST NOT be re-used by any subsequent authentication token.
+  - *De bron bevestigt de uniciteit van jti en het verbod op hergebruik, maar dit betreft client assertion JWTs (token endpoint), niet ID Token validatie. De claim stelt 'bewaar voldoende lang om hergebruik te detecteren', wat niet expliciet in de bron staat.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *jti claim uniciteit wordt niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0031` — SKILL.md:229 *(§ Record-velden)*
+
+> Het ADL veld `trace_id` is verplicht en bestaat uit 16 byte hex (32 chars) conform W3C Trace Context, cryptografisch random.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - record-velden
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
+  > trace-id = 32 HEXDIGLC ; 16 bytes array identifier. All zeroes forbidden
+  - *De bron bevestigt dat trace-id 16 bytes (32 hex chars) is conform W3C Trace Context. De eis van 'cryptografisch random' wordt ondersteund door sectie 8.2: 'Randomly generated value of trace-id SHOULD be preferred', maar dat is een SHOULD, geen MUST. Het ADL-specifieke veld `trace_id` en de verplichting ervan zijn niet in deze bron te vinden — dat is IAM/ADL-specificatie, niet W3C Trace Context.*
+
+### `ls-iam-0045` — reference.md:55 *(§ OIN (Organisatie Identificatie Nummer))*
+
+> Het OIN is opgenomen in het `subject.serialNumber` veld van PKIoverheid-certificaten voor server- en client-authenticatie (mTLS).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel - PKIoverheid-certificaten
+
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > In case PKIoverheid certificates are used, the certificate and entire certificate chain up until the root certificate MUST be included as either an x5c or as x5u parameter, according to [RFC7517] Sections 4.6 and 4.7.
+  - *De bron vermeldt PKIoverheid-certificaten in de context van JWK-sets voor OIDC, maar zegt niets specifieks over het OIN in het subject.serialNumber veld voor mTLS. Dat is een aanvullende bewering over PKIoverheid-certificaatstructuur die buiten de scope van deze spec valt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > In case the Authorization Server, Resource Server and client are not operated under responsibility of the same organisation, each party MUST use PKIoverheid certificates with OIN.
+  - *De bron bevestigt dat OIN wordt gebruikt in PKIoverheid-certificaten, maar beschrijft niet specifiek dat het OIN in het `subject.serialNumber` veld staat.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *OIN in PKIoverheid-certificaten wordt niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0047` — reference.md:89 *(§ Toegangsbeheer en Scopes)*
+
+> De authorization server MOET controleren of gevraagde scopes geldig zijn, de client geautoriseerd is, en de resource owner akkoord gaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth-NL-profiel - scope-validatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > Authorization servers MAY restrict certain scopes from use by dynamically registered systems or public clients. [...] Client authorization requests containing scopes that are outside their permission MUST be rejected.
+  - *De bron bevestigt dat de authorization server scopes kan beperken en verzoeken buiten de scope-rechten moet afwijzen, maar bevat geen expliciete drieledige controle (geldigheid, client-autorisatie én resource owner akkoord) als één gecombineerde MUST-vereiste.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt scope in de context van OIDC-verzoeken (scope MUST contain at least openid), maar bevat geen expliciete normering dat de authorization server MUST controleren of gevraagde scopes geldig zijn, de client geautoriseerd is, en de resource owner akkoord gaat als gecombineerde verplichting. Dit is een OAuth-profiel-vereiste die in de NL GOV OAuth-spec thuis hoort.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Scope-validatie door de authorization server wordt niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0053` — reference.md:151 *(§ Client Registratie)*
+
+> Voor native clients met per-instance registratie is dynamische client registratie verplicht (MUST); voor web- en browser-applicaties blijft handmatige registratie toegestaan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - client registratie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > In case a native Client is using per-instance registration, the Client MUST use Dynamic Registration. [...] Clients SHOULD use Dynamic Registration as per [RFC7591] to reduce manual labor and the risks of configuration errors.
+  - *De bron ondersteunt dat native clients met per-instance registratie MUST Dynamic Registration gebruiken. Voor web- en browser-applicaties zegt de bron SHOULD (niet dat handmatige registratie expliciet toegestaan blijft). De claim dat 'handmatige registratie toegestaan blijft' voor web/browser is een inferentie die de bron niet expliciet bevestigt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > Native clients MUST either: use dynamic client registration to obtain a separate client id for each instance, or act as a public client by using a common client id and use PKCE [RFC7636] to protect calls to the token endpoint.
+  - *De bron bevestigt dat native clients met per-instance registratie dynamische client registratie MUST gebruiken, maar de claim stelt ook dat voor web- en browser-applicaties handmatige registratie toegestaan blijft — dit wordt niet expliciet zo geformuleerd in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Dynamische client registratie voor native clients wordt niet besproken in dit beheermodeldocument.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (29)
+
+### `ls-iam-0001` — SKILL.md:36 *(§ Versiemodel)*
+
+> OpenID.NLGov (v1.0.1) en SAML zijn beide verplicht ('pas-toe-of-leg-uit') sinds 21-09-2023.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie - Authenticatie-standaarden
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron is de technische specificatie van OpenID NLGov 1.0.1 zelf. Informatie over 'pas-toe-of-leg-uit'-status bij Forum Standaardisatie of de datum 21-09-2023 staat niet in deze bron. De bron vermeldt wel 'September 18, 2023' als publicatiedatum, maar niet de verplichtstellingsstatus door Forum Standaardisatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De brontekst gaat over het beheermodel van het OAuth-NL profiel. OpenID.NLGov en SAML worden niet besproken; de datum 21-09-2023 wordt nergens genoemd.*
+
+### `ls-iam-0002` — SKILL.md:36 *(§ Versiemodel)*
+
+> Voor nieuwe implementaties wordt OIDC aanbevolen; bestaande SAML-koppelingen blijven ondersteund.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Authenticatie-standaarden NL overheid
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron bevat geen aanbeveling over migratie van SAML naar OIDC of het ondersteunen van bestaande SAML-koppelingen. Dit is beleid van Forum Standaardisatie, niet inhoud van de technische spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron behandelt het beheermodel van OAuth-NL, niet de aanbeveling van OIDC versus SAML voor nieuwe implementaties.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt uitsluitend het OAuth NL profiel. OIDC versus SAML-aanbevelingen voor nieuwe implementaties komen niet voor in deze tekst.*
+</details>
+
+### `ls-iam-0011` — SKILL.md:67 *(§ Token specificaties)*
+
+> Access tokens MOETEN het JWT-formaat (RFC 9068) hebben per het OAuth NL profiel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth-NL-profiel - access tokens
+
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9068.txt](https://www.rfc-editor.org/rfc/rfc9068.txt)
+  - *RFC 9068 definieert het JWT-profiel voor OAuth 2.0 access tokens als standaard, maar bevat geen verwijzing naar een 'OAuth NL profiel' of enige verplichting dat dit NL profiel JWT-formaat MOET gebruiken. De bron beschrijft de RFC zelf, niet een nationaal profiel dat daarnaar verwijst.*
+
+### `ls-iam-0030` — SKILL.md:223 *(§ Authorization Decision Log)*
+
+> Het ADL record-model is transport-onafhankelijk; OTLP wordt aanbevolen, maar elke transport is toegestaan zolang het record de gespecificeerde velden draagt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Authorization Decision Log - transport
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL transport-onafhankelijkheid en OTLP worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *ADL record-model en OTLP transport worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. ADL (Authorization Decision Log), OTLP en transport-onafhankelijkheid komen niet voor in deze bron.*
+</details>
+
+### `ls-iam-0032` — SKILL.md:231 *(§ Record-velden)*
+
+> Het ADL veld `parent_span_id` is conditioneel verplicht: verplicht bij upstream `traceparent`, alleen weglaatbaar bij root-span.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - record-velden
+
+- **NOT_FOUND** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
+  - *De W3C Trace Context spec definieert parent-id als veld in de traceparent header, maar bevat geen uitspraken over een ADL-veld `parent_span_id` of conditionele verplichtingen daaromtrent. Dit is ADL-specifieke logica buiten scope van deze bron.*
+
+### `ls-iam-0034` — SKILL.md:239 *(§ Record-velden)*
+
+> Een denial (decision: false) heeft status `Unset`, niet `Error` in het ADL.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - status
+
+- **NOT_FOUND** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
+  - *De W3C Trace Context spec bevat geen informatie over ADL-statusvelden of de relatie tussen een authorization denial en een `Unset`-status. Dit valt buiten het onderwerp van deze bron.*
+
+### `ls-iam-0035` — SKILL.md:253 *(§ `attributes.adl.core.*`)*
+
+> Een ADL-veld MOET in precies één van de twee locaties staan: `attributes` (source-referenties) of `body` (raw data).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - attributes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL attributes/body-velden worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *ADL-velden en hun locaties worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL record-model met attributes/body-velden komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0036` — SKILL.md:264 *(§ `attributes.adl.core.*`)*
+
+> Aanvullende ADL attribute keys volgen het patroon `<vendor>.<area>.<name>`. Onbekende keys MOETEN door consumers worden genegeerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - attributes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL attribute key-patronen worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *ADL attribute key patronen worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL attribute key patronen komen niet voor in deze bron.*
+</details>
+
+### `ls-iam-0037` — SKILL.md:296 *(§ Trace context en ingestion)*
+
+> Alle ADL-componenten (PEP, PDP, PIP, PAP) MOETEN W3C Trace Context propageren; `trace_id` blijft ongewijzigd over organisatiegrenzen, ook bij sampling=0.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - trace context
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *W3C Trace Context propagatie in ADL-context wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *W3C Trace Context propagatie in ADL-componenten wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *W3C Trace Context propagatie voor ADL-componenten (PEP, PDP, PIP, PAP) komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0038` — SKILL.md:296 *(§ Trace context en ingestion)*
+
+> ADL-records worden altijd geproduceerd ongeacht het sampled-bit in traceparent (sampling=0 geeft geen vrijstelling van logging).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - trace context
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL-logging ongeacht sampled-bit wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *ADL-records en het sampled-bit worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL-records en sampled-bit/sampling vrijstelling komen niet voor in deze bron.*
+</details>
+
+### `ls-iam-0039` — SKILL.md:296 *(§ Trace context en ingestion)*
+
+> Ingestion van ADL log records MOET idempotent zijn met `(trace_id, span_id)` of content-hash als sleutel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - ingestion
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron gaat over OpenID Connect NL GOV profiel. ADL (Authorization Decision Log) ingestion en idempotentie worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Idempotente ingestion van ADL log records wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Idempotente ingestion van ADL log records komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0040` — reference.md:9 *(§ SAML)*
+
+> SAML is samen met OpenID.NLGov (v1.0.1) verplicht als onderdeel van de gecombineerde vermelding 'Authenticatie-standaarden' op het Forum Standaardisatie (sinds 21-09-2023).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie - Authenticatie-standaarden
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron beschrijft de OIDC NL GOV standaard zelf, maar bevat geen informatie over de gecombineerde vermelding met SAML op het Forum Standaardisatie-lijst of de datum 21-09-2023.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De gecombineerde vermelding 'Authenticatie-standaarden' met SAML en OpenID.NLGov per 21-09-2023 wordt niet besproken in dit beheermodeldocument, dat alleen over OAuth-NL gaat.*
+
+### `ls-iam-0041` — reference.md:44 *(§ SAML Implementatiedetails)*
+
+> SAML assertions MOETEN worden ondertekend door de Identity Provider.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - security requirements
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt OpenID Connect, niet SAML. SAML-ondertekeningsvereisten voor assertions staan niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *SAML assertion signing wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *SAML assertions en ondertekening door de Identity Provider worden niet behandeld in deze OAuth-NL-profiel bron.*
+</details>
+
+### `ls-iam-0042` — reference.md:45 *(§ SAML Implementatiedetails)*
+
+> SAML assertions KUNNEN worden versleuteld voor de Service Provider.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** SAML - security requirements
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt OpenID Connect, niet SAML. SAML assertion-encryptie wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *SAML assertion encryptie wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *SAML assertion versleuteling voor de Service Provider komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0043` — reference.md:46 *(§ SAML Implementatiedetails)*
+
+> TLS MOET worden gebruikt voor alle SAML communicatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - security requirements
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt OpenID Connect, niet SAML. TLS-vereisten voor SAML-communicatie staan niet in deze spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *TLS-vereisten voor SAML communicatie worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Hoewel de bron TLS vereist voor OAuth-communicatie, behandelt zij geen SAML-specifieke TLS-vereisten.*
+</details>
+
+### `ls-iam-0044` — reference.md:47 *(§ SAML Implementatiedetails)*
+
+> SAML Metadata MOET worden ondertekend en periodiek worden gevalideerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - security requirements
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt OpenID Connect, niet SAML. SAML Metadata-ondertekening en -validatie worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *SAML Metadata ondertekening en validatie worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *SAML Metadata ondertekening en periodieke validatie komen niet voor in deze bron.*
+</details>
+
+### `ls-iam-0048` — reference.md:96 *(§ Pushed Authorization Requests (PAR))*
+
+> Pushed Authorization Requests (PAR) worden aanbevolen (RFC 9126) per het OAuth NL profiel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OAuth-NL-profiel - PAR
+
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9126.txt](https://www.rfc-editor.org/rfc/rfc9126.txt)
+  - *De bron is RFC 9126 zelf. De bron beschrijft de PAR-specificatie maar maakt geen melding van een 'OAuth NL profiel' of een Nederlandse aanbeveling. De claim gaat over het NL-profiel dat PAR aanbeveelt, wat buiten de scope van deze bron valt.*
+
+### `ls-iam-0050` — reference.md:138 *(§ Userinfo Endpoint)*
+
+> De OpenID Provider MOET gebruikers informeren over welke claims worden gedeeld en met welke Relying Parties.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - privacy
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron bevat geen verplichting dat de OpenID Provider gebruikers moet informeren over welke claims worden gedeeld en met welke Relying Parties. Privacy-overwegingen richten zich op dataminimalisatie, pairwise identifiers en encryptie, niet op een informatieplicht richting gebruikers.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Informatieplicht van de OpenID Provider richting gebruikers wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Informatieplicht van de OpenID Provider aan gebruikers over gedeelde claims en Relying Parties komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0052` — reference.md:151 *(§ Client Registratie)*
+
+> Het OIDC NL GOV profiel beveelt dynamische client registratie (RFC 7591) aan ('Clients SHOULD use Dynamic Registration').
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OIDC NL GOV profiel - client registratie
+
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7591.txt](https://www.rfc-editor.org/rfc/rfc7591.txt)
+  - *De brontekst is RFC 7591 zelf (de specificatie voor OAuth 2.0 Dynamic Client Registration). De claim gaat over wat het OIDC NL GOV profiel aanbeveelt ('Clients SHOULD use Dynamic Registration'). RFC 7591 bevat geen tekst over het NL GOV profiel of aanbevelingen daarin; die uitspraak staat in het NL GOV profiel-document, niet in RFC 7591.*
+
+### `ls-iam-0054` — reference.md:176 *(§ Trace context propagatie)*
+
+> Alle ADL-componenten MOETEN W3C Trace Context propageren en trace-continuïteit over componentgrenzen behouden. Een nieuwe `trace_id` MAG NIET worden gealloceerd binnen een lopende beslissingsflow.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Authorization Decision Log - trace context propagatie
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt OpenID Connect NL GOV. ADL (Authorization Decision Log) en W3C Trace Context worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *W3C Trace Context propagatie en verbod op nieuwe trace_id allocatie worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *W3C Trace Context propagatie en verbod op nieuwe trace_id allocatie binnen ADL-flows komen niet voor in deze bron.*
+</details>
+
+### `ls-iam-0055` — reference.md:178 *(§ Trace context propagatie)*
+
+> ADL-records zijn accountability records en MOETEN altijd worden geproduceerd, ongeacht sampling. ADL-emitters MOGEN het `sampled`-flag NIET wijzigen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - sampling
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt OpenID Connect NL GOV. ADL-records, accountability records en sampling-flags worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *ADL-records als accountability records en sampling-vereisten worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL-records als accountability records en het sampled-flag komen niet voor in deze bron.*
+</details>
+
+### `ls-iam-0056` — reference.md:184 *(§ Idempotente ingestion)*
+
+> Ingestion van ADL log records MOET idempotent zijn; re-submission MOET niet leiden tot een duplicate persisted record. De idempotency-sleutel is `(trace_id, span_id)` of een content-hash.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - idempotente ingestion
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron gaat over OpenID Connect NL GOV profiel. Er is geen sprake van een Authorization Decision Log, idempotente ingestion, trace_id, span_id of content-hash.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Idempotente ingestion van ADL log records wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Idempotente ingestion van ADL log records met (trace_id, span_id) als sleutel komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0057` — reference.md:188 *(§ Cached decisions)*
+
+> Caching van autorisatiebeslissingen wordt afgeraden. Indien toch toegepast, MOET de toepassing van een gecachte beslissing een nieuw log record produceren met de `trace_id` en `parent_span_id` van de nieuwe request en een vers gealloceerde `span_id`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - cached decisions
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt caching van Discovery-documenten en JWK-sets, niet het cachen van autorisatiebeslissingen of een Authorization Decision Log.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Caching van autorisatiebeslissingen en bijbehorende ADL-vereisten worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Caching van autorisatiebeslissingen en bijbehorende logging-vereisten komen niet voor in deze bron.*
+</details>
+
+### `ls-iam-0058` — reference.md:214 *(§ Retention en Privacy)*
+
+> ADL log records MOETEN minimaal 12 maanden worden bewaard voor audit doeleinden.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - retention
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Geen vermelding van ADL log records, retentieperiodes of audit-bewaarplicht in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Minimale bewaarperiode van ADL log records wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Bewaarplicht van 12 maanden voor ADL log records komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0059` — reference.md:217 *(§ Retention en Privacy)*
+
+> Persoonlijke identificeerbare informatie (PII) in ADL log records MOET worden beschermd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - privacy
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron bevat privacy-overwegingen over pairwise identifiers en data minimization, maar niets over PII-bescherming in ADL log records.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *PII-bescherming in ADL log records wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Bescherming van PII in ADL log records komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0060` — reference.md:218 *(§ Retention en Privacy)*
+
+> Toegang tot ADL logs MOET worden beperkt tot geautoriseerd personeel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - privacy
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Geen vermelding van toegangsbeperking tot ADL logs in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron gaat over het beheermodel van de OAuth-NL standaard. Er wordt nergens gesproken over een Authorization Decision Log (ADL) of toegangsbeperking tot logbestanden.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Toegangsbeperking tot ADL logs voor geautoriseerd personeel komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0061` — reference.md:220 *(§ Retention en Privacy)*
+
+> Bij het delen van ADL logs voor analyse MOETEN PII worden geanonimiseerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - privacy
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Geen vermelding van het delen of anonimiseren van ADL logs voor analyse in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron bevat geen informatie over Authorization Decision Logs, het delen van logs voor analyse, of het anonimiseren van PII in logbestanden.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Anonimisering van PII bij delen van ADL logs voor analyse komt niet voor in deze bron.*
+</details>
+
+### `ls-iam-0062` — reference.md:235 *(§ Toegankelijkheidsvalidatie)*
+
+> IAM-specificaties MOETEN voldoen aan WCAG 2.1 niveau AA voor toegankelijkheid.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** IAM repositories - toegankelijkheid
+
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-NL-profiel](https://logius-standaarden.github.io/OAuth-NL-profiel)
+  - *De brontekst bevat geen enkele verwijzing naar WCAG, toegankelijkheid (accessibility), of soortgelijke vereisten. De specificatie richt zich uitsluitend op OAuth 2.0 autorisatie- en authenticatieprofielen.*
+
+### `ls-iam-0063` — reference.md:248 *(§ Markdown Linting)*
+
+> Markdown bestanden MOETEN voldoen aan de markdownlint regels voor consistente opmaak.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** IAM repositories - markdown linting
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron bevat geen vereisten over markdown linting of markdownlint regels.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron beschrijft het beheermodel van OAuth-NL en noemt wel dat pre-commit hooks worden gebruikt in het generieke beheermodel, maar bevat geen specifieke vereisten over markdownlint regels voor markdown bestanden.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De brontekst is de NL GOV Assurance profile for OAuth 2.0 specificatie. Deze bevat geen informatie over markdownlint regels of opmaakconventies voor Markdown bestanden in repositories. Dit is een technische OAuth-specificatie, geen repository-stijlgids.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (19)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-iam-0003` — SKILL.md:38 *(§ Versiemodel)*
+
+> Het OAuth-NL-profiel v1.0 staat op het Forum Standaardisatie als verplicht ('pas-toe-of-leg-uit').
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie - OAuth NL profiel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  > De status van de standaard is 'Verplicht (pas toe leg uit)'. Dit houdt kort gezegd in dat Nederlandse overheden en instellingen uit de (semi) publieke sector verplicht zijn deze standaard toe te passen op het moment dat zij REST API's gaan gebruiken voor het ontsluiten van overheidsinformatie
+
+### `ls-iam-0004` — SKILL.md:38 *(§ Versiemodel)*
+
+> OAuth-NL-profiel versie v1.1.0 is vastgesteld door Logius (DEF) en gepubliceerd op gitdocumentatie.logius.nl.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth-NL-profiel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > NL GOV Assurance profile for OAuth 2.0 v1.1.0 Logius Standard Definitive version December 03, 2024 [...] MIDO programmeringstafel 1.1.0 definitive approved version 03-12-2024
+
+### `ls-iam-0005` — SKILL.md:61 *(§ Verplichte beveiligingseisen)*
+
+> PKCE is verplicht voor alle clients per het OIDC NL GOV profiel, inclusief confidential clients die private_key_jwt of mTLS gebruiken; er is geen vrijstelling.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - PKCE
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > Clients MUST use 'Proof Key for Code Exchange' [RFC7636] to protect calls to the Token Endpoint. [...] OpenID Providers MUST support and require the use of 'Proof Key for Code Exchange' ([RFC7636]) using only the S256 verification method
+  - *De MUST geldt voor alle clients zonder vrijstelling. Sectie 4.1 stelt dit als algemene vereiste voor alle client types, en sectie 5 vereist dat providers dit afdwingen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron beschrijft het beheermodel, niet de technische inhoud van het OIDC NL GOV profiel. PKCE-vereisten worden niet besproken.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron is het OAuth NL profiel, niet het OIDC NL GOV profiel. PKCE-vereisten voor confidential clients die private_key_jwt of mTLS gebruiken worden in deze bron niet behandeld. De bron vereist PKCE voor public clients en native clients, maar spreekt niet van een vrijstellingsloze verplichting voor alle clients inclusief confidential clients.*
+
+### `ls-iam-0006` — SKILL.md:62 *(§ Verplichte beveiligingseisen)*
+
+> De grant type 'authorization_code' is verplicht (MUST) per het OAuth NL profiel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth-NL-profiel - grant types
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > grant_type REQUIRED . MUST contain the value authorization_code . Identical as in [OAuth2.NLGov].
+  - *De bron bevestigt dat authorization_code verplicht is in het token request, en verwijst naar OAuth2.NLGov. De claim stelt dit als vereiste 'per het OAuth NL profiel', maar de bron zelf is het OIDC NL GOV profiel dat verwijst naar OAuth2.NLGov. De inhoud klopt, maar de directe bron voor de claim is het OAuth NL profiel dat hier niet beschikbaar is.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > The authorization server MUST support the authorization_code , and MAY support the client_credentials grant types as described in Section 2.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Grant types worden in dit beheermodeldocument niet technisch gespecificeerd.*
+
+### `ls-iam-0007` — SKILL.md:62 *(§ Verplichte beveiligingseisen)*
+
+> De grant type 'client_credentials' is toegestaan (MAY) voor machine-to-machine communicatie per het OAuth NL profiel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth-NL-profiel - grant types
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > The authorization server MUST support the authorization_code , and MAY support the client_credentials grant types as described in Section 2. [...] These clients use the client credentials flow of OAuth 2 by sending a request to the token endpoint with the client's credentials and obtaining an access token in the response.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron vermeldt client_credentials grant type niet. In de discovery document sectie staat grant_types_supported MUST be ['authorization_code']. client_credentials wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Client credentials grant type wordt niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0009` — SKILL.md:63 *(§ Verplichte beveiligingseisen)*
+
+> Access tokens worden als HTTP Authorization header (Bearer scheme) meegegeven. Transport via query parameters is verboden (MUST NOT).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** OAuth-NL-profiel - token transport
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > Clients SHOULD send bearer tokens passed in the Authentication header as defined by [rfc6750]. [...] A Protected Resource under this profile MUST NOT accept access tokens passed using the query parameter method.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron bevat geen expliciete bepaling over het verbod op het meegeven van access tokens als query parameter. Het Bearer scheme wordt getoond in een voorbeeld (Authorization: Bearer ...) maar een MUST NOT voor query parameters staat er niet in.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Token transport en Authorization header-vereisten worden niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0010` — SKILL.md:63 *(§ Verplichte beveiligingseisen)*
+
+> Form-encoded body parameters (RFC 6750 Section 2.2) zijn toegestaan voor het meegeven van access tokens.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth-NL-profiel - token transport
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc6750.txt](https://www.rfc-editor.org/rfc/rfc6750.txt)
+  > Resource servers MAY support this method.
+  - *RFC 6750 Section 2.2 beschrijft de form-encoded body parameter methode en stelt dat resource servers deze MAY ondersteunen. De claim gebruikt 'toegestaan' (MAY), wat overeenkomt met de tekst in de bron.*
+
+### `ls-iam-0012` — SKILL.md:68 *(§ Token specificaties)*
+
+> Refresh tokens worden ondersteund (MAY) bij de authorization_code flow en maken het mogelijk nieuwe access tokens te verkrijgen zonder hernieuwde gebruikersinteractie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth-NL-profiel - refresh tokens
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > OpenID Providers MAY issue Refresh Tokens to Clients; when used, Refresh Tokens MUST be one-time-use or sender-constrained.
+  - *De bron bevestigt dat refresh tokens MAY worden uitgegeven. De koppeling aan specifiek de authorization_code flow staat niet expliciet vermeld maar is impliciet (dit profiel gebruikt alleen authorization_code).*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > This client type MAY request and be issued a refresh token if the security parameters of the access request allow for it. [...] Under this profile, refresh tokens are supported.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Refresh tokens worden niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0013` — SKILL.md:68 *(§ Token specificaties)*
+
+> Refresh token rotation wordt aanbevolen per het OAuth NL profiel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OAuth-NL-profiel - refresh tokens
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > For security reasons, Refresh Tokens that are not sender-constrained MUST be one-time-use, i.e. with every Access Token refresh response the OpenID Provider can issue a new Refresh Token and MUST invalidate the previous Refresh Token
+  - *Refresh token rotation wordt vereist (MUST) voor niet-sender-constrained tokens, wat de aanbeveling (SHOULD) in de claim ondersteunt. De bron stelt het als vereiste, wat sterker is dan de claim suggereert.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Refresh token rotation wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron vermeldt dat refresh tokens voor public clients sender-constrained of one-time use MOETEN zijn, maar een expliciete SHOULD-aanbeveling voor 'refresh token rotation' als algemeen concept ontbreekt.*
+
+### `ls-iam-0014` — SKILL.md:75 *(§ Client authenticatie)*
+
+> private_key_jwt is verplicht per het OAuth NL profiel voor client authenticatie bij het token endpoint.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth-NL-profiel - client authenticatie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > Confidential Clients, as defined in Section 4.1, MUST authenticate to the OpenID Provider using either: a JWT assertion as defined by the 'JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants' [RFC7523] using only the private_key_jwt method defined in [OpenID.Core]; or mutually authenticated TLS, as specified in [RFC8705].
+  - *De bron vereist private_key_jwt ÓÓOF mTLS voor confidential clients — het is dus geen absolute verplichting van private_key_jwt alleen. De claim stelt private_key_jwt als enige verplichte methode, maar de bron geeft mTLS als gelijkwaardig alternatief. Bovendien is de claim dat dit 'per het OAuth NL profiel' is, terwijl deze bron het OIDC NL GOV profiel is.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > Full clients, native clients with dynamically registered keys, and direct access clients as defined above MUST authenticate to the authorization server's token endpoint using a JWT assertion as defined by the [JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants] using only the private_key_jwt method defined in [OpenID Connect Core].
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *private_key_jwt als verplicht authenticatiemechanisme bij het token endpoint wordt niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0018` — SKILL.md:106 *(§ Betrouwbaarheidsniveaus (Levels of Assurance))*
+
+> De `acr_values` parameter in het authentication request mapt naar eIDAS-betrouwbaarheidsniveaus. De OpenID Provider geeft het bereikte niveau terug in de `acr` claim van het ID Token.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC NL GOV profiel - acr_values
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > acr_values OPTIONAL. Lists the acceptable LoAs for this authentication. [...] OpenID Providers SHOULD use eIDAS Level of Assurance (LoA) values for the acr Claim [...] acr OPTIONAL. The LoA the End-User was authenticated at. MUST be at least the requested Level of Assurance value requested by the Client (either via the acr_values or claims parameters)
+  - *De bron bevestigt dat acr_values in het authentication request verwijst naar LoA-niveaus en dat de provider het bereikte niveau teruggeeft in de acr claim van het ID Token, gerelateerd aan eIDAS.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De acr_values parameter en mapping naar eIDAS-niveaus worden niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. acr_values-parameter en ID Token acr claim worden niet besproken.*
+
+### `ls-iam-0020` — SKILL.md:120 *(§ Verplichte claims in het ID Token)*
+
+> De `acr` claim is OPTIONAL per OIDC NL GOV; als gezet MOET de waarde minimaal het gevraagde betrouwbaarheidsniveau zijn.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token acr claim
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > acr OPTIONAL . The LoA the End-User was authenticated at. MUST be at least the requested Level of Assurance value requested by the Client (either via the acr_values or claims parameters) or - if none was requested - a Level of Assurance established through prior agreement.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De acr claim in ID Tokens wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. De acr claim in ID Tokens is geen onderdeel van deze specificatie.*
+
+### `ls-iam-0022` — SKILL.md:127 *(§ ID Token validatie)*
+
+> De `iss` claim MOET exact overeenkomen met de `issuer` uit het discovery document bij ID Token validatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > iss The issuer Claim is the Uniform Resource Locater (URL) of the expected Issuer. Identical as in [OpenID.iGov].
+  - *De bron stelt dat iss de URL van de verwachte issuer moet zijn. De expliciete formulering 'exact overeenkomen met de issuer uit het discovery document' staat niet letterlijk zo in de bron, maar dit is de directe strekking van de verificatieverplichting.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *iss claim validatie wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. ID Token iss-validatie per OIDC NL GOV profiel wordt niet besproken.*
+
+### `ls-iam-0023` — SKILL.md:128 *(§ ID Token validatie)*
+
+> De `aud` claim MOET de `client_id` van de relying party bevatten bij ID Token validatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > aud The audience Claim contains the Client ID of the Client. Identical as in [OpenID.iGov].
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *aud claim validatie wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth NL profiel. aud-validatie van ID Tokens per OIDC NL GOV profiel wordt niet besproken.*
+
+### `ls-iam-0049` — reference.md:138 *(§ Userinfo Endpoint)*
+
+> De Relying Party MOET alleen de claims vragen die strikt noodzakelijk zijn voor de dienstverlening (dataminimalisatie).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - privacy
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > All Clients MUST apply the concept of data minimization. As a result, a Client MUST NOT request any more identifiers, attributes or other Claims than strictly necessary.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Dataminimalisatie voor Relying Parties wordt niet besproken in dit beheermodeldocument.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Dataminimalisatie als MUST-verplichting voor de Relying Party in het OIDC NL GOV profiel komt niet voor in deze OAuth-NL-profiel bron.*
+
+### `ls-iam-0051` — reference.md:144 *(§ Client Registratie)*
+
+> Redirect URI's bij client registratie vereisen een exacte match; wildcards zijn niet toegestaan voor beveiliging.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** OIDC NL GOV profiel - client registratie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > One of these registered Redirection URI values MUST exactly match the redirect_uri parameter value used in each Authorization Request.
+  - *De bron stelt expliciet dat exact matching vereist is. Wildcards worden niet vermeld als optie, en de exacte-match eis sluit wildcard-gebruik uit.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > The Authorization Server MUST compare a client's registered redirect URIs with the redirect URI presented during an authorization request using an exact string match.
+  - *De bron bevestigt exact string matching voor redirect URIs. Wildcards worden niet expliciet verboden, maar exact string match sluit ze impliciet uit.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *Redirect URI exacte match en verbod op wildcards worden niet besproken in dit beheermodeldocument.*
+
+### `ls-iam-0064` — reference.md:357 *(§ Aanvullende Bronnen)*
+
+> RFC 7636 definieert PKCE (Proof Key for Code Exchange).
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth - PKCE
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7636.txt](https://www.rfc-editor.org/rfc/rfc7636.txt)
+  > Proof Key for Code Exchange by OAuth Public Clients [...] This specification describes the attack as well as a technique to mitigate against the threat through the use of Proof Key for Code Exchange (PKCE, pronounced "pixy").
+
+### `ls-iam-0065` — reference.md:358 *(§ Aanvullende Bronnen)*
+
+> RFC 9068 definieert het JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth - JWT access tokens
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9068.txt](https://www.rfc-editor.org/rfc/rfc9068.txt)
+  > This specification defines a profile for issuing OAuth 2.0 access tokens in JSON Web Token (JWT) format.
+
+### `ls-iam-0066` — reference.md:359 *(§ Aanvullende Bronnen)*
+
+> RFC 9126 definieert OAuth 2.0 Pushed Authorization Requests.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth - PAR
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9126.txt](https://www.rfc-editor.org/rfc/rfc9126.txt)
+  > This document defines the pushed authorization request (PAR) endpoint, which allows clients to push the payload of an OAuth 2.0 authorization request to the authorization server via a direct request and provides them with a request URI that is used as reference to the data in a subsequent call to the authorization endpoint.
+
+</details>

--- a/skills/ls-iam/audit.md
+++ b/skills/ls-iam/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-iam — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,100 +7,100 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 8 | 12% |
+| UNSUPPORTED_ASSERTION | 12 | 16% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 10 | 15% |
-| UNGROUNDED | 29 | 44% |
+| PARTIALLY_GROUNDED | 11 | 15% |
+| UNGROUNDED | 24 | 33% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 19 | 29% |
+| GROUNDED | 26 | 36% |
 
-*Geverifieerd met sonnet, 16 calls, $2.1815.*
+*Geverifieerd met sonnet, 24 calls, $2.7302.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (8)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (12)
 
-### `ls-iam-0017` — SKILL.md:98 *(§ Betrouwbaarheidsniveaus (Levels of Assurance))*
+### `ls-iam-0015` — SKILL.md:98 *(§ Betrouwbaarheidsniveaus (Levels of Assurance))*
 
-> Het OIDC NL GOV profiel definieert drie betrouwbaarheidsniveaus (Laag, Substantieel, Hoog) conform de eIDAS-verordening.
+> Het OIDC NL GOV profiel definieert drie betrouwbaarheidsniveaus conform de eIDAS-verordening: Laag (Low), Substantieel (Substantial), Hoog (High).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC NL GOV profiel - betrouwbaarheidsniveaus
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron definieert geen drie betrouwbaarheidsniveaus (Laag, Substantieel, Hoog) zelf. Het profiel verwijst naar eIDAS LoA-waarden en gebruikt 'substantial' en 'high' als voorbeelden, maar definieert geen drie niveaus als eigen onderdeel van het profiel. De eIDAS-niveaus worden als extern gegeven behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Betrouwbaarheidsniveaus conform eIDAS worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel, niet het OIDC NL GOV profiel. Betrouwbaarheidsniveaus conform eIDAS worden niet gedefinieerd.*
-</details>
-
-### `ls-iam-0025` — SKILL.md:139 *(§ AuthZEN NL GOV)*
-
-> Het AuthZEN NL GOV profiel specificeert een architectuur voor geëxternaliseerde autorisatie via een centraal PDP.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV profiel
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC NL GOV profiel - Betrouwbaarheidsniveaus
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De brontekst betreft het OIDC NL GOV profiel. AuthZEN wordt nergens in de bron genoemd.*
+  - *De bron verwijst naar eIDAS LoA-waarden (substantial, high) maar definieert zelf geen drie niveaus (Low/Substantial/High) als eigen definitie. De spec verwijst naar [eIDAS.SAML] Section 3.2 voor de definitie. 'Laag' wordt niet als apart niveau in deze bron geïntroduceerd.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *AuthZEN NL GOV profiel wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over eIDAS-betrouwbaarheidsniveaus in OIDC NL GOV.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. AuthZEN en geëxternaliseerde autorisatie via een PDP worden niet besproken.*
+  - *De bron behandelt het OIDC NL GOV profiel niet. eIDAS-betrouwbaarheidsniveaus worden niet gedefinieerd in deze bron.*
 </details>
 
-### `ls-iam-0026` — SKILL.md:156 *(§ Evaluation endpoint)*
+### `ls-iam-0027` — SKILL.md:143 *(§ Architectuurcomponenten)*
 
-> Het AuthZEN evaluation endpoint is POST /access/v1/evaluation met Content-Type application/json.
+> Het AuthZEN NL GOV profiel specificeert een architectuur voor geëxternaliseerde autorisatie met PDP en PEP als kerncomponenten; PAP en PIP komen uit het XACML-referentiemodel.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV profiel - evaluation endpoint
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV - Architectuur
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *AuthZEN en het evaluation endpoint komen niet voor in deze brontekst.*
+  - *De bron gaat over het OIDC NL GOV profiel. AuthZEN, PDP, PEP, PAP, PIP en het XACML-referentiemodel worden nergens in de bron genoemd.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Het AuthZEN evaluation endpoint wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over AuthZEN NL GOV.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. Het AuthZEN evaluation endpoint wordt niet besproken.*
+  - *AuthZEN NL GOV wordt niet behandeld in het OAuth NL profiel.*
 </details>
 
-### `ls-iam-0027` — SKILL.md:163 *(§ Request formaat)*
+### `ls-iam-0028` — SKILL.md:156 *(§ Evaluation endpoint)*
+
+> Het AuthZEN NL GOV evaluation endpoint is POST /access/v1/evaluation met Content-Type application/json.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV - Evaluation endpoint
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *AuthZEN en het evaluation endpoint POST /access/v1/evaluation worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over AuthZEN endpoints.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *AuthZEN evaluation endpoint wordt niet behandeld in het OAuth NL profiel.*
+</details>
+
+### `ls-iam-0029` — SKILL.md:163 *(§ Request formaat)*
 
 > Een AuthZEN autorisatieverzoek bestaat uit vier elementen: subject, action, resource en context (optioneel).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV profiel - request formaat
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV - Request formaat
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *AuthZEN autorisatieverzoekformaat (subject, action, resource, context) wordt niet behandeld in deze bron.*
+  - *AuthZEN autorisatieverzoeken met subject, action, resource en context worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *AuthZEN autorisatieverzoek-elementen worden niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over AuthZEN request formaat.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. AuthZEN autorisatieverzoeken worden niet besproken.*
+  - *AuthZEN autorisatieverzoekformaat wordt niet behandeld in het OAuth NL profiel.*
 </details>
 
-### `ls-iam-0028` — SKILL.md:197 *(§ Response formaat)*
+### `ls-iam-0030` — SKILL.md:196 *(§ Response formaat)*
 
-> Het PDP retourneert een `decision` (boolean: true voor toestaan, false voor weigeren) en optioneel een `context` met aanvullende informatie.
+> Het PDP retourneert een `decision` (boolean): true voor toestaan, false voor weigeren; optioneel met `context` met aanvullende informatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV profiel - response formaat
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** AuthZEN NL GOV - Response formaat
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *PDP-responses en het AuthZEN decision-formaat komen niet voor in deze bron.*
+  - *AuthZEN PDP response met decision (boolean) wordt niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *AuthZEN PDP response formaat wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over AuthZEN response formaat.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. AuthZEN PDP responses worden niet besproken.*
+  - *De bron gaat over het OAuth 2.0 NL GOV profiel. AuthZEN en PDP response-formaten worden niet behandeld.*
 </details>
 
-### `ls-iam-0029` — SKILL.md:223 *(§ Authorization Decision Log)*
+### `ls-iam-0031` — SKILL.md:223 *(§ Authorization Decision Log)*
 
 > De ADL-werkversie volgt sinds april 2026 een OpenTelemetry-vorm op basis van het AuthZEN-informatiemodel.
 
@@ -109,181 +109,627 @@
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *ADL (Authorization Decision Log) en OpenTelemetry worden niet behandeld in deze bron.*
+  - *Authorization Decision Log en OpenTelemetry worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Authorization Decision Log en OpenTelemetry worden niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over Authorization Decision Log of OpenTelemetry.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. De ADL-werkversie en OpenTelemetry worden niet besproken.*
+  - *Authorization Decision Log, OpenTelemetry en AuthZEN-informatiemodel worden niet behandeld in deze bron.*
 </details>
 
-### `ls-iam-0033` — SKILL.md:234 *(§ Record-velden)*
+### `ls-iam-0036` — SKILL.md:234 *(§ Record-velden)*
 
-> Het ADL `status` veld kent drie waarden: `Unset` (default, ook bij denial), `Ok`, of `Error` (PDP kon geen beslissing produceren).
+> Het ADL veld `status` kent drie waarden: `Unset` (default, ook bij denial), `Ok`, of `Error` (PDP kon geen beslissing produceren).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Authorization Decision Log - status
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Authorization Decision Log - Record-velden
 
 - **NOT_FOUND** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
-  - *De W3C Trace Context spec behandelt geen statuswaarden zoals `Unset`, `Ok` of `Error`. Dit zijn OpenTelemetry-concepten voor span-status, niet gedefinieerd in deze specificatie.*
+  - *De W3C Trace Context spec definieert geen statusvelden (Unset, Ok, Error). Dit is OpenTelemetry-terminologie, niet W3C Trace Context. Deze bron behandelt het onderwerp niet.*
 
-### `ls-iam-0046` — reference.md:63 *(§ OIN Structuur)*
+### `ls-iam-0048` — reference.md:63 *(§ OIN Structuur)*
 
-> Een OIN bestaat uit 20 cijfers waarbij de eerste 8 cijfers de organisatie identificeren en de resterende cijfers een volgnummer zijn.
+> Een OIN bestaat uit 20 cijfers; de eerste 8 identificeren de organisatie, de resterende cijfers zijn een volgnummer.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel - structuur
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel - Structuur
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron vermeldt OIN niet als afkorting in de glossary, maar geeft geen structuurbeschrijving (20 cijfers, eerste 8 voor organisatie-ID). De OIN-structuur wordt niet behandeld in deze spec.*
+  - *OIN-structuur (20 cijfers, eerste 8 voor organisatie) wordt niet beschreven in deze bron. De bron vermeldt OIN alleen zijdelings als onderdeel van PKIoverheid certificaten.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *OIN-structuur (20 cijfers) wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over de structuur van een OIN.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De structuur van een OIN (20 cijfers, eerste 8 voor organisatie, rest volgnummer) wordt niet beschreven in deze bron.*
+  - *OIN-structuur (20 cijfers, eerste 8 identificeren de organisatie) wordt niet behandeld in deze bron.*
 </details>
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (10)
+### `ls-iam-0049` — reference.md:69 *(§ OIN Structuur)*
 
-### `ls-iam-0008` — SKILL.md:62 *(§ Verplichte beveiligingseisen)*
+> In PKIoverheid-certificaten wordt het OIN opgenomen in het `subject.serialNumber` veld.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel - PKIoverheid certificaten
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron vermeldt PKIoverheid certificaten in de context van publieke sleutels (JWK Set, x5c/x5u parameters), maar beschrijft niet dat het OIN in het subject.serialNumber veld wordt opgenomen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over OIN in PKIoverheid-certificaten.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron vermeldt PKIoverheid certificaten met OIN maar specificeert niet dat het OIN in het subject.serialNumber veld wordt opgenomen.*
+</details>
+
+### `ls-iam-0055` — reference.md:163 *(§ Levels of detail)*
+
+> De ADL-standaard definieert vier niveaus van replayability: (1) request+response, (2) + adl.core.policies, (3) + adl.core.information, (4) + adl.core.configuration.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Authorization Decision Log - Levels of detail
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL-standaard en replayability-niveaus worden niet behandeld in deze OIDC NL GOV specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ADL niveaus van replayability.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL-standaard en niveaus van replayability worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0069` — SKILL.md:51 *(§ Repositories)*
+
+> OIN-Stelsel vastgestelde versie is v3.0.0, gepubliceerd op gitdocumentatie.logius.nl/publicatie/dk/oin/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-Stelsel
+
+<details><summary>7x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Het OIN-Stelsel en versienummers daarvan worden niet behandeld in deze OIDC NL GOV bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth-NL-profiel. Er is geen informatie over het OIN-Stelsel of de versie daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-NL-profiel](https://logius-standaarden.github.io/OAuth-NL-profiel)
+  - *De bron bevat geen informatie over het OIN-Stelsel, versienummers daarvan, of de publicatielocatie ervan.*
+- **OUT_OF_SCOPE** (high) — [https://github.com/logius-standaarden/OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel)
+  - *De bron gaat over het OAuth-NL-profiel. OIN-Stelsel is een andere standaard; geen informatie hierover in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV)
+  - *De bron gaat uitsluitend over OIDC-NLGOV. Het OIN-Stelsel wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIDC-NLGOV](https://logius-standaarden.github.io/OIDC-NLGOV)
+  - *Het OIN-Stelsel wordt in de bron niet als referentie of onderwerp behandeld. De bron noemt OIN alleen in een afkortingenlijst als begrip, maar bevat geen informatie over het OIN-Stelsel als standaard of een vastgestelde versie ervan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OAuth-Inleiding](https://github.com/logius-standaarden/OAuth-Inleiding)
+  - *De brontekst bevat geen informatie over het OIN-Stelsel, versienummers of publicatie-URL's.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-Inleiding](https://logius-standaarden.github.io/OAuth-Inleiding)
+  - *De aangeleverde brontekst bevat alleen navigatie-elementen zonder inhoudelijke tekst over versienummers of publicatie-URLs van het OIN-Stelsel.*
+</details>
+
+### `ls-iam-0070` — SKILL.md:47 *(§ Repositories)*
+
+> OAuth-Beheermodel heeft een vastgestelde versie v1.0 maar is gearchiveerd.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth-Beheermodel
+
+<details><summary>8x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Een OAuth-Beheermodel en de archiefstatus daarvan worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron bevat geen informatie over een OAuth-Beheermodel of de archiefstatus daarvan.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-NL-profiel](https://logius-standaarden.github.io/OAuth-NL-profiel)
+  - *De bron vermeldt niets over een OAuth-Beheermodel, een versie v1.0 daarvan, of archivering ervan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel)
+  - *De bron verwijst naar een beheermodel via 'https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/' maar geeft geen versienummer, geen vermelding van v1.0, en geen aanduiding dat het gearchiveerd is.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV)
+  - *De bron gaat uitsluitend over OIDC-NLGOV. Het OAuth-Beheermodel wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIDC-NLGOV](https://logius-standaarden.github.io/OIDC-NLGOV)
+  - *Het OAuth-Beheermodel wordt in de bron niet genoemd. Er is geen verwijzing naar een beheermodel, een versie v1.0 daarvan, of archiefstatus ervan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OAuth-Inleiding](https://github.com/logius-standaarden/OAuth-Inleiding)
+  - *De brontekst bevat geen informatie over een OAuth-Beheermodel, versienummers of archiveringsstatus.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-Inleiding](https://logius-standaarden.github.io/OAuth-Inleiding)
+  - *De aangeleverde brontekst bevat alleen navigatie-elementen zonder inhoudelijke tekst over het OAuth-Beheermodel of archiefstatus.*
+</details>
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (11)
+
+### `ls-iam-0002` — SKILL.md:36 *(§ Versiemodel)*
+
+> Voor nieuwe implementaties wordt OIDC aanbevolen; bestaande SAML-koppelingen blijven ondersteund.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Forum Standaardisatie - Authenticatie-standaarden
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  > Deze gecombineerde verplichting van OpenID.NLGov (en de achterliggende internationale standaard OIDC) en SAML zet een transitie in gang met afbouw van SAML en opbouw naar OpenID.NLGov (en de achterliggende internationale standaard OIDC).
+  - *De bron bevestigt dat er een transitie loopt van SAML naar OpenID.NLGov, en dat SAML blijft ondersteund. Maar de bron zegt niet expliciet dat OIDC 'aanbevolen' wordt voor nieuwe implementaties; het gaat om een gecombineerde verplichting waarbij serviceproviders mogen kiezen. De strekking klopt deels, maar de formulering 'voor nieuwe implementaties wordt OIDC aanbevolen' staat niet letterlijk in de bron.*
+<details><summary>5x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron behandelt OAuth 2.0 en het NL GOV profiel daarvoor. OIDC als aanbeveling voor nieuwe implementaties en SAML-ondersteuning worden niet besproken.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *OIDC als aanbeveling voor nieuwe implementaties en de status van bestaande SAML-koppelingen worden niet besproken in deze bron. De bron gaat over OAuth 2.0 en het NL Gov profiel daarop.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De spec spreekt niet over aanbevelingen voor nieuwe vs. bestaande implementaties ten opzichte van SAML. Dit is Forum Standaardisatie-beleid, niet de technische spec.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron gaat over het OAuth-NL beheermodel en doet geen uitspraken over aanbevelingen voor OIDC vs SAML voor nieuwe implementaties.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron betreft uitsluitend het OAuth NL profiel. SAML en aanbevelingen voor nieuwe implementaties versus bestaande SAML-koppelingen worden nergens behandeld.*
+</details>
+
+### `ls-iam-0004` — SKILL.md:38 *(§ Versiemodel)*
+
+> OAuth-NL-profiel v1.1.0 is vastgesteld door Logius (DEF) maar staat bij het Forum in procedure (intake goedgekeurd 24-09-2025, verkort expertonderzoek loopt).
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth-NL-profiel
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > MIDO programmeringstafel 1.1.0 definitive approved version 03-12-2024
+  - *De bron bevestigt dat v1.1.0 definitief is vastgesteld (03-12-2024). De claim over de Forum Standaardisatie-procedure (intake goedgekeurd 24-09-2025, verkort expertonderzoek loopt) staat niet in de bron; die datum ligt ook na de publicatiedatum van het document.*
+
+### `ls-iam-0007` — SKILL.md:62 *(§ Verplichte beveiligingseisen)*
 
 > Implicit grant en Resource Owner Password Credentials zijn expliciet verboden vanwege bekende beveiligingsrisico's.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** OAuth-NL-profiel - grant types
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** OAuth NL profiel - Grant types
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > Therefore, the Implicit Flow and Hybrid Flow MUST NOT be used. Also, the IETF OAuth Working Group is removing support for the Implicit Flow from the OAuth 2.1 specification [OAuth2.1] for the same reasons.
-  - *De bron verbiedt expliciet de Implicit Flow (MUST NOT). Resource Owner Password Credentials wordt niet expliciet vermeld in de bron. Alleen het Implicit Flow verbod is gedekt.*
+  > The Implicit Flow and Hybrid Flow allow tokens to be obtained from the Authorization Endpoint... Therefore, the Implicit Flow and Hybrid flow MUST NOT be used.
+  - *Implicit Flow is expliciet verboden (MUST NOT). Resource Owner Password Credentials wordt in deze bron niet genoemd — die claim is dus slechts gedeeltelijk ondersteund.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Implicit grant en Resource Owner Password Credentials worden niet besproken in dit beheermodeldocument.*
+  - *De bron is het beheermodel en bevat geen technische specificaties over verboden grant types.*
 - **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron noemt implicit grant wel in de discovery response ('response_types_supported': ['code', 'token']) en in de grant_types_supported lijst, maar verbiedt deze grant types niet expliciet. Resource Owner Password Credentials wordt nergens vermeld. Er is geen MUST NOT voor deze grant types.*
+  - *De bron noemt de implicit grant in de discovery-voorbeeldresponse (response_types_supported: code, token) maar verbiedt implicit grant en ROPC niet expliciet. Er is geen MUST NOT voor deze grant types te vinden in de normatieve tekst.*
 
-### `ls-iam-0015` — SKILL.md:76 *(§ Client authenticatie)*
+### `ls-iam-0012` — SKILL.md:75 *(§ Client authenticatie)*
 
-> mTLS is toegestaan (MAY) per het OAuth NL profiel als gelijkwaardig alternatief voor client authenticatie per het OIDC NL GOV profiel, bij voorkeur met PKIoverheid-certificaat.
+> private_key_jwt is verplicht per het OAuth NL profiel als client authenticatiemethode bij het token endpoint.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth-NL-profiel / OIDC NL GOV - client authenticatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth NL profiel - Client authenticatie
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > Confidential Clients, as defined in Section 4.1, MUST authenticate to the OpenID Provider using either: a JWT assertion [...] using only the private_key_jwt method [...]; or mutually authenticated TLS, as specified in [RFC8705]. [...] In case PKIoverheid certificates are used, the certificate and entire certificate chain up until the root certificate MUST be included
-  - *De bron bevestigt mTLS als toegestaan alternatief (MAY in de zin van een van beide opties). De verwijzing naar PKIoverheid-certificaten staat in de context van public keys/JWK, niet specifiek als voorkeur voor mTLS client authenticatie. 'Bij voorkeur met PKIoverheid-certificaat' voor mTLS client auth is niet expliciet gesteld in de bron.*
+  > Confidential Clients, as defined in Section 4.1, MUST authenticate to the OpenID Provider using either: a JWT assertion as defined by... using only the private_key_jwt method... or mutually authenticated TLS, as specified in [RFC8705].
+  - *De bron stelt dat confidential clients MUST authenticeren met private_key_jwt OF mTLS. private_key_jwt is dus niet de enige verplichte methode — mTLS is een gelijkwaardig alternatief. De claim dat private_key_jwt 'verplicht' is als enige methode is daarmee te absoluut.*
 - **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > In addition to private_key_jwt , the client authentication method tls_client_auth [rfc8705] MAY also be used. [...] In case the Authorization Server, Resource Server and client are not operated under responsibility of the same organisation, each party MUST use PKIoverheid certificates with OIN.
-  - *De bron bevestigt dat mTLS (tls_client_auth) MAY worden gebruikt als alternatief, en dat PKIoverheid-certificaten verplicht zijn tussen verschillende organisaties. De claim stelt echter 'bij voorkeur met PKIoverheid-certificaat' als een SHOULD/voorkeur, terwijl de bron PKIoverheid MUST stelt voor cross-organisatie situaties. Bovendien is de gelijkwaardigheid met het OIDC NL GOV profiel niet in deze bron bevestigd.*
+  > Full clients, native clients with dynamically registered keys, and direct access clients as defined above MUST authenticate to the authorization server's token endpoint using a JWT assertion [...] using only the private_key_jwt method
+  - *De bron bevestigt dat private_key_jwt verplicht is, maar voegt toe dat tls_client_auth MAY ook worden gebruikt als alternatief. De claim stelt dat private_key_jwt 'verplicht' is zonder alternatief te noemen, wat de bron nuanceert met een MAY voor mTLS.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *mTLS als alternatief voor client authenticatie wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het beheermodel en bevat geen technische specificaties over client authenticatiemethoden.*
 
-### `ls-iam-0016` — SKILL.md:94 *(§ OpenID Connect NL GOV Profiel)*
+### `ls-iam-0017` — SKILL.md:110 *(§ Verplichte claims in het ID Token)*
 
-> Het OIDC NL GOV profiel bouwt voort op OpenID Connect Core 1.0 en het iGov-profiel.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC NL GOV profiel
-
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > This profile is based upon the 'International Government Assurance Profile (iGov) for OpenID Connect 1.0' [OpenID.iGov] as published by the OpenID Foundation. It should be considered a fork of this profile [...] This profile builds on top of, and inherits all properties of, the NL GOV Assurance profile for OAuth 2.0 [OAuth2.NLGov].
-  - *De bron bevestigt dat het profiel voortbouwt op iGov en op OAuth2.NLGov. OpenID Connect Core 1.0 wordt als basis gebruikt maar de bron zegt het profiel bouwt 'op' het iGov-profiel en OAuth2.NLGov, niet expliciet 'op OpenID Connect Core 1.0' direct. Indirect klopt het wel — iGov zelf bouwt op Core. De claim is grotendeels gedekt.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De bron beschrijft het OAuth-NL beheermodel, niet het OIDC NL GOV profiel of diens relatie met OpenID Connect Core 1.0 of het iGov-profiel.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron is het OAuth NL profiel. Het OIDC NL GOV profiel en zijn relatie met OpenID Connect Core 1.0 worden hier niet beschreven.*
-
-### `ls-iam-0019` — SKILL.md:110 *(§ Verplichte claims in het ID Token)*
-
-> Het ID Token MOET minimaal de claims sub, iss, aud, exp, iat en nonce bevatten per het OIDC NL GOV profiel.
+> Het ID Token moet minimaal de claims sub, iss, aud, exp, iat en nonce bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token claims
 
 - **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > iss REQUIRED [...] aud REQUIRED [...] sub REQUIRED [...] nonce REQUIRED [...] exp, iat, nbf REQUIRED. The expiration, issued at, and not before timestamps indicate when the token expires, was issued and becomes valid
-  - *De bron bevestigt sub, iss, aud, exp, iat en nonce als REQUIRED in het ID Token (sectie 5.2.2). nbf is ook REQUIRED. De claim stelt 'minimaal sub, iss, aud, exp, iat en nonce', wat klopt — al mist de claim nbf en jti (ook REQUIRED per de bron). De genoemde claims zijn allemaal gedekt; de claim is correct maar niet volledig ten opzichte van wat de bron vereist.*
+  > iss REQUIRED... aud REQUIRED... sub REQUIRED... nonce REQUIRED... exp, iat, nbf REQUIRED... jti REQUIRED.
+  - *De bron bevestigt iss, aud, sub, exp, iat, nonce als verplicht. nbf is ook REQUIRED (niet in de claim). jti is ook REQUIRED (niet in de claim). De claim noemt de minimale set correct maar is niet volledig — de spec vereist ook jti en nbf.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *ID Token claims worden niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen technische specificaties over verplichte ID Token claims.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. ID Token claims per het OIDC NL GOV profiel komen niet aan bod.*
+  - *De bron gaat over OAuth access tokens en JWT Bearer tokens, niet over OIDC ID Token claims. De minimale ID Token claim-set is niet in deze bron beschreven.*
 
-### `ls-iam-0021` — SKILL.md:124 *(§ ID Token validatie)*
+### `ls-iam-0020` — SKILL.md:127 *(§ ID Token validatie)*
 
-> Bij het valideren van een OIDC ID Token MOETEN de JWS handtekening, iss, aud, nonce, exp, iat, acr en jti worden geverifieerd.
+> Bij ID Token validatie MOET de `iss` claim exact overeenkomen met de `issuer` uit het discovery document.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > All Clients MUST validate the signature of an ID Token before accepting it. Clients MUST verify the following in received ID tokens: iss [...] aud [...] nonce [...] exp, iat, nbf [...] acr [...] represents
-  - *De bron bevestigt JWS handtekening, iss, aud, nonce, exp/iat, en acr als te valideren velden. De claim noemt ook 'jti', maar de bron schrijft jti-validatie niet expliciet voor als verificatieplicht voor clients — jti is een REQUIRED veld in het ID Token (voor de OP), maar niet expliciet als client-validatieverplichting opgesomd. nbf wordt wel genoemd maar de claim heeft 'exp, iat' zonder nbf. De claim noemt niet 'represents' terwijl de bron dat wel verplicht stelt.*
+  > iss — The issuer Claim is the Uniform Resource Locater (URL) of the expected Issuer. Identical as in [OpenID.iGov].
+  - *De bron bevestigt dat de iss claim de URL van de verwachte issuer moet zijn, maar specificeert niet expliciet dat dit exact moet overeenkomen met de issuer uit het discovery document. De claim is breder dan wat de bron letterlijk zegt.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *ID Token validatie wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ID Token validatie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. ID Token validatie per OIDC NL GOV profiel wordt niet beschreven.*
+  - *ID Token iss-validatie valt buiten scope van het OAuth NL profiel.*
 
-### `ls-iam-0024` — SKILL.md:133 *(§ ID Token validatie)*
+### `ls-iam-0026` — SKILL.md:133 *(§ ID Token validatie)*
 
-> De `jti` claim MOET uniek zijn; bewaar voldoende lang om hergebruik te detecteren.
+> Bij ID Token validatie MOET `jti` uniek zijn (bewaar voldoende lang om hergebruik te detecteren).
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > jti REQUIRED . A unique identifier for the token, which can be used to prevent reuse of the token. The value of jti MUST uniquely identify the ID Token between sender and receiver for at least 12 months.
-  - *De bron bevestigt dat jti uniek MOET zijn (minimaal 12 maanden). De claim dat clients jti voldoende lang moeten bewaren om hergebruik te detecteren is impliciet aanwezig maar niet als expliciete client-verplichting geformuleerd — de bron formuleert jti als OP-verplichting bij het aanmaken van het token.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > jti a unique identifier generated by the client for this authentication. This identifier MUST contain at least 128 bits of entropy and MUST NOT be re-used by any subsequent authentication token.
-  - *De bron bevestigt de uniciteit van jti en het verbod op hergebruik, maar dit betreft client assertion JWTs (token endpoint), niet ID Token validatie. De claim stelt 'bewaar voldoende lang om hergebruik te detecteren', wat niet expliciet in de bron staat.*
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > jti REQUIRED. A unique identifier for the token, which can be used to prevent reuse of the token. The value of jti MUST uniquely identify the ID Token between sender and receiver for at least 12 months.
+  - *De bron bevestigt dat jti uniek moet zijn en voor minimaal 12 maanden uniek moet identificeren, maar zegt niets over de verplichting om jti-waarden bij te houden om hergebruik te detecteren (dat is een client-implementatieverplichting die niet expliciet in de bron staat).*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *jti claim uniciteit wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over jti-validatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ID Token jti-uniekheid valt buiten scope van het OAuth NL profiel. De bron beschrijft wel jti-uniciteit voor access tokens en client assertions, maar niet voor ID Tokens.*
 
-### `ls-iam-0031` — SKILL.md:229 *(§ Record-velden)*
+### `ls-iam-0033` — SKILL.md:229 *(§ Record-velden)*
 
-> Het ADL veld `trace_id` is verplicht en bestaat uit 16 byte hex (32 chars) conform W3C Trace Context, cryptografisch random.
+> Het ADL veld `trace_id` is verplicht: 16 byte hex (32 chars), conform W3C Trace Context, cryptografisch random.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - record-velden
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Record-velden
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
+  > trace-id = 32 HEXDIGLC ; 16 bytes array identifier. All zeroes forbidden
+  - *De bron bevestigt dat trace-id 16 byte hex (32 chars) is conform W3C Trace Context. De eis 'cryptografisch random' wordt slechts als aanbeveling beschreven: 'Randomly generated value of trace-id SHOULD be preferred', niet als MUST. De claim stelt het als verplicht vereiste, maar de spec zegt SHOULD. Verder is 'verplicht' in ADL-context (het ADL-veld zelf is verplicht) niet iets wat deze bron kan bevestigen.*
+
+### `ls-iam-0034` — SKILL.md:230 *(§ Record-velden)*
+
+> Het ADL veld `span_id` is verplicht: 8 byte hex (16 chars).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Record-velden
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
+  > parent-id = 16 HEXDIGLC ; 8 bytes array identifier. All zeroes forbidden
+  - *De bron bevestigt dat parent-id (span-id) 8 byte hex (16 chars) is. De claim dat het ADL-veld `span_id` verplicht is, kan deze technische spec niet bevestigen — dat is een ADL-specifieke eis buiten deze bron.*
+
+### `ls-iam-0035` — SKILL.md:231 *(§ Record-velden)*
+
+> Het ADL veld `parent_span_id` is conditioneel verplicht: verplicht bij upstream `traceparent`; alleen weglaatbaar bij root-span.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Record-velden
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
-  > trace-id = 32 HEXDIGLC ; 16 bytes array identifier. All zeroes forbidden
-  - *De bron bevestigt dat trace-id 16 bytes (32 hex chars) is conform W3C Trace Context. De eis van 'cryptografisch random' wordt ondersteund door sectie 8.2: 'Randomly generated value of trace-id SHOULD be preferred', maar dat is een SHOULD, geen MUST. Het ADL-specifieke veld `trace_id` en de verplichting ervan zijn niet in deze bron te vinden — dat is IAM/ADL-specificatie, niet W3C Trace Context.*
+  > If the value of the traceparent field wasn't changed before propagation, tracestate MUST NOT be modified as well.
+  - *De bron beschrijft traceparent-propagatie en de rol van parent-id als 'ID of this request as known by the caller', wat het concept van een upstream traceparent en root-span ondersteunt. De specifieke ADL-regel dat parent_span_id verplicht is bij upstream traceparent en weglaatbaar bij root-span staat niet expliciet in deze bron; de bron bevestigt alleen de onderliggende W3C-structuur.*
 
-### `ls-iam-0045` — reference.md:55 *(§ OIN (Organisatie Identificatie Nummer))*
+### `ls-iam-0050` — reference.md:89 *(§ Toegangsbeheer en Scopes)*
 
-> Het OIN is opgenomen in het `subject.serialNumber` veld van PKIoverheid-certificaten voor server- en client-authenticatie (mTLS).
+> De authorization server MOET controleren of gevraagde scopes geldig zijn, de client geautoriseerd is om ze te vragen, en de resource owner akkoord gaat met de gevraagde scopes.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIN-stelsel - PKIoverheid-certificaten
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth 2.0 - Scope-validatie
 
-- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > In case PKIoverheid certificates are used, the certificate and entire certificate chain up until the root certificate MUST be included as either an x5c or as x5u parameter, according to [RFC7517] Sections 4.6 and 4.7.
-  - *De bron vermeldt PKIoverheid-certificaten in de context van JWK-sets voor OIDC, maar zegt niets specifieks over het OIN in het subject.serialNumber veld voor mTLS. Dat is een aanvullende bewering over PKIoverheid-certificaatstructuur die buiten de scope van deze spec valt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > In case the Authorization Server, Resource Server and client are not operated under responsibility of the same organisation, each party MUST use PKIoverheid certificates with OIN.
-  - *De bron bevestigt dat OIN wordt gebruikt in PKIoverheid-certificaten, maar beschrijft niet specifiek dat het OIN in het `subject.serialNumber` veld staat.*
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > "Authorization servers SHOULD define and document default scope values that will be used if an authorization request does not specify a requested set of scopes." en "Authorization servers MAY restrict certain scopes from use by dynamically registered systems or public clients."
+  - *De bron beschrijft scope-beheer door de authorization server maar formuleert geen expliciete MUST-verplichting dat de server controleert of gevraagde scopes geldig zijn, de client geautoriseerd is, én de resource owner akkoord gaat. Sectie 4.1 zegt wel dat authorization servers alleen toegang mogen verlenen aan hogere scope-niveaus aan clients met toestemming, en dat verzoeken buiten toestemming worden geweigerd: "Client authorization requests containing scopes that are outside their permission MUST be rejected." Dit ondersteunt deels de claim maar dekt niet alle drie genoemde elementen expliciet.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt scope-validatie niet expliciet in de termen van de claim. Scope wordt wel als REQUIRED parameter genoemd maar de validatieplicht voor authorization servers zoals beschreven in de claim staat er niet in.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *OIN in PKIoverheid-certificaten wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen technische specificaties over scope-validatie door de authorization server.*
 
-### `ls-iam-0047` — reference.md:89 *(§ Toegangsbeheer en Scopes)*
+## UNGROUNDED — geen bron ondersteunt de claim (24)
 
-> De authorization server MOET controleren of gevraagde scopes geldig zijn, de client geautoriseerd is, en de resource owner akkoord gaat.
+### `ls-iam-0010` — SKILL.md:67 *(§ Token specificaties)*
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth-NL-profiel - scope-validatie
+> Access tokens in JWT-formaat (RFC 9068) zijn verplicht (MUST) per het OAuth NL profiel.
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > Authorization servers MAY restrict certain scopes from use by dynamically registered systems or public clients. [...] Client authorization requests containing scopes that are outside their permission MUST be rejected.
-  - *De bron bevestigt dat de authorization server scopes kan beperken en verzoeken buiten de scope-rechten moet afwijzen, maar bevat geen expliciete drieledige controle (geldigheid, client-autorisatie én resource owner akkoord) als één gecombineerde MUST-vereiste.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron behandelt scope in de context van OIDC-verzoeken (scope MUST contain at least openid), maar bevat geen expliciete normering dat de authorization server MUST controleren of gevraagde scopes geldig zijn, de client geautoriseerd is, en de resource owner akkoord gaat als gecombineerde verplichting. Dit is een OAuth-profiel-vereiste die in de NL GOV OAuth-spec thuis hoort.*
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth NL profiel - Token specificaties
+
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9068.txt](https://www.rfc-editor.org/rfc/rfc9068.txt)
+  - *RFC 9068 definieert een JWT-profiel voor access tokens, maar bevat geen verwijzing naar een 'OAuth NL profiel' of een verplichting vanuit dat profiel. De bron kan niet bevestigen dat het OAuth NL profiel JWT access tokens verplicht stelt; dat is een claim over het NL profiel zelf, niet over RFC 9068.*
+
+### `ls-iam-0032` — SKILL.md:223 *(§ Authorization Decision Log)*
+
+> Het ADL record-model is transport-onafhankelijk; OTLP wordt aanbevolen, maar elke transport is toegestaan zolang het record de gespecificeerde velden draagt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Authorization Decision Log - Transport
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL record-model en OTLP transport worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Scope-validatie door de authorization server wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ADL transport.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL record-model en OTLP transport worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0037` — SKILL.md:239 *(§ Record-velden)*
+
+> Een denial (decision: false) in ADL heeft status `Unset`, niet `Error`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Record-velden
+
+- **NOT_FOUND** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
+  - *De W3C Trace Context spec kent geen concept van 'status Unset bij denial'. Dit is ADL/OpenTelemetry-specifieke semantiek die niet in deze bron staat.*
+
+### `ls-iam-0038` — SKILL.md:253 *(§ attributes.adl.core.*)*
+
+> Source-referenties in ADL horen in `attributes`; een veld MOET in precies één van `attributes` of `body` staan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - attributes.adl.core.*
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL attributes en body velden worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ADL attributes.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL attributes/body structuur wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0039` — SKILL.md:264 *(§ attributes.adl.core.*)*
+
+> Aanvullende ADL attribute keys volgen `<vendor>.<area>.<name>`. Onbekende keys MOETEN door consumers worden genegeerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - attributes
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL attribute key naamgeving conventies worden niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ADL attribute keys.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL attribute key-naamgeving en consumer-gedrag worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0040` — SKILL.md:296 *(§ Trace context en ingestion)*
+
+> Alle componenten (PEP, PDP, PIP, PAP) MOETEN W3C Trace Context propageren; trace_id blijft ongewijzigd over organisatiegrenzen, ook bij sampling=0.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Trace context
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron betreft het OIDC NL GOV profiel. W3C Trace Context, PEP/PDP/PIP/PAP componenten en ADL worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over W3C Trace Context.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *W3C Trace Context propagatie door PEP/PDP/PIP/PAP wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0041` — SKILL.md:296 *(§ Trace context en ingestion)*
+
+> ADL records worden altijd geproduceerd, ook bij sampling=0 (records worden altijd geproduceerd).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Trace context
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *ADL records en sampling-gedrag vallen buiten de scope van deze OIDC-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ADL records bij sampling.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL records bij sampling=0 worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0042` — SKILL.md:296 *(§ Trace context en ingestion)*
+
+> Ingestion van ADL log records MOET idempotent zijn met `(trace_id, span_id)` of content-hash als sleutel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Ingestion
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Ingestion van ADL log records wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over idempotente ingestion van ADL records.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Idempotente ingestion van ADL log records wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0044` — reference.md:44 *(§ SAML Implementatiedetails)*
+
+> SAML assertions MOETEN worden ondertekend door de Identity Provider.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - Security Requirements
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *SAML assertions en ondertekeningsvereisten door Identity Providers worden niet behandeld in deze OIDC-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over SAML assertion signing.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *SAML assertions en ondertekening door de Identity Provider worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0045` — reference.md:45 *(§ SAML Implementatiedetails)*
+
+> SAML assertions KUNNEN worden versleuteld voor de Service Provider.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** SAML - Security Requirements
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *SAML assertion-encryptie voor Service Providers valt buiten de scope van deze OIDC-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over SAML assertion encryption.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Versleuteling van SAML assertions wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0046` — reference.md:46 *(§ SAML Implementatiedetails)*
+
+> TLS MOET worden gebruikt voor alle SAML communicatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - Security Requirements
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Hoewel de bron TLS vereist voor OIDC-communicatie, behandelt het geen TLS-vereisten specifiek voor SAML-communicatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over TLS voor SAML.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *TLS voor SAML communicatie specifiek wordt niet behandeld. De bron vereist wel TLS voor OAuth-communicatie, maar niet voor SAML.*
+</details>
+
+### `ls-iam-0047` — reference.md:47 *(§ SAML Implementatiedetails)*
+
+> SAML Metadata MOET worden ondertekend en periodiek worden gevalideerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - Security Requirements
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *SAML Metadata ondertekening en validatie worden niet behandeld in deze OIDC-specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over SAML Metadata ondertekening.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *SAML Metadata ondertekening en validatie worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0051` — reference.md:96 *(§ Pushed Authorization Requests (PAR))*
+
+> Pushed Authorization Requests (PAR) worden aanbevolen per RFC 9126 voor het OAuth NL profiel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OAuth NL profiel - PAR
+
+- **NOT_FOUND** (medium) — [https://www.rfc-editor.org/rfc/rfc9126.txt](https://www.rfc-editor.org/rfc/rfc9126.txt)
+  - *RFC 9126 definieert PAR en beschrijft de technische specificatie, maar bevat geen verwijzing naar een 'OAuth NL profiel' of een aanbeveling specifiek voor dat profiel. De claim gaat over een nationaal profiel dat buiten de scope van deze RFC valt.*
 
 ### `ls-iam-0053` — reference.md:151 *(§ Client Registratie)*
 
-> Voor native clients met per-instance registratie is dynamische client registratie verplicht (MUST); voor web- en browser-applicaties blijft handmatige registratie toegestaan.
+> Het OIDC NL GOV profiel beveelt dynamische client registratie (RFC 7591) aan ('Clients SHOULD use Dynamic Registration').
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - client registratie
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OIDC NL GOV profiel - Client registratie
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > In case a native Client is using per-instance registration, the Client MUST use Dynamic Registration. [...] Clients SHOULD use Dynamic Registration as per [RFC7591] to reduce manual labor and the risks of configuration errors.
-  - *De bron ondersteunt dat native clients met per-instance registratie MUST Dynamic Registration gebruiken. Voor web- en browser-applicaties zegt de bron SHOULD (niet dat handmatige registratie expliciet toegestaan blijft). De claim dat 'handmatige registratie toegestaan blijft' voor web/browser is een inferentie die de bron niet expliciet bevestigt.*
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > Native clients MUST either: use dynamic client registration to obtain a separate client id for each instance, or act as a public client by using a common client id and use PKCE [RFC7636] to protect calls to the token endpoint.
-  - *De bron bevestigt dat native clients met per-instance registratie dynamische client registratie MUST gebruiken, maar de claim stelt ook dat voor web- en browser-applicaties handmatige registratie toegestaan blijft — dit wordt niet expliciet zo geformuleerd in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7591.txt](https://www.rfc-editor.org/rfc/rfc7591.txt)
+  - *De bron is RFC 7591 zelf (de specificatie voor OAuth 2.0 Dynamic Client Registration). De claim gaat over het OIDC NL GOV profiel dat RFC 7591 aanbeveelt ('Clients SHOULD use Dynamic Registration'). RFC 7591 bevat geen uitspraken over het NL GOV profiel of aanbevelingen vanuit dat profiel — dat is een apart document. De bron is dus niet de juiste bron om deze claim te verifiëren.*
+
+### `ls-iam-0056` — reference.md:176 *(§ Trace context propagatie)*
+
+> Alle componenten (PEP, PDP, PIP, PAP) MOETEN W3C Trace Context propageren en trace-continuïteit over componentgrenzen behouden. De `trace_id` mag NIET binnen een lopende beslissingsflow opnieuw worden gealloceerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Trace context propagatie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *W3C Trace Context propagatie over componentgrenzen (PEP/PDP/PIP/PAP) en trace_id-allocatieregels worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Dynamische client registratie voor native clients wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over W3C Trace Context propagatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *W3C Trace Context propagatie en trace-continuïteit over componentgrenzen worden niet behandeld in deze bron.*
+</details>
 
-## UNGROUNDED — geen bron ondersteunt de claim (29)
+### `ls-iam-0057` — reference.md:178 *(§ Trace context propagatie)*
+
+> ADL-records zijn accountability records en MOETEN altijd worden geproduceerd, ongeacht sampling. ADL-emitters MOGEN het `sampled`-flag NIET wijzigen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Trace context propagatie
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron gaat over OIDC NL GOV profiel. ADL (Authorization Decision Log), trace context propagatie en sampling-flags worden nergens in de bron behandeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ADL-records als accountability records.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ADL-records als accountability records en sampled-flag beheer worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0058` — reference.md:184 *(§ Idempotente ingestion)*
+
+> Ingestion van ADL log records MOET idempotent zijn: re-submission van hetzelfde record MOET niet leiden tot een duplicate persisted record. De idempotency-sleutel is gangbaar `(trace_id, span_id)` of content-hash.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Idempotente ingestion
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Idempotente ingestion van ADL log records en idempotency-sleutels worden niet behandeld in deze OIDC NL GOV bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over idempotente ingestion van ADL records.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Idempotente ingestion van ADL log records wordt niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0059` — reference.md:188 *(§ Cached decisions)*
+
+> Indien een gecachte autorisatiebeslissing toch wordt toegepast, MOET de toepassing een nieuw log record produceren met trace_id en parent_span_id van de nieuwe request en een vers gealloceerde span_id.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Cached decisions
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Gecachte autorisatiebeslissingen en ADL log records voor nieuwe requests komen niet voor in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over gecachte autorisatiebeslissingen.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Gecachte autorisatiebeslissingen en bijbehorende log record vereisten worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0060` — reference.md:214 *(§ Retention en Privacy)*
+
+> ADL log records MOETEN minimaal 12 maanden worden bewaard voor audit doeleinden.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Retention
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Retentievereisten voor ADL log records worden niet behandeld in deze OIDC NL GOV bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over retentie van ADL log records.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Retentievereisten voor ADL log records worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0061` — reference.md:217 *(§ Retention en Privacy)*
+
+> Persoonlijke identificeerbare informatie (PII) in ADL log records MOET worden beschermd en toegang tot logs MOET worden beperkt tot geautoriseerd personeel.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Privacy
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Hoewel de bron privacy-overwegingen bespreekt, gaat die niet over bescherming van PII in ADL log records of toegangsbeperking tot logs.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De brontekst beschrijft het beheermodel van de OAuth-NL standaard. Er is geen enkele vermelding van Authorization Decision Logs (ADL), PII-bescherming in logs, of toegangsbeperking tot logbestanden.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *PII-bescherming in ADL log records en toegangsbeperking tot logs worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0062` — reference.md:220 *(§ Retention en Privacy)*
+
+> Bij het delen van ADL logs voor analyse MOETEN PII worden geanonimiseerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - Privacy
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Anonimisering van PII bij het delen van ADL logs wordt niet behandeld in deze bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De brontekst bevat geen informatie over ADL logs, anonimisering van PII, of het delen van loggegevens voor analyse.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt het OAuth 2.0 NL GOV profiel. Er is geen vermelding van Authorization Decision Log (ADL) of anonimisering van PII in logs.*
+</details>
+
+### `ls-iam-0063` — reference.md:235 *(§ Toegankelijkheidsvalidatie)*
+
+> De IAM-specificaties MOETEN voldoen aan WCAG 2.1 niveau AA voor toegankelijkheid.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** IAM - Toegankelijkheidsvalidatie
+
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-NL-profiel](https://logius-standaarden.github.io/OAuth-NL-profiel)
+  - *De brontekst bevat geen enkele verwijzing naar WCAG, toegankelijkheid, of AA-niveaus.*
+
+### `ls-iam-0064` — reference.md:248 *(§ Markdown Linting)*
+
+> Markdown bestanden in IAM repositories MOETEN voldoen aan de markdownlint regels voor consistente opmaak.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** IAM - Markdown Linting
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *Markdown linting vereisten voor IAM repositories worden niet behandeld in deze technische specificatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De brontekst gaat over het beheermodel van OAuth-NL en bevat geen vereisten over markdownlint of opmaakregels voor Markdown bestanden.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron bevat geen informatie over markdownlint regels of Markdown opmaak vereisten voor IAM repositories.*
+</details>
+
+### `ls-iam-0066` — reference.md:138 *(§ Userinfo Endpoint)*
+
+> De OpenID Provider MOET gebruikers informeren over welke claims worden gedeeld en met welke Relying Parties.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV - Userinfo privacy
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron behandelt dataminimalisatie en privacy, maar een expliciete verplichting voor de OpenID Provider om gebruikers te informeren over welke claims worden gedeeld en met welke Relying Parties staat niet in de bron.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De brontekst bevat geen informatie over OpenID Provider verplichtingen rondom het informeren van gebruikers over gedeelde claims of Relying Parties.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron behandelt OAuth 2.0, niet OIDC NL GOV gebruikersinformatie-verplichtingen voor OpenID Providers over het informeren van gebruikers.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (26)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
 
 ### `ls-iam-0001` — SKILL.md:36 *(§ Versiemodel)*
 
@@ -291,624 +737,356 @@
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie - Authenticatie-standaarden
 
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  > De Authenticatie-standaarden op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie bestaan uit: OpenID.NLGov, Nederlands overheidsprofiel op OpenID Connect, versie 1.0.1 SAML, versie 2.0 [...] Datum van besluit 21-09-2023
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. OpenID.NLGov (v1.0.1) en SAML worden niet genoemd, en de datum 21-09-2023 komt niet voor in de bron.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *De bron behandelt uitsluitend het intakeadvies voor NL Gov Assurance Profile for OAuth 2.0 versie 1.1. OpenID.NLGov (v1.0.1) en SAML worden niet genoemd, laat staan hun verplichtingstatus of de datum 21-09-2023.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron is de technische specificatie van OpenID NLGov 1.0.1 zelf. Informatie over 'pas-toe-of-leg-uit'-status bij Forum Standaardisatie of de datum 21-09-2023 staat niet in deze bron. De bron vermeldt wel 'September 18, 2023' als publicatiedatum, maar niet de verplichtstellingsstatus door Forum Standaardisatie.*
+  - *De bron is de technische specificatie zelf (v1.0.1). Publicatie-metadata over 'pas-toe-of-leg-uit'-status of de datum 21-09-2023 staat niet in de spec.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De brontekst gaat over het beheermodel van het OAuth-NL profiel. OpenID.NLGov en SAML worden niet besproken; de datum 21-09-2023 wordt nergens genoemd.*
-
-### `ls-iam-0002` — SKILL.md:36 *(§ Versiemodel)*
-
-> Voor nieuwe implementaties wordt OIDC aanbevolen; bestaande SAML-koppelingen blijven ondersteund.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Authenticatie-standaarden NL overheid
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron bevat geen aanbeveling over migratie van SAML naar OIDC of het ondersteunen van bestaande SAML-koppelingen. Dit is beleid van Forum Standaardisatie, niet inhoud van de technische spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De bron behandelt het beheermodel van OAuth-NL, niet de aanbeveling van OIDC versus SAML voor nieuwe implementaties.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt uitsluitend het OAuth NL profiel. OIDC versus SAML-aanbevelingen voor nieuwe implementaties komen niet voor in deze tekst.*
+  - *De brontekst betreft het beheermodel van OAuth-NL. SAML en OpenID.NLGov v1.0.1 als gecombineerde vermelding per 21-09-2023 worden niet genoemd.*
 </details>
-
-### `ls-iam-0011` — SKILL.md:67 *(§ Token specificaties)*
-
-> Access tokens MOETEN het JWT-formaat (RFC 9068) hebben per het OAuth NL profiel.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth-NL-profiel - access tokens
-
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9068.txt](https://www.rfc-editor.org/rfc/rfc9068.txt)
-  - *RFC 9068 definieert het JWT-profiel voor OAuth 2.0 access tokens als standaard, maar bevat geen verwijzing naar een 'OAuth NL profiel' of enige verplichting dat dit NL profiel JWT-formaat MOET gebruiken. De bron beschrijft de RFC zelf, niet een nationaal profiel dat daarnaar verwijst.*
-
-### `ls-iam-0030` — SKILL.md:223 *(§ Authorization Decision Log)*
-
-> Het ADL record-model is transport-onafhankelijk; OTLP wordt aanbevolen, maar elke transport is toegestaan zolang het record de gespecificeerde velden draagt.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Authorization Decision Log - transport
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *ADL transport-onafhankelijkheid en OTLP worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *ADL record-model en OTLP transport worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. ADL (Authorization Decision Log), OTLP en transport-onafhankelijkheid komen niet voor in deze bron.*
-</details>
-
-### `ls-iam-0032` — SKILL.md:231 *(§ Record-velden)*
-
-> Het ADL veld `parent_span_id` is conditioneel verplicht: verplicht bij upstream `traceparent`, alleen weglaatbaar bij root-span.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - record-velden
-
-- **NOT_FOUND** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
-  - *De W3C Trace Context spec definieert parent-id als veld in de traceparent header, maar bevat geen uitspraken over een ADL-veld `parent_span_id` of conditionele verplichtingen daaromtrent. Dit is ADL-specifieke logica buiten scope van deze bron.*
-
-### `ls-iam-0034` — SKILL.md:239 *(§ Record-velden)*
-
-> Een denial (decision: false) heeft status `Unset`, niet `Error` in het ADL.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - status
-
-- **NOT_FOUND** (high) — [https://www.w3.org/TR/trace-context](https://www.w3.org/TR/trace-context)
-  - *De W3C Trace Context spec bevat geen informatie over ADL-statusvelden of de relatie tussen een authorization denial en een `Unset`-status. Dit valt buiten het onderwerp van deze bron.*
-
-### `ls-iam-0035` — SKILL.md:253 *(§ `attributes.adl.core.*`)*
-
-> Een ADL-veld MOET in precies één van de twee locaties staan: `attributes` (source-referenties) of `body` (raw data).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - attributes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *ADL attributes/body-velden worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *ADL-velden en hun locaties worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *ADL record-model met attributes/body-velden komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0036` — SKILL.md:264 *(§ `attributes.adl.core.*`)*
-
-> Aanvullende ADL attribute keys volgen het patroon `<vendor>.<area>.<name>`. Onbekende keys MOETEN door consumers worden genegeerd.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - attributes
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *ADL attribute key-patronen worden niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *ADL attribute key patronen worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *ADL attribute key patronen komen niet voor in deze bron.*
-</details>
-
-### `ls-iam-0037` — SKILL.md:296 *(§ Trace context en ingestion)*
-
-> Alle ADL-componenten (PEP, PDP, PIP, PAP) MOETEN W3C Trace Context propageren; `trace_id` blijft ongewijzigd over organisatiegrenzen, ook bij sampling=0.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - trace context
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *W3C Trace Context propagatie in ADL-context wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *W3C Trace Context propagatie in ADL-componenten wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *W3C Trace Context propagatie voor ADL-componenten (PEP, PDP, PIP, PAP) komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0038` — SKILL.md:296 *(§ Trace context en ingestion)*
-
-> ADL-records worden altijd geproduceerd ongeacht het sampled-bit in traceparent (sampling=0 geeft geen vrijstelling van logging).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - trace context
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *ADL-logging ongeacht sampled-bit wordt niet behandeld in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *ADL-records en het sampled-bit worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *ADL-records en sampled-bit/sampling vrijstelling komen niet voor in deze bron.*
-</details>
-
-### `ls-iam-0039` — SKILL.md:296 *(§ Trace context en ingestion)*
-
-> Ingestion van ADL log records MOET idempotent zijn met `(trace_id, span_id)` of content-hash als sleutel.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - ingestion
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron gaat over OpenID Connect NL GOV profiel. ADL (Authorization Decision Log) ingestion en idempotentie worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Idempotente ingestion van ADL log records wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Idempotente ingestion van ADL log records komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0040` — reference.md:9 *(§ SAML)*
-
-> SAML is samen met OpenID.NLGov (v1.0.1) verplicht als onderdeel van de gecombineerde vermelding 'Authenticatie-standaarden' op het Forum Standaardisatie (sinds 21-09-2023).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie - Authenticatie-standaarden
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron beschrijft de OIDC NL GOV standaard zelf, maar bevat geen informatie over de gecombineerde vermelding met SAML op het Forum Standaardisatie-lijst of de datum 21-09-2023.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De gecombineerde vermelding 'Authenticatie-standaarden' met SAML en OpenID.NLGov per 21-09-2023 wordt niet besproken in dit beheermodeldocument, dat alleen over OAuth-NL gaat.*
-
-### `ls-iam-0041` — reference.md:44 *(§ SAML Implementatiedetails)*
-
-> SAML assertions MOETEN worden ondertekend door de Identity Provider.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - security requirements
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron behandelt OpenID Connect, niet SAML. SAML-ondertekeningsvereisten voor assertions staan niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *SAML assertion signing wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *SAML assertions en ondertekening door de Identity Provider worden niet behandeld in deze OAuth-NL-profiel bron.*
-</details>
-
-### `ls-iam-0042` — reference.md:45 *(§ SAML Implementatiedetails)*
-
-> SAML assertions KUNNEN worden versleuteld voor de Service Provider.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** SAML - security requirements
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron behandelt OpenID Connect, niet SAML. SAML assertion-encryptie wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *SAML assertion encryptie wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *SAML assertion versleuteling voor de Service Provider komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0043` — reference.md:46 *(§ SAML Implementatiedetails)*
-
-> TLS MOET worden gebruikt voor alle SAML communicatie.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - security requirements
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron behandelt OpenID Connect, niet SAML. TLS-vereisten voor SAML-communicatie staan niet in deze spec.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *TLS-vereisten voor SAML communicatie worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Hoewel de bron TLS vereist voor OAuth-communicatie, behandelt zij geen SAML-specifieke TLS-vereisten.*
-</details>
-
-### `ls-iam-0044` — reference.md:47 *(§ SAML Implementatiedetails)*
-
-> SAML Metadata MOET worden ondertekend en periodiek worden gevalideerd.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SAML - security requirements
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron behandelt OpenID Connect, niet SAML. SAML Metadata-ondertekening en -validatie worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *SAML Metadata ondertekening en validatie worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *SAML Metadata ondertekening en periodieke validatie komen niet voor in deze bron.*
-</details>
-
-### `ls-iam-0048` — reference.md:96 *(§ Pushed Authorization Requests (PAR))*
-
-> Pushed Authorization Requests (PAR) worden aanbevolen (RFC 9126) per het OAuth NL profiel.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OAuth-NL-profiel - PAR
-
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc9126.txt](https://www.rfc-editor.org/rfc/rfc9126.txt)
-  - *De bron is RFC 9126 zelf. De bron beschrijft de PAR-specificatie maar maakt geen melding van een 'OAuth NL profiel' of een Nederlandse aanbeveling. De claim gaat over het NL-profiel dat PAR aanbeveelt, wat buiten de scope van deze bron valt.*
-
-### `ls-iam-0050` — reference.md:138 *(§ Userinfo Endpoint)*
-
-> De OpenID Provider MOET gebruikers informeren over welke claims worden gedeeld en met welke Relying Parties.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - privacy
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron bevat geen verplichting dat de OpenID Provider gebruikers moet informeren over welke claims worden gedeeld en met welke Relying Parties. Privacy-overwegingen richten zich op dataminimalisatie, pairwise identifiers en encryptie, niet op een informatieplicht richting gebruikers.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Informatieplicht van de OpenID Provider richting gebruikers wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Informatieplicht van de OpenID Provider aan gebruikers over gedeelde claims en Relying Parties komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0052` — reference.md:151 *(§ Client Registratie)*
-
-> Het OIDC NL GOV profiel beveelt dynamische client registratie (RFC 7591) aan ('Clients SHOULD use Dynamic Registration').
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OIDC NL GOV profiel - client registratie
-
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7591.txt](https://www.rfc-editor.org/rfc/rfc7591.txt)
-  - *De brontekst is RFC 7591 zelf (de specificatie voor OAuth 2.0 Dynamic Client Registration). De claim gaat over wat het OIDC NL GOV profiel aanbeveelt ('Clients SHOULD use Dynamic Registration'). RFC 7591 bevat geen tekst over het NL GOV profiel of aanbevelingen daarin; die uitspraak staat in het NL GOV profiel-document, niet in RFC 7591.*
-
-### `ls-iam-0054` — reference.md:176 *(§ Trace context propagatie)*
-
-> Alle ADL-componenten MOETEN W3C Trace Context propageren en trace-continuïteit over componentgrenzen behouden. Een nieuwe `trace_id` MAG NIET worden gealloceerd binnen een lopende beslissingsflow.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Authorization Decision Log - trace context propagatie
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron behandelt OpenID Connect NL GOV. ADL (Authorization Decision Log) en W3C Trace Context worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *W3C Trace Context propagatie en verbod op nieuwe trace_id allocatie worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *W3C Trace Context propagatie en verbod op nieuwe trace_id allocatie binnen ADL-flows komen niet voor in deze bron.*
-</details>
-
-### `ls-iam-0055` — reference.md:178 *(§ Trace context propagatie)*
-
-> ADL-records zijn accountability records en MOETEN altijd worden geproduceerd, ongeacht sampling. ADL-emitters MOGEN het `sampled`-flag NIET wijzigen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - sampling
-
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **OUT_OF_SCOPE** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron behandelt OpenID Connect NL GOV. ADL-records, accountability records en sampling-flags worden niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *ADL-records als accountability records en sampling-vereisten worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *ADL-records als accountability records en het sampled-flag komen niet voor in deze bron.*
-</details>
-
-### `ls-iam-0056` — reference.md:184 *(§ Idempotente ingestion)*
-
-> Ingestion van ADL log records MOET idempotent zijn; re-submission MOET niet leiden tot een duplicate persisted record. De idempotency-sleutel is `(trace_id, span_id)` of een content-hash.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - idempotente ingestion
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron gaat over OpenID Connect NL GOV profiel. Er is geen sprake van een Authorization Decision Log, idempotente ingestion, trace_id, span_id of content-hash.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Idempotente ingestion van ADL log records wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Idempotente ingestion van ADL log records met (trace_id, span_id) als sleutel komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0057` — reference.md:188 *(§ Cached decisions)*
-
-> Caching van autorisatiebeslissingen wordt afgeraden. Indien toch toegepast, MOET de toepassing van een gecachte beslissing een nieuw log record produceren met de `trace_id` en `parent_span_id` van de nieuwe request en een vers gealloceerde `span_id`.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - cached decisions
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron behandelt caching van Discovery-documenten en JWK-sets, niet het cachen van autorisatiebeslissingen of een Authorization Decision Log.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Caching van autorisatiebeslissingen en bijbehorende ADL-vereisten worden niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Caching van autorisatiebeslissingen en bijbehorende logging-vereisten komen niet voor in deze bron.*
-</details>
-
-### `ls-iam-0058` — reference.md:214 *(§ Retention en Privacy)*
-
-> ADL log records MOETEN minimaal 12 maanden worden bewaard voor audit doeleinden.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - retention
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *Geen vermelding van ADL log records, retentieperiodes of audit-bewaarplicht in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Minimale bewaarperiode van ADL log records wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Bewaarplicht van 12 maanden voor ADL log records komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0059` — reference.md:217 *(§ Retention en Privacy)*
-
-> Persoonlijke identificeerbare informatie (PII) in ADL log records MOET worden beschermd.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - privacy
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron bevat privacy-overwegingen over pairwise identifiers en data minimization, maar niets over PII-bescherming in ADL log records.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *PII-bescherming in ADL log records wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Bescherming van PII in ADL log records komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0060` — reference.md:218 *(§ Retention en Privacy)*
-
-> Toegang tot ADL logs MOET worden beperkt tot geautoriseerd personeel.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - privacy
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *Geen vermelding van toegangsbeperking tot ADL logs in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De bron gaat over het beheermodel van de OAuth-NL standaard. Er wordt nergens gesproken over een Authorization Decision Log (ADL) of toegangsbeperking tot logbestanden.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Toegangsbeperking tot ADL logs voor geautoriseerd personeel komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0061` — reference.md:220 *(§ Retention en Privacy)*
-
-> Bij het delen van ADL logs voor analyse MOETEN PII worden geanonimiseerd.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Authorization Decision Log - privacy
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *Geen vermelding van het delen of anonimiseren van ADL logs voor analyse in deze bron.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De bron bevat geen informatie over Authorization Decision Logs, het delen van logs voor analyse, of het anonimiseren van PII in logbestanden.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Anonimisering van PII bij delen van ADL logs voor analyse komt niet voor in deze bron.*
-</details>
-
-### `ls-iam-0062` — reference.md:235 *(§ Toegankelijkheidsvalidatie)*
-
-> IAM-specificaties MOETEN voldoen aan WCAG 2.1 niveau AA voor toegankelijkheid.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** IAM repositories - toegankelijkheid
-
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-NL-profiel](https://logius-standaarden.github.io/OAuth-NL-profiel)
-  - *De brontekst bevat geen enkele verwijzing naar WCAG, toegankelijkheid (accessibility), of soortgelijke vereisten. De specificatie richt zich uitsluitend op OAuth 2.0 autorisatie- en authenticatieprofielen.*
-
-### `ls-iam-0063` — reference.md:248 *(§ Markdown Linting)*
-
-> Markdown bestanden MOETEN voldoen aan de markdownlint regels voor consistente opmaak.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** IAM repositories - markdown linting
-
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron bevat geen vereisten over markdown linting of markdownlint regels.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De bron beschrijft het beheermodel van OAuth-NL en noemt wel dat pre-commit hooks worden gebruikt in het generieke beheermodel, maar bevat geen specifieke vereisten over markdownlint regels voor markdown bestanden.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De brontekst is de NL GOV Assurance profile for OAuth 2.0 specificatie. Deze bevat geen informatie over markdownlint regels of opmaakconventies voor Markdown bestanden in repositories. Dit is een technische OAuth-specificatie, geen repository-stijlgids.*
-</details>
-
-## GROUNDED — minstens één bron ondersteunt de claim (19)
-
-<details>
-<summary>Klap uit voor alle GROUNDED claims</summary>
 
 ### `ls-iam-0003` — SKILL.md:38 *(§ Versiemodel)*
 
-> Het OAuth-NL-profiel v1.0 staat op het Forum Standaardisatie als verplicht ('pas-toe-of-leg-uit').
+> OAuth-NL-profiel v1.0 staat op het Forum Standaardisatie als verplicht ('pas-toe-of-leg-uit').
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie - OAuth NL profiel
 
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  > Verplicht ('Pas toe leg uit') [...] NL GOV Assurance Profile for OAuth 2.0 moet worden toegepast bij applicaties waarbij gebruikers of 'resource owners' impliciet of expliciet toestemming geven aan een dienst van een derde om namens deze toegang te krijgen tot gegevens via een REST API
+  - *De bron bevestigt de verplichte ('pas-toe-of-leg-uit') status. De versie wordt in de detailinformatie als '15 juli 2019' / 'v1.0' aangeduid; het besluit viel op 09-07-2020.*
+- **SUPPORTED** (medium) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  > NL Gov Assurance profile for OAuth 2.0 is 15 juli 2019 opgenomen op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie.
+  - *De bron bevestigt dat het OAuth-NL-profiel op de 'Pas toe of leg uit'-lijst staat, maar noemt expliciet de opnamedatum 15 juli 2019 en verwijst naar v1.0 impliciet (de huidige aanmelding betreft v1.1 als nieuwe versie). De claim spreekt over 'v1.0' wat consistent is met de context, maar de bron specificeert het versienummer van de reeds geplaatste versie niet expliciet als '1.0'.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  > De status van de standaard is 'Verplicht (pas toe leg uit)'. Dit houdt kort gezegd in dat Nederlandse overheden en instellingen uit de (semi) publieke sector verplicht zijn deze standaard toe te passen op het moment dat zij REST API's gaan gebruiken voor het ontsluiten van overheidsinformatie
-
-### `ls-iam-0004` — SKILL.md:38 *(§ Versiemodel)*
-
-> OAuth-NL-profiel versie v1.1.0 is vastgesteld door Logius (DEF) en gepubliceerd op gitdocumentatie.logius.nl.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth-NL-profiel
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > NL GOV Assurance profile for OAuth 2.0 v1.1.0 Logius Standard Definitive version December 03, 2024 [...] MIDO programmeringstafel 1.1.0 definitive approved version 03-12-2024
+  > De actuele versie van de OAuth-NL is v1.0. [...] De status van de standaard is 'Verplicht (pas toe leg uit)'. Dit houdt kort gezegd in dat Nederlandse overheden en instellingen uit de (semi) publieke sector verplicht zijn deze standaard toe te passen
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De bron behandelt uitsluitend de Authenticatie-standaarden (OpenID.NLGov en SAML). Het OAuth-NL-profiel wordt in deze brontekst niet genoemd.*
 
 ### `ls-iam-0005` — SKILL.md:61 *(§ Verplichte beveiligingseisen)*
 
-> PKCE is verplicht voor alle clients per het OIDC NL GOV profiel, inclusief confidential clients die private_key_jwt of mTLS gebruiken; er is geen vrijstelling.
+> PKCE is verplicht voor alle clients per het OIDC NL GOV profiel ('Clients MUST use PKCE to protect calls to the Token Endpoint'), inclusief confidential clients die private_key_jwt of mTLS gebruiken — er is geen vrijstelling.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - PKCE
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > Clients MUST use 'Proof Key for Code Exchange' [RFC7636] to protect calls to the Token Endpoint. [...] OpenID Providers MUST support and require the use of 'Proof Key for Code Exchange' ([RFC7636]) using only the S256 verification method
-  - *De MUST geldt voor alle clients zonder vrijstelling. Sectie 4.1 stelt dit als algemene vereiste voor alle client types, en sectie 5 vereist dat providers dit afdwingen.*
+  > Clients MUST use 'Proof Key for Code Exchange' [RFC7636] to protect calls to the Token Endpoint.
+  - *De spec maakt geen uitzondering voor confidential clients die private_key_jwt of mTLS gebruiken. De MUST geldt voor alle clients universeel (sectie 4.1).*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De bron beschrijft het beheermodel, niet de technische inhoud van het OIDC NL GOV profiel. PKCE-vereisten worden niet besproken.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron is het OAuth NL profiel, niet het OIDC NL GOV profiel. PKCE-vereisten voor confidential clients die private_key_jwt of mTLS gebruiken worden in deze bron niet behandeld. De bron vereist PKCE voor public clients en native clients, maar spreekt niet van een vrijstellingsloze verplichting voor alle clients inclusief confidential clients.*
+  - *De bron is het beheermodel van OAuth-NL, geen technische specificatie. PKCE-vereisten worden niet beschreven.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron is het OAuth NL profiel, niet het OIDC NL GOV profiel. PKCE-verplichtingen voor confidential clients in OIDC NL GOV context worden hier niet behandeld. Het OAuth NL profiel verplicht PKCE voor public/native clients en via section 3.1.7 voor de authorization server, maar de specifieke OIDC NL GOV formulering over geen vrijstelling voor confidential clients staat niet in deze bron.*
 
 ### `ls-iam-0006` — SKILL.md:62 *(§ Verplichte beveiligingseisen)*
 
-> De grant type 'authorization_code' is verplicht (MUST) per het OAuth NL profiel.
+> Grant type `authorization_code` is verplicht (MUST); `client_credentials` is toegestaan (MAY) voor machine-to-machine communicatie.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth-NL-profiel - grant types
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth NL profiel - Grant types
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > grant_type REQUIRED . MUST contain the value authorization_code . Identical as in [OAuth2.NLGov].
-  - *De bron bevestigt dat authorization_code verplicht is in het token request, en verwijst naar OAuth2.NLGov. De claim stelt dit als vereiste 'per het OAuth NL profiel', maar de bron zelf is het OIDC NL GOV profiel dat verwijst naar OAuth2.NLGov. De inhoud klopt, maar de directe bron voor de claim is het OAuth NL profiel dat hier niet beschikbaar is.*
+  > grant_types_supported REQUIRED . JSON array containing the list of OAuth 2.0 grant_type values that the OpenID Provider supports. In the context of this profile, the value MUST be ['authorization_code'].
+  - *authorization_code als MUST wordt ondersteund. Echter, client_credentials (MAY voor M2M) wordt in deze OIDC-spec niet vermeld — die scope valt onder de OAuth NL GOV spec. De bron is een OIDC-profiel, niet de OAuth NL profiel.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
   > The authorization server MUST support the authorization_code , and MAY support the client_credentials grant types as described in Section 2.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Grant types worden in dit beheermodeldocument niet technisch gespecificeerd.*
+  - *De bron is het beheermodel en bevat geen technische specificaties over grant types.*
 
-### `ls-iam-0007` — SKILL.md:62 *(§ Verplichte beveiligingseisen)*
-
-> De grant type 'client_credentials' is toegestaan (MAY) voor machine-to-machine communicatie per het OAuth NL profiel.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth-NL-profiel - grant types
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > The authorization server MUST support the authorization_code , and MAY support the client_credentials grant types as described in Section 2. [...] These clients use the client credentials flow of OAuth 2 by sending a request to the token endpoint with the client's credentials and obtaining an access token in the response.
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron vermeldt client_credentials grant type niet. In de discovery document sectie staat grant_types_supported MUST be ['authorization_code']. client_credentials wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Client credentials grant type wordt niet besproken in dit beheermodeldocument.*
-
-### `ls-iam-0009` — SKILL.md:63 *(§ Verplichte beveiligingseisen)*
+### `ls-iam-0008` — SKILL.md:63 *(§ Verplichte beveiligingseisen)*
 
 > Access tokens worden als HTTP Authorization header (Bearer scheme) meegegeven. Transport via query parameters is verboden (MUST NOT).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** OAuth-NL-profiel - token transport
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** OAuth NL profiel - Token transport
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > Clients SHOULD send bearer tokens passed in the Authentication header as defined by [rfc6750]. [...] A Protected Resource under this profile MUST NOT accept access tokens passed using the query parameter method.
+  > A Protected Resource under this profile MUST NOT accept access tokens passed using the query parameter method.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  - *De bron bevat geen expliciete bepaling over het verbod op het meegeven van access tokens als query parameter. Het Bearer scheme wordt getoond in een voorbeeld (Authorization: Bearer ...) maar een MUST NOT voor query parameters staat er niet in.*
+  - *De bron bevat geen expliciete bepaling over het verbod op transport van access tokens via query parameters. Dit is OAuth NL GOV profiel-materie, niet terug te vinden in deze OIDC-spec.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Token transport en Authorization header-vereisten worden niet besproken in dit beheermodeldocument.*
+  - *De bron is het beheermodel en bevat geen technische specificaties over token transport.*
 
-### `ls-iam-0010` — SKILL.md:63 *(§ Verplichte beveiligingseisen)*
+### `ls-iam-0009` — SKILL.md:63 *(§ Verplichte beveiligingseisen)*
 
-> Form-encoded body parameters (RFC 6750 Section 2.2) zijn toegestaan voor het meegeven van access tokens.
+> Form-encoded body parameters (RFC 6750 Section 2.2) zijn toegestaan als methode om access tokens mee te sturen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth-NL-profiel - token transport
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth NL profiel - Token transport
 
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc6750.txt](https://www.rfc-editor.org/rfc/rfc6750.txt)
   > Resource servers MAY support this method.
-  - *RFC 6750 Section 2.2 beschrijft de form-encoded body parameter methode en stelt dat resource servers deze MAY ondersteunen. De claim gebruikt 'toegestaan' (MAY), wat overeenkomt met de tekst in de bron.*
+  - *RFC 6750 Section 2.2 beschrijft de form-encoded body parameter methode en stelt expliciet dat resource servers deze methode MAY ondersteunen, wat overeenkomt met de claim dat deze methode 'toegestaan' is.*
 
-### `ls-iam-0012` — SKILL.md:68 *(§ Token specificaties)*
+### `ls-iam-0011` — SKILL.md:68 *(§ Token specificaties)*
 
-> Refresh tokens worden ondersteund (MAY) bij de authorization_code flow en maken het mogelijk nieuwe access tokens te verkrijgen zonder hernieuwde gebruikersinteractie.
+> Refresh tokens worden ondersteund (MAY) bij de authorization_code flow; refresh token rotation wordt aanbevolen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth-NL-profiel - refresh tokens
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth NL profiel - Refresh tokens
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
   > OpenID Providers MAY issue Refresh Tokens to Clients; when used, Refresh Tokens MUST be one-time-use or sender-constrained.
-  - *De bron bevestigt dat refresh tokens MAY worden uitgegeven. De koppeling aan specifiek de authorization_code flow staat niet expliciet vermeld maar is impliciet (dit profiel gebruikt alleen authorization_code).*
+  - *MAY voor refresh tokens wordt bevestigd. Rotation wordt indirect ondersteund: 'with every Access Token refresh response the OpenID Provider can issue a new Refresh Token and MUST invalidate the previous Refresh Token'.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > This client type MAY request and be issued a refresh token if the security parameters of the access request allow for it. [...] Under this profile, refresh tokens are supported.
+  > Authorization Servers MAY issue refresh tokens to clients under the following context: [...] This client type MAY request and be issued a refresh token if the security parameters of the access request allow for it.
+  - *Refresh token rotation wordt als 'Refresh tokens for public clients must either be sender-constrained or one-time use' aangestipt, wat gedeeltelijk overeenkomt met de aanbeveling voor rotation.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Refresh tokens worden niet besproken in dit beheermodeldocument.*
+  - *De bron is het beheermodel en bevat geen technische specificaties over refresh tokens.*
 
-### `ls-iam-0013` — SKILL.md:68 *(§ Token specificaties)*
+### `ls-iam-0013` — SKILL.md:76 *(§ Client authenticatie)*
 
-> Refresh token rotation wordt aanbevolen per het OAuth NL profiel.
+> mTLS (Mutual TLS) is een gelijkwaardig alternatief per het OIDC NL GOV profiel voor client authenticatie bij het token endpoint (MAY per OAuth NL profiel).
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** OAuth-NL-profiel - refresh tokens
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** OAuth NL profiel / OIDC NL GOV - Client authenticatie
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > For security reasons, Refresh Tokens that are not sender-constrained MUST be one-time-use, i.e. with every Access Token refresh response the OpenID Provider can issue a new Refresh Token and MUST invalidate the previous Refresh Token
-  - *Refresh token rotation wordt vereist (MUST) voor niet-sender-constrained tokens, wat de aanbeveling (SHOULD) in de claim ondersteunt. De bron stelt het als vereiste, wat sterker is dan de claim suggereert.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Refresh token rotation wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron vermeldt dat refresh tokens voor public clients sender-constrained of one-time use MOETEN zijn, maar een expliciete SHOULD-aanbeveling voor 'refresh token rotation' als algemeen concept ontbreekt.*
-
-### `ls-iam-0014` — SKILL.md:75 *(§ Client authenticatie)*
-
-> private_key_jwt is verplicht per het OAuth NL profiel voor client authenticatie bij het token endpoint.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OAuth-NL-profiel - client authenticatie
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > Confidential Clients, as defined in Section 4.1, MUST authenticate to the OpenID Provider using either: a JWT assertion as defined by the 'JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants' [RFC7523] using only the private_key_jwt method defined in [OpenID.Core]; or mutually authenticated TLS, as specified in [RFC8705].
-  - *De bron vereist private_key_jwt ÓÓOF mTLS voor confidential clients — het is dus geen absolute verplichting van private_key_jwt alleen. De claim stelt private_key_jwt als enige verplichte methode, maar de bron geeft mTLS als gelijkwaardig alternatief. Bovendien is de claim dat dit 'per het OAuth NL profiel' is, terwijl deze bron het OIDC NL GOV profiel is.*
+  > Confidential Clients, as defined in Section 4.1, MUST authenticate to the OpenID Provider using either: a JWT assertion as defined by the 'JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants' [RFC7523] using only the private_key_jwt method... or mutually authenticated TLS, as specified in [RFC8705].
+  - *mTLS wordt in deze OIDC NL GOV spec als gelijkwaardig alternatief voor private_key_jwt gepresenteerd (beide als MUST-opties). De kwalificatie 'MAY per OAuth NL profiel' kan niet vanuit deze bron worden geverifieerd.*
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > Full clients, native clients with dynamically registered keys, and direct access clients as defined above MUST authenticate to the authorization server's token endpoint using a JWT assertion as defined by the [JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants] using only the private_key_jwt method defined in [OpenID Connect Core].
+  > In addition to private_key_jwt , the client authentication method tls_client_auth [ rfc8705 ] MAY also be used.
+  - *De claim verwijst ook naar OIDC NL GOV profiel, maar het OAuth NL profiel bevestigt de MAY-status van mTLS als alternatief voor client authenticatie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *private_key_jwt als verplicht authenticatiemechanisme bij het token endpoint wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het beheermodel en bevat geen technische specificaties over mTLS.*
 
-### `ls-iam-0018` — SKILL.md:106 *(§ Betrouwbaarheidsniveaus (Levels of Assurance))*
+### `ls-iam-0014` — SKILL.md:94 *(§ OpenID Connect NL GOV Profiel)*
 
-> De `acr_values` parameter in het authentication request mapt naar eIDAS-betrouwbaarheidsniveaus. De OpenID Provider geeft het bereikte niveau terug in de `acr` claim van het ID Token.
+> Het OIDC NL GOV profiel bouwt voort op OpenID Connect Core 1.0 en het iGov-profiel.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC NL GOV profiel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > This profile builds on top of, and inherits all properties of, the NL GOV Assurance profile for OAuth 2.0 [OAuth2.NLGov]... This profile is based upon the 'International Government Assurance Profile (iGov) for OpenID Connect 1.0' [OpenID.iGov] as published by the OpenID Foundation. It should be considered a fork of this profile.
+  - *Zowel OpenID Connect Core 1.0 (impliciet via iGov en OpenID.Core) als het iGov-profiel worden als basis vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron gaat over OAuth-NL beheermodel, niet over het OIDC NL GOV profiel. De relatie met OpenID Connect Core 1.0 en iGov-profiel voor OIDC wordt niet beschreven.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron is het OAuth NL profiel, niet het OIDC NL GOV profiel. Het OIDC NL GOV profiel en zijn relatie tot OpenID Connect Core 1.0 wordt in deze bron niet beschreven.*
+
+### `ls-iam-0016` — SKILL.md:106 *(§ Betrouwbaarheidsniveaus (Levels of Assurance))*
+
+> De `acr_values` parameter in het authentication request mapt naar eIDAS-niveaus. De OpenID Provider geeft het daadwerkelijk bereikte niveau terug in de `acr` claim van het ID Token.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC NL GOV profiel - acr_values
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > acr_values OPTIONAL. Lists the acceptable LoAs for this authentication. [...] OpenID Providers SHOULD use eIDAS Level of Assurance (LoA) values for the acr Claim [...] acr OPTIONAL. The LoA the End-User was authenticated at. MUST be at least the requested Level of Assurance value requested by the Client (either via the acr_values or claims parameters)
-  - *De bron bevestigt dat acr_values in het authentication request verwijst naar LoA-niveaus en dat de provider het bereikte niveau teruggeeft in de acr claim van het ID Token, gerelateerd aan eIDAS.*
+  > acr_values OPTIONAL. Lists the acceptable LoAs for this authentication... acr OPTIONAL. The LoA the End-User was authenticated at. MUST be at least the requested Level of Assurance value requested by the Client (either via the acr_values or claims parameters).
+  - *Zowel het gebruik van acr_values in het request als het retourneren van het bereikte niveau in de acr claim van het ID Token worden expliciet beschreven.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De acr_values parameter en mapping naar eIDAS-niveaus worden niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over acr_values of ID Token claims.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. acr_values-parameter en ID Token acr claim worden niet besproken.*
+  - *De bron behandelt acr_values en eIDAS-niveaumapping niet.*
 
-### `ls-iam-0020` — SKILL.md:120 *(§ Verplichte claims in het ID Token)*
+### `ls-iam-0018` — SKILL.md:120 *(§ Verplichte claims in het ID Token)*
 
-> De `acr` claim is OPTIONAL per OIDC NL GOV; als gezet MOET de waarde minimaal het gevraagde betrouwbaarheidsniveau zijn.
+> De `acr` claim in het ID Token is OPTIONAL per OIDC NL GOV; als gezet MOET de waarde minimaal het gevraagde betrouwbaarheidsniveau zijn.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token acr claim
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > acr OPTIONAL . The LoA the End-User was authenticated at. MUST be at least the requested Level of Assurance value requested by the Client (either via the acr_values or claims parameters) or - if none was requested - a Level of Assurance established through prior agreement.
+  > acr OPTIONAL. The LoA the End-User was authenticated at. MUST be at least the requested Level of Assurance value requested by the Client (either via the acr_values or claims parameters) or - if none was requested - a Level of Assurance established through prior agreement.
+  - *De bron bevestigt exact: acr is OPTIONAL in het ID Token, maar als gezet MOET de waarde minimaal het gevraagde niveau zijn.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *De acr claim in ID Tokens wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over de acr claim in ID Tokens.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. De acr claim in ID Tokens is geen onderdeel van deze specificatie.*
+  - *De bron behandelt het OIDC NL GOV profiel en ID Token acr claim niet.*
 
-### `ls-iam-0022` — SKILL.md:127 *(§ ID Token validatie)*
+### `ls-iam-0019` — SKILL.md:126 *(§ ID Token validatie)*
 
-> De `iss` claim MOET exact overeenkomen met de `issuer` uit het discovery document bij ID Token validatie.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
-
-- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > iss The issuer Claim is the Uniform Resource Locater (URL) of the expected Issuer. Identical as in [OpenID.iGov].
-  - *De bron stelt dat iss de URL van de verwachte issuer moet zijn. De expliciete formulering 'exact overeenkomen met de issuer uit het discovery document' staat niet letterlijk zo in de bron, maar dit is de directe strekking van de verificatieverplichting.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *iss claim validatie wordt niet besproken in dit beheermodeldocument.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. ID Token iss-validatie per OIDC NL GOV profiel wordt niet besproken.*
-
-### `ls-iam-0023` — SKILL.md:128 *(§ ID Token validatie)*
-
-> De `aud` claim MOET de `client_id` van de relying party bevatten bij ID Token validatie.
+> Bij ID Token validatie MOET de JWS handtekening worden geverifieerd met de publieke sleutel van de provider (via jwks_uri).
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > aud The audience Claim contains the Client ID of the Client. Identical as in [OpenID.iGov].
+  > All Clients MUST validate the signature of an ID Token before accepting it. Validation can be done using the public key of the issuing server, which is published in JSON Web Key (JWK) format... Clients MUST use the public keys obtained from the jwks endpoint to validate the signature on tokens.
+  - *Beide vereisten worden expliciet bevestigd: handtekeningverificatie verplicht (MUST) en gebruik van jwks_uri voor de publieke sleutel.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *aud claim validatie wordt niet besproken in dit beheermodeldocument.*
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ID Token validatie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *De bron behandelt het OAuth NL profiel. aud-validatie van ID Tokens per OIDC NL GOV profiel wordt niet besproken.*
+  - *ID Token validatie valt buiten scope van het OAuth NL profiel dat in deze bron staat.*
 
-### `ls-iam-0049` — reference.md:138 *(§ Userinfo Endpoint)*
+### `ls-iam-0021` — SKILL.md:128 *(§ ID Token validatie)*
+
+> Bij ID Token validatie MOET de `aud` claim de `client_id` van de relying party bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > aud — The audience Claim contains the Client ID of the Client. Identical as in [OpenID.iGov].
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over ID Token validatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ID Token aud-validatie valt buiten scope van het OAuth NL profiel.*
+
+### `ls-iam-0022` — SKILL.md:129 *(§ ID Token validatie)*
+
+> Bij ID Token validatie MOET de `nonce` exact overeenkomen met de nonce uit het authorization request.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > nonce — The nonce parameter in the ID Token MUST equal the nonce request parameter sent in the Authentication Request. This is in line with [OpenID.Core], Section 3.1.3.7.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over nonce-validatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ID Token nonce-validatie valt buiten scope van het OAuth NL profiel.*
+
+### `ls-iam-0023` — SKILL.md:130 *(§ ID Token validatie)*
+
+> Bij ID Token validatie MOET `exp` in de toekomst liggen (token niet verlopen).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > exp, iat, nbf — Values for iat and nbf MUST lie in the past and exp MUST lie in the future; the acceptable range for how far away iat is in the past is specific to the Client.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over exp-validatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ID Token exp-validatie valt buiten scope van het OAuth NL profiel.*
+
+### `ls-iam-0024` — SKILL.md:131 *(§ ID Token validatie)*
+
+> Bij ID Token validatie MOET `iat` in het verleden liggen; de acceptabele afstand is per Client te bepalen (OIDC NL GOV laat dit expliciet aan de Client).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > Values for iat and nbf MUST lie in the past and exp MUST lie in the future; the acceptable range for how far away iat is in the past is specific to the Client.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over iat-validatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ID Token iat-validatie valt buiten scope van het OAuth NL profiel.*
+
+### `ls-iam-0025` — SKILL.md:132 *(§ ID Token validatie)*
+
+> Bij ID Token validatie MOET de `acr` minimaal het gevraagde betrouwbaarheidsniveau bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - ID Token validatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > acr — The Level of Assurance received in the acr Claim is at least the Level of Assurance requested. See also Section 5.2.3. This is in line with [OpenID.Core], Section 3.1.3.7.
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen informatie over acr-validatie.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *ID Token acr-validatie valt buiten scope van het OAuth NL profiel.*
+
+### `ls-iam-0043` — reference.md:9 *(§ SAML)*
+
+> SAML is verplicht als onderdeel van de gecombineerde vermelding 'Authenticatie-standaarden (OpenID.NLGov en SAML)' op het Forum Standaardisatie (sinds 21-09-2023).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie - SAML
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  > De 'Pas toe of leg uit'-verplichting van de Authenticatie-standaarden bestaat eruit dat aanbieders van identitydiensten [...] zowel OpenID.NLGov [...] als SAML dienen te ondersteunen. [...] Datum van besluit 21-09-2023
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron is de technische OIDC NL GOV specificatie zelf en bevat geen informatie over Forum Standaardisatie-vermeldingen of gecombineerde opname met SAML.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron vermeldt SAML niet. De bron gaat over het OAuth-NL beheermodel.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *Forum Standaardisatie-vermelding van SAML en gecombineerde authenticatiestandaarden worden niet behandeld in deze bron.*
+</details>
+
+### `ls-iam-0052` — reference.md:144 *(§ Client Registratie)*
+
+> Redirect URI's bij client registratie moeten een exacte match zijn; wildcards zijn niet toegestaan voor beveiliging.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV - Client registratie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > "One of these registered Redirection URI values MUST exactly match the redirect_uri parameter value used in each Authorization Request." en "MUST exactly match one of the Redirection URI values for the Client pre-registered at the OpenID Provider"
+  - *De bron bevestigt de exact-match eis. Wildcards worden niet expliciet verboden maar de exact-match eis sluit wildcards impliciet uit.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > "The Authorization Server MUST validate the redirect URI given by the client at the authorization endpoint using strict string comparison." en "Clients MUST NOT allow the redirecting to the local domain."
+  - *De bron stelt expliciet dat exacte string-vergelijking vereist is voor redirect URIs. Wildcards worden niet vermeld als toegestaan, en strict string comparison sluit ze impliciet uit.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen technische specificaties over redirect URI matching.*
+
+### `ls-iam-0054` — reference.md:151 *(§ Client Registratie)*
+
+> Voor native clients met per-instance registratie is dynamische client registratie verplicht (MUST); voor web- en browser-applicaties blijft handmatige registratie toegestaan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - Client registratie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  > "In case a native Client is using per-instance registration, the Client MUST use Dynamic Registration." en "In other cases, particularly when dealing with Browser-based applications or Native Apps, Dynamic Registration SHOULD be supported"
+  - *De bron bevestigt exact wat de claim stelt: MUST voor native clients met per-instance registratie, en SHOULD (niet verplicht) voor web/browser-applicaties.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > "Native clients MUST either: use dynamic client registration to obtain a separate client id for each instance, or act as a public client by using a common client id and use PKCE [RFC7636] to protect calls to the token endpoint."
+  - *De bron stelt dat native clients dynamische registratie MOETEN gebruiken OF als public client met PKCE mogen opereren. De claim stelt dat dynamische registratie verplicht is voor native clients met per-instance registratie, wat klopt. Maar de claim zegt ook dat voor web- en browser-applicaties handmatige registratie toegestaan blijft — dit wordt niet expliciet zo gesteld in de bron; de bron behandelt registratie van web-clients niet als apart onderscheid.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
+  - *De bron is het OAuth-NL beheermodel en bevat geen technische specificaties over dynamische client registratie voor native clients.*
+
+### `ls-iam-0065` — reference.md:138 *(§ Userinfo Endpoint)*
 
 > De Relying Party MOET alleen de claims vragen die strikt noodzakelijk zijn voor de dienstverlening (dataminimalisatie).
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV profiel - privacy
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** OIDC NL GOV - Userinfo privacy
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
   > All Clients MUST apply the concept of data minimization. As a result, a Client MUST NOT request any more identifiers, attributes or other Claims than strictly necessary.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Dataminimalisatie voor Relying Parties wordt niet besproken in dit beheermodeldocument.*
+  - *De brontekst behandelt het beheermodel van OAuth-NL, niet de technische specificaties van OIDC NL GOV. Er is geen vermelding van Relying Party, claims, of dataminimalisatie.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  - *Dataminimalisatie als MUST-verplichting voor de Relying Party in het OIDC NL GOV profiel komt niet voor in deze OAuth-NL-profiel bron.*
+  - *De bron is het OAuth 2.0 NL GOV profiel, niet het OIDC NL GOV profiel. Er is geen bepaling over dataminimalisatie voor Relying Parties bij UserInfo claims.*
 
-### `ls-iam-0051` — reference.md:144 *(§ Client Registratie)*
+### `ls-iam-0067` — SKILL.md:45 *(§ Repositories)*
 
-> Redirect URI's bij client registratie vereisen een exacte match; wildcards zijn niet toegestaan voor beveiliging.
+> OIDC-NLGOV vastgestelde versie is v1.0.1, gepubliceerd op gitdocumentatie.logius.nl/publicatie/api/oidc/.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** OIDC NL GOV profiel - client registratie
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OIDC-NLGOV
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
-  > One of these registered Redirection URI values MUST exactly match the redirect_uri parameter value used in each Authorization Request.
-  - *De bron stelt expliciet dat exact matching vereist is. Wildcards worden niet vermeld als optie, en de exacte-match eis sluit wildcard-gebruik uit.*
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
-  > The Authorization Server MUST compare a client's registered redirect URIs with the redirect URI presented during an authorization request using an exact string match.
-  - *De bron bevestigt exact string matching voor redirect URIs. Wildcards worden niet expliciet verboden, maar exact string match sluit ze impliciet uit.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer](https://gitdocumentatie.logius.nl/publicatie/api/oauth-beheer)
-  - *Redirect URI exacte match en verbod op wildcards worden niet besproken in dit beheermodeldocument.*
+  > OpenID NLGov 1.0.1 Logius Standard Definitive version September 18, 2023 This version: https://gitdocumentatie.logius.nl/publicatie/api/oidc/1.0.1 Latest published version: https://gitdocumentatie.logius.nl/publicatie/api/oidc
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV)
+  > Deze versie: https://gitdocumentatie.logius.nl/publicatie/api/oidc/1.0.1
+<details><summary>6x NOT_FOUND (klap uit)</summary>
 
-### `ls-iam-0064` — reference.md:357 *(§ Aanvullende Bronnen)*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  - *De bron is het OAuth-NL-profiel, niet het OIDC-NLGOV profiel. Er is geen informatie over de versie of publicatielocatie van OIDC-NLGOV.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-NL-profiel](https://logius-standaarden.github.io/OAuth-NL-profiel)
+  - *De bron verwijst naar de NLGOV OpenID specificatie via een URL maar noemt geen versienummer v1.0.1 voor OIDC-NLGOV.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel)
+  - *De brontekst gaat over het OAuth-NL-profiel repository, niet over OIDC-NLGOV. Geen informatie over OIDC-NLGOV versie of publicatielocatie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIDC-NLGOV](https://logius-standaarden.github.io/OIDC-NLGOV)
+  - *De bron vermeldt geen versienummer 'v1.0.1'. De brontekst verwijst naar de latest published version op gitdocumentatie.logius.nl/publicatie/api/oidc/ en noemt het originele concept als 'version 1.0 in February 2021', maar een vastgesteld versienummer v1.0.1 staat niet in de bron. Publicatie-metadata zoals versienummers staan zelden in de spec zelf.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OAuth-Inleiding](https://github.com/logius-standaarden/OAuth-Inleiding)
+  - *De brontekst is de GitHub-repositorypagina van OAuth-Inleiding en bevat geen informatie over versienummers of publicatie-URL's van OIDC-NLGOV.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-Inleiding](https://logius-standaarden.github.io/OAuth-Inleiding)
+  - *De aangeleverde brontekst bevat alleen navigatie-elementen (Inleiding, Samenvatting, Use Cases, etc.) zonder inhoudelijke tekst over versienummers of publicatie-URLs van OIDC-NLGOV.*
+</details>
+
+### `ls-iam-0068` — SKILL.md:44 *(§ Repositories)*
+
+> OAuth-NL-profiel vastgestelde versie is v1.1.0, gepubliceerd op gitdocumentatie.logius.nl/publicatie/api/oauth/.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth-NL-profiel
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oauth](https://gitdocumentatie.logius.nl/publicatie/api/oauth)
+  > NL GOV Assurance profile for OAuth 2.0 v1.1.0 Logius Standard Definitive version December 03, 2024 This version: https://gitdocumentatie.logius.nl/publicatie/api/oauth/v1.1.0/ Latest published version: https://gitdocumentatie.logius.nl/publicatie/api/oauth/
+  - *De bron bevestigt expliciet versie v1.1.0 als vastgestelde versie, gepubliceerd op de genoemde URL.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/OAuth-NL-profiel](https://logius-standaarden.github.io/OAuth-NL-profiel)
+  > Latest published version: https://gitdocumentatie.logius.nl/publicatie/api/oauth/ ... Previous version: https://gitdocumentatie.logius.nl/publicatie/api/oauth/v1.1.0/ ... MIDO programmeringstafel 1.1.0 definitive approved version 03-12-2024
+  - *De bron bevestigt dat v1.1.0 een vastgestelde versie is en gepubliceerd op gitdocumentatie.logius.nl/publicatie/api/oauth/. De 'latest published version' URL zonder versienummer suggereert dat er mogelijk een nieuwere versie is dan v1.1.0, maar dat is niet expliciet bevestigd. De publicatielocatie klopt wel.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/OAuth-NL-profiel](https://github.com/logius-standaarden/OAuth-NL-profiel)
+  > Versie 1.1.0 - Client credentials Latest Dec 20, 2024
+  - *De bron bevestigt dat versie 1.1.0 de laatste release is. De publicatielocatie gitdocumentatie.logius.nl/publicatie/api/oauth/ wordt ook genoemd: 'Bekijk hier de laatste vastgestelde versie van de standaard: https://gitdocumentatie.logius.nl/publicatie/api/oauth/' — daarmee is de claim volledig ondersteund. SUPPORTED zou hier passender zijn, maar de bron bevestigt de versie indirect via de releases-sectie en de URL expliciet.*
+<details><summary>5x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/api/oidc](https://gitdocumentatie.logius.nl/publicatie/api/oidc)
+  - *De bron verwijst naar het OAuth NL GOV profiel ([OAuth2.NLGov]) maar noemt geen versienummer v1.1.0. De referentie geeft alleen 'july 2020' en de URL https://gitdocumentatie.logius.nl/publicatie/api/oauth/ zonder versieaanduiding.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OIDC-NLGOV](https://github.com/logius-standaarden/OIDC-NLGOV)
+  - *De bron gaat uitsluitend over OIDC-NLGOV. Het OAuth-NL-profiel wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OIDC-NLGOV](https://logius-standaarden.github.io/OIDC-NLGOV)
+  - *De bron verwijst naar het OAuth-NL-profiel via [OAuth2.NLgov] met URL https://gitdocumentatie.logius.nl/publicatie/api/oauth/ en vermeldt 'july 2020' als datum, maar noemt geen versienummer v1.1.0. Versie-informatie van een externe standaard staat niet in deze spec.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/OAuth-Inleiding](https://github.com/logius-standaarden/OAuth-Inleiding)
+  - *De brontekst bevat geen informatie over versienummers of publicatie-URL's van het OAuth-NL-profiel.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/OAuth-Inleiding](https://logius-standaarden.github.io/OAuth-Inleiding)
+  - *De aangeleverde brontekst bevat alleen navigatie-elementen zonder inhoudelijke tekst over versienummers of publicatie-URLs van het OAuth-NL-profiel.*
+</details>
+
+### `ls-iam-0071` — reference.md:357 *(§ Aanvullende Bronnen)*
 
 > RFC 7636 definieert PKCE (Proof Key for Code Exchange).
 
@@ -917,16 +1095,16 @@
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7636.txt](https://www.rfc-editor.org/rfc/rfc7636.txt)
   > Proof Key for Code Exchange by OAuth Public Clients [...] This specification describes the attack as well as a technique to mitigate against the threat through the use of Proof Key for Code Exchange (PKCE, pronounced "pixy").
 
-### `ls-iam-0065` — reference.md:358 *(§ Aanvullende Bronnen)*
+### `ls-iam-0072` — reference.md:358 *(§ Aanvullende Bronnen)*
 
 > RFC 9068 definieert het JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens.
 
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth - JWT access tokens
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth - JWT Access Tokens
 
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9068.txt](https://www.rfc-editor.org/rfc/rfc9068.txt)
   > This specification defines a profile for issuing OAuth 2.0 access tokens in JSON Web Token (JWT) format.
 
-### `ls-iam-0066` — reference.md:359 *(§ Aanvullende Bronnen)*
+### `ls-iam-0073` — reference.md:359 *(§ Aanvullende Bronnen)*
 
 > RFC 9126 definieert OAuth 2.0 Pushed Authorization Requests.
 

--- a/skills/ls-logboek/audit.md
+++ b/skills/ls-logboek/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-logboek — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,74 +7,83 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 6 | 16% |
+| UNSUPPORTED_ASSERTION | 7 | 18% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 12 | 32% |
+| PARTIALLY_GROUNDED | 15 | 38% |
 | UNGROUNDED | 0 | 0% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 19 | 51% |
+| GROUNDED | 17 | 44% |
 
-*Geverifieerd met sonnet, 3 calls, $0.3082.*
+*Geverifieerd met sonnet, 5 calls, $0.4027.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (6)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (7)
 
 ### `ls-logboek-0002` — SKILL.md:37 *(§ Versiemodel)*
 
 > Logboek Dataverwerkingen is nog niet opgenomen op de lijst van het Forum Standaardisatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen status
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen standaard status
 
 - **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  - *De bron vermeldt dat de standaard beoogd is voor opname op de lijst van Forum Standaardisatie (§1.1), maar bevestigt noch ontkent of opname al heeft plaatsgevonden.*
+  - *De bron vermeldt alleen dat de sectie werkingsgebied 'beoogde beschrijvingen voor opname op de lijst van Aanbevolen standaarden van Forum Standaardisatie' bevat, maar zegt niet expliciet dat de standaard er nog niet op staat.*
 
 ### `ls-logboek-0022` — SKILL.md:153 *(§ Protocol)*
 
-> OTLP ondersteunt zowel gRPC als HTTP/protobuf als transportlaag met standaard poorten 4317 voor gRPC en 4318 voor HTTP, maar deze poorten zijn niet voorgeschreven door de Logboek-standaard zelf.
+> OTLP ondersteunt zowel gRPC als HTTP/protobuf als transportlaag; standaard OTLP-poorten zijn 4317 voor gRPC en 4318 voor HTTP.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen protocol
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen protocol / OTLP
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  - *De bron noemt OTLP en verwijst naar OpenTelemetry, maar specificeert nergens poortnummers (4317/4318) of een onderscheid tussen gRPC en HTTP/protobuf als transportlagen van OTLP.*
+  - *De bron noemt OTLP maar beschrijft geen transportlagen (gRPC vs HTTP/protobuf) of specifieke poorten (4317/4318). Dit is OTLP-interne specificatie die buiten scope van deze standaard valt.*
 
-### `ls-logboek-0023` — SKILL.md:173 *(§ NEN 7513 Extensie)*
+### `ls-logboek-0024` — SKILL.md:161 *(§ Object Extensie)*
 
-> De NEN 7513 extensie voegt verplichte attributen toe voor de zorgsector, zoals gebruikersidentificatie, patiëntidentificatie en de specifieke actie op het medisch dossier.
+> De Object Extensie definieert aanvullende attributes in de `dpl.objects` namespace voor het vastleggen van objectgegevens bij verwerkingen.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen NEN 7513 extensie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen Object Extensie
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/logboek-extensie-object](https://github.com/logius-standaarden/logboek-extensie-object)
+  - *De brontekst is de GitHub repository README van logboek-extensie-object. Deze bevat alleen een projectbeschrijving, inleiding, doel en verwijzingstabel. Er is geen technische inhoud over de `dpl.objects` namespace of aanvullende attributes voor objectgegevens. De claim kan niet worden bevestigd of weersproken op basis van deze brontekst.*
+
+### `ls-logboek-0026` — SKILL.md:173 *(§ NEN 7513 Extensie)*
+
+> De NEN 7513 Extensie voegt verplichte attributen toe voor de zorgsector, zoals gebruikersidentificatie, patiëntidentificatie en de specifieke actie op het medisch dossier.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen NEN 7513 Extensie
 
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/logboek-extensie-nen7513](https://github.com/logius-standaarden/logboek-extensie-nen7513)
-  - *De aangeleverde brontekst bevat alleen de GitHub-repositorypagina met navigatie-UI, bestandsnamen en metadata. Er is geen inhoudelijke tekst over de NEN 7513 extensie, verplichte attributen, gebruikersidentificatie, patiëntidentificatie of medische dossiers. De specificatie-inhoud (specificatie.md, abstract.md) is niet meegeleverd.*
+  - *De aangeleverde brontekst bevat alleen de GitHub-repositorypagina met metadata (bestandslijst, contributeurs, licentie, etc.). De inhoud van specificatie.md of abstract.md is niet meegeleverd. Er is geen informatie over verplichte attributen, gebruikersidentificatie, patiëntidentificatie of acties op medische dossiers.*
 
-### `ls-logboek-0032` — reference.md:13 *(§ Architectuur - Kernprincipes)*
+### `ls-logboek-0034` — reference.md:13 *(§ Architectuur - Kernprincipes)*
 
-> Het Register beschrijft het wat en waarom van een verwerking; het Logboek beschrijft het wanneer en voor wie.
+> Het Register beschrijft het wat en waarom; het Logboek beschrijft het wanneer en voor wie.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen architectuur
 
-- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  - *De bron beschrijft de functies van Register en Logboek afzonderlijk, maar formuleert nergens expliciet het onderscheid als 'Register = wat en waarom, Logboek = wanneer en voor wie'. Dit is een parafrase/synthese die niet letterlijk of als directe parafrase in de bron staat.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  - *De bron beschrijft de rollen van Register en Logboek afzonderlijk, maar formuleert nergens expliciet de samenvatting 'het Register beschrijft het wat en waarom; het Logboek beschrijft het wanneer en voor wie'. Dit onderscheid staat niet als zodanig in de brontekst.*
 
-### `ls-logboek-0035` — reference.md:33 *(§ Header formaat)*
+### `ls-logboek-0037` — reference.md:41 *(§ Header formaat)*
 
-> Het W3C Trace Context `traceparent` header formaat is: `<version>-<trace_id>-<span_id>-<trace_flags>` waarbij version altijd `00` is in de huidige specificatie.
+> Het traceparent header formaat is `<version>-<trace_id>-<span_id>-<trace_flags>`, waarbij `version` altijd `00` is in de huidige specificatie.
 
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context header formaat
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  - *De bron verwijst naar de W3C Trace Context standaard maar beschrijft het exacte header-formaat (<version>-<trace_id>-<span_id>-<trace_flags>) en de versie '00' niet.*
+  - *De bron verwijst naar de W3C Trace Context specificatie maar beschrijft het traceparent header formaat (<version>-<trace_id>-<span_id>-<trace_flags> met version=00) niet in de brontekst zelf.*
 
-### `ls-logboek-0037` — reference.md:44 *(§ Header formaat)*
+### `ls-logboek-0039` — reference.md:44 *(§ Header formaat)*
 
-> In het W3C Trace Context header formaat geldt: `trace_flags` `01` = gesampled, `00` = niet gesampled.
+> In het traceparent header betekent `trace_flags` waarde `01` dat de trace gesampled is; `00` betekent niet gesampled.
 
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context header formaat
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  - *De bron vermeldt niets over trace_flags of de semantiek van waarden 01 en 00 daarin. Dit is detail uit de W3C Trace Context specificatie zelf, niet uit deze bron.*
+  - *De bron beschrijft de trace_flags waarden (01=gesampled, 00=niet gesampled) niet. Dit is detail uit de W3C Trace Context specificatie, niet uit de brontekst.*
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (12)
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (15)
 
 ### `ls-logboek-0003` — SKILL.md:37 *(§ Versiemodel)*
 
@@ -83,120 +92,150 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen publicatiekanalen
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > De LDV Normatieve Standaard - Logboek dataverwerkingen (werkversie) [...] De Algemene Inleiding - De Algemene Inleiding (werkversie) [...] Het Juridische Beleidskader - Juridisch Beleidskader (werkversie) [...] LDV Extensie Guideline - Guideline voor het schrijven van een extensie voor LDV (werkversie)
-  - *De tabel toont alle vier documenten met '(werkversie)' voor gepubliceerde versie, maar de bron zelf ís de vastgestelde versie van document 1. De claim dat de overige drie alleen werkversies hebben wordt ondersteund, maar voor document 1 is de vastgestelde versie juist deze bron zelf. De tabel is vermoedelijk niet volledig bijgewerkt na vaststelling.*
+  > De LDV Normatieve Standaard - Logboek dataverwerkingen (werkversie) logboek-dataverwerkingen / De Algemene Inleiding - De Algemene Inleiding (werkversie) / Het Juridische Beleidskader - Juridisch Beleidskader (werkversie) / LDV Extensie Guideline - Guideline voor het schrijven van een extensie voor LDV (werkversie)
+  - *De bron bevestigt dat inleiding, juridisch beleidskader en extensie guideline werkversies hebben, maar geeft geen expliciete 'gepubliceerde versie' kolom-waarden voor die drie — de kolom 'Gepubliceerde versie' lijkt leeg voor die documenten. De claim is daarmee grotendeels ondersteund maar niet volledig aantoonbaar uit de tabel.*
 
-### `ls-logboek-0004` — SKILL.md:75 *(§ Log Record Structuur)*
+### `ls-logboek-0004` — SKILL.md:27 *(§ Logboek Dataverwerkingen)*
 
-> Het veld `trace_id` (16 bytes) is verplicht in elk log record en bevat een uniek trace ID over systemen heen conform W3C Trace Context.
+> Logboek Dataverwerkingen is gebaseerd op OpenTelemetry en W3C Trace Context, waardoor verwerkingen over organisatiegrenzen heen traceerbaar zijn.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen architectuur
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Het is AANBEVOLEN om het OpenTelemetry Protocol (OTLP) te gebruiken in de interactie tussen Applicatie en Logboek. ... Als gebruik wordt gemaakt van HTTP/1.1 of HTTP/2 voor het uitvoeren van dataverwerkingen in meerdere applicaties MOET gebruik worden gemaakt van de Trace Context specificatie voor het uitwisselen van metadata over Traces.
+  - *De bron bevestigt OTLP (aanbevolen) en W3C Trace Context (verplicht bij HTTP), en bevestigt dat verwerkingen over organisatiegrenzen heen traceerbaar zijn. Echter: OTLP is aanbevolen, niet verplicht, dus 'gebaseerd op OpenTelemetry' is enigszins sterker gesteld dan de bron rechtvaardigt.*
+
+### `ls-logboek-0005` — SKILL.md:75 *(§ Log Record Structuur)*
+
+> Het log record veld `trace_id` (16 bytes) is verplicht en vormt een uniek trace ID over systemen heen conform W3C Trace Context.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > trace_id | 16 byte | verplicht [...] Unieke identificerende code van Trace die Dataverwerking volgt.
-  - *De bron bevestigt trace_id als 16 byte en verplicht. De claim dat het 'conform W3C Trace Context' is, wordt niet expliciet zo gesteld voor trace_id zelf; W3C Trace Context wordt genoemd voor metadata-uitwisseling bij HTTP, niet als definitie van trace_id.*
+  > trace_id | 16 byte | verplicht ... Unieke identificerende code van Trace die Dataverwerking volgt. Als er meerdere applicaties dataverwerkingen uitvoeren ten behoeve van 1 originele dataverwerking, dan is de trace code identiek voor al deze dataverwerkingen
+  - *De bron bevestigt dat trace_id 16 bytes en verplicht is, en dat het over meerdere applicaties wordt gedeeld. De claim stelt 'conform W3C Trace Context' — de bron vermeldt W3C Trace Context voor HTTP-verkeer, maar koppelt dit niet expliciet aan de trace_id definitie zelf.*
 
-### `ls-logboek-0009` — SKILL.md:80 *(§ Log Record Structuur)*
+### `ls-logboek-0010` — SKILL.md:80 *(§ Log Record Structuur)*
 
-> Het veld `start_time` (uint64, starttijd in milliseconden sinds Unix Epoch) is verplicht in elk log record.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
-
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > start_time | uint64 | verplicht [...] Tijdstip waarop de Actie gestart is in milliseconden sinds Epoch.
-  - *De bron bevestigt uint64, verplicht, en milliseconden sinds Epoch. De claim zegt 'Unix Epoch'; de bron zegt alleen 'Epoch' zonder 'Unix' te specificeren — inhoudelijk gelijkwaardig maar niet letterlijk identiek.*
-
-### `ls-logboek-0010` — SKILL.md:81 *(§ Log Record Structuur)*
-
-> Het veld `end_time` (uint64, eindtijd in milliseconden sinds Unix Epoch) is verplicht in elk log record.
+> Het log record veld `start_time` (uint64) is verplicht en bevat de starttijd in milliseconden sinds Unix Epoch.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
 
 - **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > end_time | uint64 | verplicht [...] Tijdstip waarop de Actie beëindigd is in milliseconden sinds Epoch.
-  - *Zelfde kanttekening als ls-logboek-0009: 'Epoch' vs 'Unix Epoch' — inhoudelijk gelijkwaardig, niet letterlijk identiek.*
+  > start_time | uint64 | verplicht ... Tijdstip waarop de Actie gestart is in milliseconden sinds Epoch.
+  - *De bron zegt 'milliseconden sinds Epoch', de claim zegt 'milliseconden sinds Unix Epoch'. Dit is inhoudelijk hetzelfde, maar de bron gebruikt niet het woord 'Unix'. Verder volledig ondersteund.*
 
-### `ls-logboek-0013` — SKILL.md:99 *(§ Core Attributes (dpl.core namespace))*
+### `ls-logboek-0011` — SKILL.md:81 *(§ Log Record Structuur)*
 
-> `dpl.core.processing_activity_id` (URI) is een verplicht attribuut dat verwijst naar de verwerkingsactiviteit in het Register conform AVG Art. 30.
+> Het log record veld `end_time` (uint64) is verplicht en bevat de eindtijd in milliseconden sinds Unix Epoch.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > end_time | uint64 | verplicht ... Tijdstip waarop de Actie beëindigd is in milliseconden sinds Epoch.
+  - *Zelfde nuance als ls-logboek-0010: 'Epoch' vs 'Unix Epoch'. Inhoudelijk gelijkwaardig.*
+
+### `ls-logboek-0014` — SKILL.md:99 *(§ Core Attributes (dpl.core namespace))*
+
+> `dpl.core.processing_activity_id` is een verplicht URI-attribuut dat verwijst naar de verwerkingsactiviteit in het Register (AVG Art. 30).
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
 
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
   > dpl.core.processing_activity_id | URI | Verwijzing naar een Register met meer informatie over de Verwerkingsactiviteit.
-  - *De bron bevestigt het veld als URI en verwijzing naar een Register. De claim voegt 'conform AVG Art. 30' toe; de bron vermeldt AVG Art. 30 in de context van het Register van Verwerkingsactiviteiten maar koppelt dat niet expliciet aan dit attribuut als eis.*
+  - *De bron bevestigt dat het een verplicht URI-attribuut is dat verwijst naar het Register. De claim voegt '(AVG Art. 30)' toe als specificatie van het Register — de bron vermeldt AVG art. 30 elders in de context van het Register van Verwerkingsactiviteiten, maar koppelt dit niet expliciet aan dpl.core.processing_activity_id in de attribuut-definitie zelf.*
 
 ### `ls-logboek-0016` — SKILL.md:101 *(§ Core Attributes (dpl.core namespace))*
 
-> `dpl.core.data_subject_id_type` (string) is een verplicht attribuut. Mogelijke waarden zijn: BSN, personeelsnummer, URI, of een ander organisatiespecifiek type.
+> `dpl.core.data_subject_id_type` is een verplicht string-attribuut met mogelijke waarden `BSN`, `personeelsnummer`, `URI`, of een ander organisatiespecifiek type.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
 
 - **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
   > dpl.core.data_subject_id_type | String | Type van de identificerende code, zoals BSN, personeelsnummer, of een URI naar een Register dat het type specificeert.
-  - *De bron bevestigt het veld en noemt BSN, personeelsnummer en URI als voorbeelden. De claim voegt 'of een ander organisatiespecifiek type' toe, wat de bron niet expliciet noemt maar impliciet open laat. De kern (verplicht, string, genoemde voorbeelden) is ondersteund.*
+  - *De bron bevestigt dat het veld verplicht is en noemt BSN, personeelsnummer en URI als voorbeelden. De claim noemt ook 'ander organisatiespecifiek type' — dat staat impliciet in de voorbeeldopsomming maar niet letterlijk zo geformuleerd.*
 
-### `ls-logboek-0017` — SKILL.md:102 *(§ Core Attributes (dpl.core namespace))*
+### `ls-logboek-0025` — SKILL.md:167 *(§ Lees Extensie)*
 
-> `dpl.core.foreign_operation.processor` (URL) is een optioneel attribuut met een link naar de externe applicatie of organisatie betrokken bij een cross-organisatie verwerking.
+> De basisstandaard definieert alleen het schrijven van logregels; de Lees Extensie voegt leesoperaties toe en ondersteunt filteren op trace_id, tijdsbereik en betrokkene.
 
-**Type:** factual_assertion  ·  **Modaliteit:** MAY  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen Lees Extensie
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > dpl.core.foreign_operation.processor | URL | Link naar externe applicatie
-  - *De bron bevestigt het veld als URL en 'link naar externe applicatie'. De claim voegt 'of organisatie betrokken bij een cross-organisatie verwerking' toe; de bron zegt alleen 'externe applicatie', niet expliciet 'organisatie'.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/logboek-extensie-lezen](https://github.com/logius-standaarden/logboek-extensie-lezen)
+  > De extensie lezen breid deze uit met de mogelijkheid te kunnen lezen: De logs van een (interne) bron te lezen, Logs lezen bij de(externe) bron(loggende organisatie), Gerelateerde logs bij meerdere bronnen op te vragen
+  - *De bron bevestigt dat de basisstandaard gericht is op schrijven (wegschrijven, relateren van logs) en dat de Lees Extensie leesoperaties toevoegt. Echter, de specifieke filtermogelijkheden op trace_id, tijdsbereik en betrokkene worden nergens in de brontekst vermeld. Die details staan vermoedelijk in de inhoud van de standaard zelf, niet in de README.*
 
-### `ls-logboek-0026` — SKILL.md:356 *(§ Verplichte Velden Validatie)*
+### `ls-logboek-0027` — SKILL.md:356 *(§ Verplichte Velden Validatie)*
 
-> Een logregel MOET minimaal bevatten: trace_id, span_id, name, start_time, end_time, status, dpl.core.processing_activity_id, dpl.core.data_subject_id en dpl.core.data_subject_id_type.
+> Een logregel MOET minimaal `trace_id` (16 bytes), `span_id` (8 bytes), `name`, `start_time`, `end_time`, `status`, `dpl.core.processing_activity_id`, `dpl.core.data_subject_id` en `dpl.core.data_subject_id_type` bevatten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen verplichte velden
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > De interface MOET de volgende velden implementeren: trace_id [...] verplicht, span_id [...] verplicht, status [...] verplicht, name [...] verplicht, start_time [...] verplicht, end_time [...] verplicht [...] dpl.core.processing_activity_id [...] dpl.core.data_subject_id [...] dpl.core.data_subject_id_type
-  - *De bron bevestigt al deze velden als verplicht. Echter: dpl.core.data_subject_id en dpl.core.data_subject_id_type zijn verplicht 'voor dataverwerkingen met persoonsdata' (§3.3.1.1); voor dataverwerkingen zonder persoonsdata geldt dit niet. De claim stelt dat een logregel ALTIJD alle negen velden moet bevatten, wat de bron niet onvoorwaardelijk zo stelt.*
+  > De interface MOET de volgende velden implementeren: trace_id 16 byte verplicht / span_id 8 byte verplicht / status enum verplicht / name string verplicht / start_time uint64 verplicht / end_time uint64 verplicht / attributes object verplicht ... dpl.core.processing_activity_id URI ... dpl.core.data_subject_id String ... dpl.core.data_subject_id_type String
+  - *De bron bevestigt alle genoemde velden als verplicht. Echter: dpl.core.processing_activity_id, dpl.core.data_subject_id en dpl.core.data_subject_id_type zijn verplicht specifiek voor dataverwerkingen met persoonsdata (sectie 3.3.1.1). Voor verwerkingen zonder persoonsdata is dpl.core.processing_activity_id slechts aanbevolen (AANBEVOLEN). De claim stelt een absolute minimumverplichting zonder deze nuance.*
 
-### `ls-logboek-0027` — SKILL.md:366 *(§ Verplichte Velden Validatie)*
+### `ls-logboek-0028` — SKILL.md:366 *(§ Verplichte Velden Validatie)*
 
 > Als een verplicht veld ontbreekt, MOET de software een standaardwaarde invullen om runtime-fouten te voorkomen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen verplichte velden
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen verplichte velden validatie
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Bijvoorbeeld als name leeg is, moet deze automatisch worden gevuld met een waarde zodat er in ieder geval op dit punt geen fout kan optreden.
-  - *De bron noemt dit principe specifiek alleen voor het veld 'name', niet als algemene regel voor alle verplichte velden. De claim is breder dan wat de bron stelt.*
+  > De software van de applicatie die de registratie van de logdata registreert, moet er voor zorgen dat er geen fout optreedt in 'run-time'. Bijvoorbeeld als name leeg is, moet deze automatisch worden gevuld met een waarde zodat er in ieder geval op dit punt geen fout kan optreden.
+  - *De bron beschrijft dit als uitgangspunt voor foutregistratie (sectie 3.3.2.1), niet als een normatieve MOET-eis geformuleerd met het RFC2119-trefwoord MUST/MOET. De strekking klopt, maar de formulering als harde MUST-verplichting is sterker dan de bron ondersteunt.*
 
-### `ls-logboek-0030` — reference.md:11 *(§ Architectuur - Kernprincipes)*
+### `ls-logboek-0030` — reference.md:9 *(§ Architectuur - Kernprincipes)*
+
+> Elke verwerkingsverantwoordelijke beheert een eigen Logboek.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen architectuur
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Iedere Verantwoordelijke kan een veelheid aan Applicaties, Logboeken en Registers gebruiken. Iedere Verantwoordelijke houdt alleen Logregels bij over eigen Dataverwerkingen.
+  - *De bron bevestigt dat iedere Verantwoordelijke eigen logregels bijhoudt, maar stelt niet expliciet dat elke verwerkingsverantwoordelijke een 'eigen Logboek beheert' als verplichting. Meerdere Logboeken per Verantwoordelijke zijn mogelijk; het is geen 1-op-1 relatie.*
+
+### `ls-logboek-0032` — reference.md:11 *(§ Architectuur - Kernprincipes)*
 
 > Het Logboek verwijst naar het Register van Verwerkingsactiviteiten (AVG Art. 30) via `dpl.core.processing_activity_id`.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen architectuur
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Iedere Dataverwerking van persoonsdata betreft een Verwerkingsactiviteit die in het Register van Verwerkingsactiviteiten moet zijn opgenomen. De Applicatie MOET in de Logregel een verwijzing naar de juiste Verwerkingsactiviteit in het Register van Verwerkingsactiviteiten opnemen in het veld dpl.core.processing_activity_id.
-  - *De bron bevestigt de verwijzing via dpl.core.processing_activity_id en de relatie met het Register van Verwerkingsactiviteiten (AVG art. 30), maar de claim stelt dat het 'Logboek' verwijst naar het register, terwijl de bron stelt dat de 'Applicatie' de verwijzing opneemt in de Logregel. Dat is een nuanceverschil in architecturele attributie.*
+  > Iedere Dataverwerking van persoonsdata betreft een Verwerkingsactiviteit die in het Register van Verwerkingsactiviteiten moet zijn opgenomen. De Applicatie MOET in de Logregel een verwijzing naar de juiste Verwerkingsactiviteit in het Register van Verwerkingsactiviteiten opnemen in het veld dpl.core.processing_activity_id .
+  - *De bron bevestigt de koppeling via dpl.core.processing_activity_id naar het Register van Verwerkingsactiviteiten (AVG art. 30). De claim stelt echter dat 'het Logboek verwijst naar het Register', terwijl de bron specificeert dat de Applicatie (niet het Logboek zelf) de verwijzing in de logregel opneemt. Bovendien geldt de verplichting in de bron primair voor persoonsdata; voor dataverwerkingen zonder persoonsdata is het slechts aanbevolen.*
 
-### `ls-logboek-0033` — reference.md:21 *(§ Inkomende requests)*
+### `ls-logboek-0035` — reference.md:21 *(§ Inkomende requests)*
 
-> Bij inkomende requests moet de `traceparent` header worden geparsed, het ontvangen `trace_id` gebruikt voor de eigen logregel, en de ontvangen `span_id` opgeslagen als `parent_span_id` in het eigen log record.
+> Bij inkomende requests moet de `traceparent` header geparsed worden en het ontvangen `trace_id` gebruikt worden voor de eigen logregel; de ontvangen `span_id` wordt opgeslagen als `parent_span_id`.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Als de Applicatie een verzoek van een andere Applicatie kan ontvangen, MOET de Applicatie metadata volgens de W3C Trace Context standaard kunnen verwerken en gebruiken in de eigen Trace(s). Metadata verkregen via W3C Trace Context MOET in attributes meegenomen worden als velden die beginnen met dpl.core.foreign_operation.
-  - *De bron bevestigt verwerking van W3C Trace Context metadata bij inkomende requests en gebruik ervan in de eigen trace, maar specificeert niet expliciet het parsen van een 'traceparent' header, en stelt dat metadata wordt opgeslagen als dpl.core.foreign_operation-velden, niet letterlijk als parent_span_id. De claim is specifieker dan de bron.*
+  > Als de Applicatie een verzoek van een andere Applicatie kan ontvangen, MOET de Applicatie metadata volgens de W3C Trace Context standaard kunnen verwerken en gebruiken in de eigen Trace(s). Metadata verkregen via W3C Trace Context MOET in attributes meegenomen worden als velden die beginnen met dpl.core.foreign_operation .
+  - *De bron bevestigt dat inkomende W3C Trace Context metadata verwerkt en gebruikt moet worden. De claim spreekt specifiek over de 'traceparent header', het parsen ervan, en dat de ontvangen span_id wordt opgeslagen als parent_span_id. De bron verwijst naar parent_span_id en foreign_operation attributen maar specificeert de 'traceparent header' niet bij naam in de normatieve tekst — dat detail staat in de gerefereerde W3C Trace Context specificatie, niet in de brontekst zelf.*
 
-### `ls-logboek-0036` — reference.md:42 *(§ Header formaat)*
+### `ls-logboek-0036` — reference.md:27 *(§ Uitgaande requests)*
 
-> In het W3C Trace Context header formaat is `trace_id` 32 hex karakters (16 bytes) uniek per verwerkingsketen, en `span_id` 16 hex karakters (8 bytes) uniek per actie.
+> Bij uitgaande requests moet een `traceparent` header worden toegevoegd met het actieve `trace_id` en een nieuw gegenereerd `span_id`.
 
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
 
-- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > trace_id 16 byte verplicht ... span_id 8 byte verplicht
-  - *De bron bevestigt de groottes (16 byte voor trace_id, 8 byte voor span_id), maar noemt niet het hex-formaat (32 resp. 16 hex karakters) en niet de context 'uniek per verwerkingsketen' / 'uniek per actie' in deze exacte bewoording.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Als de Applicatie een verzoek aan een andere Applicatie kan versturen, MOET de Applicatie metadata volgens de W3C Trace Context standaard meegeven aan dit verzoek.
+  - *De bron bevestigt de verplichting om W3C Trace Context metadata mee te geven bij uitgaande requests. De claim specificeert 'traceparent header met actieve trace_id en nieuw gegenereerd span_id'; de bron verwijst hiervoor naar de W3C Trace Context standaard zonder de header of het nieuwe span_id expliciet te noemen.*
 
-## GROUNDED — minstens één bron ondersteunt de claim (19)
+### `ls-logboek-0038` — reference.md:42 *(§ Header formaat)*
+
+> Het `trace_id` in het traceparent header bestaat uit 32 hex karakters (16 bytes) en is uniek per verwerkingsketen; het `span_id` bestaat uit 16 hex karakters (8 bytes) en is uniek per actie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context header formaat
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > trace_id 16 byte verplicht [...] span_id 8 byte verplicht
+  - *De bron bevestigt dat trace_id 16 bytes is en span_id 8 bytes, en dat trace_id dataverwerkingen groepeert (uniek per verwerkingsketen) en span_id uniek is per actie. De claim voegt '32 hex karakters' en '16 hex karakters' toe als representatie; dit klopt rekenkundig maar staat niet letterlijk in de bron. Het traceparent header formaat staat ook niet in de bron.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (17)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
@@ -210,88 +249,89 @@
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
   > Logboek dataverwerkingen 1.0.0 Logius Standaard Vastgestelde versie 09 april 2026
 
-### `ls-logboek-0005` — SKILL.md:76 *(§ Log Record Structuur)*
+### `ls-logboek-0006` — SKILL.md:76 *(§ Log Record Structuur)*
 
-> Het veld `span_id` (8 bytes) is verplicht in elk log record en bevat een uniek action ID binnen een verwerking.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > span_id | 8 byte | verplicht [...] Unieke identificerende code van Actie binnen de Dataverwerking.
-
-### `ls-logboek-0006` — SKILL.md:77 *(§ Log Record Structuur)*
-
-> Het veld `parent_span_id` (8 bytes) is optioneel en bevat het ID van de aanroepende actie voor parent-child relaties.
-
-**Type:** factual_assertion  ·  **Modaliteit:** MAY  ·  **Scope:** Logboek Dataverwerkingen log record structuur
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > parent_span_id | 8 byte | optioneel [...] Unieke identificerende code aanroepende Actie. Dit geldt voor zowel binnen de huidige applicatie als bij een aanroep van een andere applicatie.
-
-### `ls-logboek-0007` — SKILL.md:78 *(§ Log Record Structuur)*
-
-> Het veld `status` (enum: Unset, Ok, of Error) is verplicht in elk log record.
+> Het log record veld `span_id` (8 bytes) is verplicht en vormt een uniek action ID binnen een verwerking.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > status | enum | verplicht [...] Het veld status is een enumeratie die de volgende waarden kan bevatten: Unset [...] Ok [...] Error
+  > span_id | 8 byte | verplicht ... Unieke identificerende code van Actie binnen de Dataverwerking. Een applicatie kan meerdere span_id voor dezelfde trace_id hebben.
 
-### `ls-logboek-0008` — SKILL.md:79 *(§ Log Record Structuur)*
+### `ls-logboek-0007` — SKILL.md:77 *(§ Log Record Structuur)*
 
-> Het veld `name` (string, mensleesbare actienaam) is verplicht in elk log record.
+> Het log record veld `parent_span_id` (8 bytes) is optioneel en bevat het ID van de aanroepende actie voor parent-child relaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > parent_span_id | 8 byte | optioneel ... Unieke identificerende code aanroepende Actie. Dit geldt voor zowel binnen de huidige applicatie als bij een aanroep van een andere applicatie.
+
+### `ls-logboek-0008` — SKILL.md:78 *(§ Log Record Structuur)*
+
+> Het log record veld `status` (enum) is verplicht en heeft waarden `Unset`, `Ok`, of `Error`.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > name | string | verplicht [...] Naam van de specifieke Actie binnen de Dataverwerking. Dit is een tekstuele beschrijving bestemd voor mensen, niet voor machines.
+  > status | enum | verplicht ... Het veld status is een enumeratie die de volgende waarden kan bevatten: Unset ... Ok ... Error
 
-### `ls-logboek-0011` — SKILL.md:82 *(§ Log Record Structuur)*
+### `ls-logboek-0009` — SKILL.md:79 *(§ Log Record Structuur)*
 
-> Het veld `resource` (object, systeem- en applicatie-identificatie) is optioneel in elk log record.
-
-**Type:** factual_assertion  ·  **Modaliteit:** MAY  ·  **Scope:** Logboek Dataverwerkingen log record structuur
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > resource | object | optioneel
-
-### `ls-logboek-0012` — SKILL.md:83 *(§ Log Record Structuur)*
-
-> Het veld `attributes` (object, verwerkingsmetadata in de `dpl` namespace) is verplicht in elk log record.
+> Het log record veld `name` (string) is verplicht en bevat een mensleesbare actienaam.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > attributes | object | verplicht [...] Het veld attributes is een object, opgebouwd uit velden in een namespace met prefix dpl (data processing log).
+  > name | string | verplicht ... Naam van de specifieke Actie binnen de Dataverwerking. Dit is een tekstuele beschrijving bestemd voor mensen, niet voor machines.
 
-### `ls-logboek-0014` — SKILL.md:100 *(§ Core Attributes (dpl.core namespace))*
+### `ls-logboek-0012` — SKILL.md:82 *(§ Log Record Structuur)*
 
-> `dpl.core.data_subject_id` (string) is een verplicht attribuut met de unieke, versleutelde identificerende code van de betrokkene.
+> Het log record veld `resource` (object) is optioneel en bevat systeem- en applicatie-identificatie.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen log record structuur
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > dpl.core.data_subject_id | String | Unieke, versleutelde identificerende code van de Betrokkene.
+  > resource | object | optioneel ... Het veld resource is een object, opgebouwd uit de volgende velden: attributes Any Een object met velden dat gebruikt wordt om een systeem, applicatie of component aan te duiden op een manier die binnen de organisatie gebruikelijk is.
+
+### `ls-logboek-0013` — SKILL.md:83 *(§ Log Record Structuur)*
+
+> Het log record veld `attributes` (object) is verplicht en bevat verwerkingsmetadata in de `dpl` namespace.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > attributes | object | verplicht ... Het veld attributes is een object, opgebouwd uit velden in een namespace met prefix dpl (data processing log).
 
 ### `ls-logboek-0015` — SKILL.md:100 *(§ Core Attributes (dpl.core namespace))*
 
-> De specificatie BEVEELT AAN (SHOULD) om `dpl.core.data_subject_id` te pseudonimiseren.
+> `dpl.core.data_subject_id` is een verplicht string-attribuut met de unieke, versleutelde identificerende code van de betrokkene. De specificatie BEVEELT AAN om deze te pseudonimiseren.
 
 **Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Het wordt AANBEVOLEN om de identificerende code te pseudonimiseren.
-  - *AANBEVOLEN correspondeert met SHOULD conform BCP 14 / RFC 2119.*
+  > dpl.core.data_subject_id | String | Unieke, versleutelde identificerende code van de Betrokkene. ... Het wordt AANBEVOLEN om de identificerende code te pseudonimiseren.
+  - *De bron bevestigt zowel dat het veld verplicht en versleuteld is, als dat pseudonimisering wordt aanbevolen (SHOULD).*
 
-### `ls-logboek-0018` — SKILL.md:115 *(§ Core Attributes (dpl.core namespace))*
+### `ls-logboek-0017` — SKILL.md:102 *(§ Core Attributes (dpl.core namespace))*
 
-> De specificatie schrijft geen specifiek pseudonimiseringsalgoritme voor `dpl.core.data_subject_id` voor.
+> `dpl.core.foreign_operation.processor` is een optioneel URL-attribuut met een link naar de externe applicatie of organisatie bij een cross-organisatie verwerking.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > dpl.core.foreign_operation.processor | URL | Link naar externe applicatie ... Als dpl.core.foreign_operation.processor aanwezig is (zie attributes), dan is het een aanroep van een andere applicatie.
+  - *De bron bevestigt het als optioneel URL-attribuut voor cross-applicatie aanroepen. De claim zegt 'externe applicatie of organisatie' — de bron spreekt over 'externe applicatie', niet expliciet over organisatie, maar de context (over organisatiegrenzen) sluit aan.*
+
+### `ls-logboek-0018` — SKILL.md:115 *(§ Core Attributes (dpl.core namespace))*
+
+> De specificatie schrijft geen specifiek pseudonimiseringsalgoritme voor voor `dpl.core.data_subject_id`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
   > Het wordt AANBEVOLEN om de identificerende code te pseudonimiseren.
-  - *De bron beveelt pseudonimisering aan maar schrijft geen specifiek algoritme voor. De claim is een negatieve bewering (geen algoritme voorgeschreven) die consistent is met de brontekst.*
+  - *De bron beveelt pseudonimisering aan maar schrijft geen specifiek algoritme voor. Dit ondersteunt de claim dat geen specifiek algoritme is voorgeschreven.*
 
 ### `ls-logboek-0019` — SKILL.md:147 *(§ Protocol)*
 
@@ -300,16 +340,16 @@
 **Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Logboek Dataverwerkingen protocol
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > De protocollen die worden gebruikt tussen applicatie en logboek [...] worden niet voorgeschreven in de standaard. [...] Het is AANBEVOLEN om het OpenTelemetry Protocol (OTLP) te gebruiken in de interactie tussen Applicatie en Logboek.
+  > De protocollen die worden gebruikt tussen applicatie en logboek en voor het uitvoeren van transacties tussen applicaties worden niet voorgeschreven in de standaard. ... Het is AANBEVOLEN om het OpenTelemetry Protocol (OTLP) te gebruiken in de interactie tussen Applicatie en Logboek.
 
 ### `ls-logboek-0020` — SKILL.md:151 *(§ Protocol)*
 
-> Het Logboek MOET TLS kunnen afdwingen (capability-eis aan de software); of TLS-connecties daadwerkelijk worden toegepast is een organisatie-keuze.
+> Het Logboek MOET TLS kunnen afdwingen (capability-eis aan de software); of TLS-connecties daadwerkelijk worden toegepast is een organisatiekeuze.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen protocol
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Het Logboek MOET TLS kunnen afdwingen. [...] Als er software wordt geschreven dat een Logboek component implementeert, dan moet dit TLS kunnen ondersteunen. Of TLS connecties daadwerkelijk worden toegepast door organisaties die de software gebruiken, is de keuze van de organisatie zelf.
+  > Het Logboek MOET TLS kunnen afdwingen. Noot: Hiermee wordt niet bedoeld dat TLS verplicht is. Als er software wordt geschreven dat een Logboek component implementeert, dan moet dit TLS kunnen ondersteunen. Of TLS connecties daadwerkelijk worden toegepast door organisaties die de software gebruiken, is de keuze van de organisatie zelf.
 
 ### `ls-logboek-0021` — SKILL.md:152 *(§ Protocol)*
 
@@ -320,60 +360,42 @@
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
   > Het Logboek MOET het wegschrijven van elke logregel bevestigen.
 
-### `ls-logboek-0024` — SKILL.md:328 *(§ Status Waarden en Wanneer te Gebruiken)*
+### `ls-logboek-0023` — SKILL.md:153 *(§ Protocol)*
 
-> Status `Unset` wordt gebruikt wanneer een verwerking is afgerond zonder systeemfout, ook als er geen resultaat is (bijv. persoon niet gevonden in BRP).
+> De standaard OTLP-poorten (4317 voor gRPC, 4318 voor HTTP) zijn niet voorgeschreven door de Logboek-standaard zelf.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen foutafhandeling
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Unset: De standaardwaarde voor elke status is Unset. Dit betekent dat de dataverwerking is uitgevoerd zonder interne fout. Deze waarde wordt toegepast wanneer de dataverwerking technisch correct is afgerond, ook als er geen resultaat beschikbaar is of wanneer de invoer onvolledig was.
-
-### `ls-logboek-0025` — SKILL.md:330 *(§ Status Waarden en Wanneer te Gebruiken)*
-
-> Status `Error` wordt gebruikt bij een systeemfout tijdens verwerking (bijv. database timeout, API onbereikbaar). Een gebruikersannulering is GEEN error.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logboek Dataverwerkingen foutafhandeling
+**Type:** normative_requirement  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen protocol
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Error: De waarde Error wordt toegekend bij fouten die zijn ontstaan binnen het systeem dat de dataverwerking uitvoert, zoals interne fouten of mislukte uitvoeringen door technische oorzaken. [...] wanneer een gebruiker een verwerking bewust afbreekt, wordt dit niet als een fout beschouwd.
-  - *De bron bevestigt beide onderdelen van de claim: Error voor systeemfouten, en gebruikersannulering is geen Error.*
+  > De protocollen die worden gebruikt tussen applicatie en logboek en voor het uitvoeren van transacties tussen applicaties worden niet voorgeschreven in de standaard.
+  - *De bron schrijft geen poorten voor; de claim dat standaard OTLP-poorten niet door de Logboek-standaard zijn voorgeschreven is consistent met de algemene vrijheid die de standaard laat voor transportprotocollen.*
 
-### `ls-logboek-0028` — SKILL.md:366 *(§ Verplichte Velden Validatie)*
+### `ls-logboek-0029` — SKILL.md:366 *(§ Verplichte Velden Validatie)*
 
-> Log sampling is NIET toegestaan bij Logboek Dataverwerkingen.
+> Log sampling is NIET toegestaan.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logboek Dataverwerkingen verplichte velden
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logboek Dataverwerkingen implementatie
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > De Applicatie MAG NIET gebruik maken van Log Sampling.
+  > De Applicatie MAG NIET gebruik maken van Log Sampling .
 
-### `ls-logboek-0029` — reference.md:9 *(§ Architectuur - Kernprincipes)*
+### `ls-logboek-0031` — reference.md:10 *(§ Architectuur - Kernprincipes)*
 
-> Elke verwerkingsverantwoordelijke beheert een eigen Logboek; een applicatie logt uitsluitend de eigen verwerkingsactiviteiten.
+> Een applicatie logt uitsluitend de eigen verwerkingsactiviteiten.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen architectuur
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
   > Belangrijk uitgangspunt is dat een Verantwoordelijke alleen Logregels bijhoudt voor Dataverwerkingen die onder eigen verantwoordelijkheid plaatsvinden.
 
-### `ls-logboek-0031` — reference.md:12 *(§ Architectuur - Kernprincipes)*
+### `ls-logboek-0033` — reference.md:12 *(§ Architectuur - Kernprincipes)*
 
 > Er wordt geen inhoudelijke data gedeeld tussen organisaties; alleen Trace-metadata (trace_id, span_id) wordt meegegeven om verwerkingen over organisatiegrenzen te correleren.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logboek Dataverwerkingen architectuur
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logboek Dataverwerkingen cross-organisatie architectuur
 
 - **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Er wordt met de standaard geen inhoudelijke informatie over Dataverwerkingen uitgewisseld tussen Verantwoordelijken. De informatie die wordt uitgewisseld is beperkt tot zogenaamde Trace-informatie waarmee Logregels van de ene Verantwoordelijke gerelateerd kunnen worden aan Logregels bij de andere Verantwoordelijke.
-
-### `ls-logboek-0034` — reference.md:27 *(§ Uitgaande requests)*
-
-> Bij uitgaande requests moet een `traceparent` header worden toegevoegd met het actieve `trace_id` en een nieuw gegenereerd `span_id`.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
-
-- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
-  > Als de Applicatie een verzoek aan een andere Applicatie kan versturen, MOET de Applicatie metadata volgens de W3C Trace Context standaard meegeven aan dit verzoek.
-  - *De bron zegt dat W3C Trace Context metadata moet worden meegegeven bij uitgaande requests, maar specificeert niet het exacte header-formaat (traceparent) of dat er een nieuw span_id moet worden gegenereerd. De kern van de claim wordt ondersteund.*
+  > Er wordt met de standaard geen inhoudelijke informatie over Dataverwerkingen uitgewisseld tussen Verantwoordelijken. [...] De informatie die wordt uitgewisseld is beperkt tot zogenaamde Trace -informatie waarmee Logregels van de ene Verantwoordelijke gerelateerd kunnen worden aan Logregels bij de andere Verantwoordelijke.
+  - *De bron noemt trace-informatie (niet expliciet 'trace_id en span_id' maar dit vloeit voort uit de Trace Context specificatie die de standaard gebruikt).*
 
 </details>

--- a/skills/ls-logboek/audit.md
+++ b/skills/ls-logboek/audit.md
@@ -1,0 +1,379 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-logboek — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 6 | 16% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 12 | 32% |
+| UNGROUNDED | 0 | 0% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 19 | 51% |
+
+*Geverifieerd met sonnet, 3 calls, $0.3082.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (6)
+
+### `ls-logboek-0002` — SKILL.md:37 *(§ Versiemodel)*
+
+> Logboek Dataverwerkingen is nog niet opgenomen op de lijst van het Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen status
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  - *De bron vermeldt dat de standaard beoogd is voor opname op de lijst van Forum Standaardisatie (§1.1), maar bevestigt noch ontkent of opname al heeft plaatsgevonden.*
+
+### `ls-logboek-0022` — SKILL.md:153 *(§ Protocol)*
+
+> OTLP ondersteunt zowel gRPC als HTTP/protobuf als transportlaag met standaard poorten 4317 voor gRPC en 4318 voor HTTP, maar deze poorten zijn niet voorgeschreven door de Logboek-standaard zelf.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen protocol
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  - *De bron noemt OTLP en verwijst naar OpenTelemetry, maar specificeert nergens poortnummers (4317/4318) of een onderscheid tussen gRPC en HTTP/protobuf als transportlagen van OTLP.*
+
+### `ls-logboek-0023` — SKILL.md:173 *(§ NEN 7513 Extensie)*
+
+> De NEN 7513 extensie voegt verplichte attributen toe voor de zorgsector, zoals gebruikersidentificatie, patiëntidentificatie en de specifieke actie op het medisch dossier.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen NEN 7513 extensie
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/logboek-extensie-nen7513](https://github.com/logius-standaarden/logboek-extensie-nen7513)
+  - *De aangeleverde brontekst bevat alleen de GitHub-repositorypagina met navigatie-UI, bestandsnamen en metadata. Er is geen inhoudelijke tekst over de NEN 7513 extensie, verplichte attributen, gebruikersidentificatie, patiëntidentificatie of medische dossiers. De specificatie-inhoud (specificatie.md, abstract.md) is niet meegeleverd.*
+
+### `ls-logboek-0032` — reference.md:13 *(§ Architectuur - Kernprincipes)*
+
+> Het Register beschrijft het wat en waarom van een verwerking; het Logboek beschrijft het wanneer en voor wie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen architectuur
+
+- **NOT_FOUND** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  - *De bron beschrijft de functies van Register en Logboek afzonderlijk, maar formuleert nergens expliciet het onderscheid als 'Register = wat en waarom, Logboek = wanneer en voor wie'. Dit is een parafrase/synthese die niet letterlijk of als directe parafrase in de bron staat.*
+
+### `ls-logboek-0035` — reference.md:33 *(§ Header formaat)*
+
+> Het W3C Trace Context `traceparent` header formaat is: `<version>-<trace_id>-<span_id>-<trace_flags>` waarbij version altijd `00` is in de huidige specificatie.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  - *De bron verwijst naar de W3C Trace Context standaard maar beschrijft het exacte header-formaat (<version>-<trace_id>-<span_id>-<trace_flags>) en de versie '00' niet.*
+
+### `ls-logboek-0037` — reference.md:44 *(§ Header formaat)*
+
+> In het W3C Trace Context header formaat geldt: `trace_flags` `01` = gesampled, `00` = niet gesampled.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  - *De bron vermeldt niets over trace_flags of de semantiek van waarden 01 en 00 daarin. Dit is detail uit de W3C Trace Context specificatie zelf, niet uit deze bron.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (12)
+
+### `ls-logboek-0003` — SKILL.md:37 *(§ Versiemodel)*
+
+> De overige onderdelen van Logboek Dataverwerkingen (inleiding, juridisch-beleidskader, extensies) hebben nog alleen werkversies.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen publicatiekanalen
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > De LDV Normatieve Standaard - Logboek dataverwerkingen (werkversie) [...] De Algemene Inleiding - De Algemene Inleiding (werkversie) [...] Het Juridische Beleidskader - Juridisch Beleidskader (werkversie) [...] LDV Extensie Guideline - Guideline voor het schrijven van een extensie voor LDV (werkversie)
+  - *De tabel toont alle vier documenten met '(werkversie)' voor gepubliceerde versie, maar de bron zelf ís de vastgestelde versie van document 1. De claim dat de overige drie alleen werkversies hebben wordt ondersteund, maar voor document 1 is de vastgestelde versie juist deze bron zelf. De tabel is vermoedelijk niet volledig bijgewerkt na vaststelling.*
+
+### `ls-logboek-0004` — SKILL.md:75 *(§ Log Record Structuur)*
+
+> Het veld `trace_id` (16 bytes) is verplicht in elk log record en bevat een uniek trace ID over systemen heen conform W3C Trace Context.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > trace_id | 16 byte | verplicht [...] Unieke identificerende code van Trace die Dataverwerking volgt.
+  - *De bron bevestigt trace_id als 16 byte en verplicht. De claim dat het 'conform W3C Trace Context' is, wordt niet expliciet zo gesteld voor trace_id zelf; W3C Trace Context wordt genoemd voor metadata-uitwisseling bij HTTP, niet als definitie van trace_id.*
+
+### `ls-logboek-0009` — SKILL.md:80 *(§ Log Record Structuur)*
+
+> Het veld `start_time` (uint64, starttijd in milliseconden sinds Unix Epoch) is verplicht in elk log record.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > start_time | uint64 | verplicht [...] Tijdstip waarop de Actie gestart is in milliseconden sinds Epoch.
+  - *De bron bevestigt uint64, verplicht, en milliseconden sinds Epoch. De claim zegt 'Unix Epoch'; de bron zegt alleen 'Epoch' zonder 'Unix' te specificeren — inhoudelijk gelijkwaardig maar niet letterlijk identiek.*
+
+### `ls-logboek-0010` — SKILL.md:81 *(§ Log Record Structuur)*
+
+> Het veld `end_time` (uint64, eindtijd in milliseconden sinds Unix Epoch) is verplicht in elk log record.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > end_time | uint64 | verplicht [...] Tijdstip waarop de Actie beëindigd is in milliseconden sinds Epoch.
+  - *Zelfde kanttekening als ls-logboek-0009: 'Epoch' vs 'Unix Epoch' — inhoudelijk gelijkwaardig, niet letterlijk identiek.*
+
+### `ls-logboek-0013` — SKILL.md:99 *(§ Core Attributes (dpl.core namespace))*
+
+> `dpl.core.processing_activity_id` (URI) is een verplicht attribuut dat verwijst naar de verwerkingsactiviteit in het Register conform AVG Art. 30.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > dpl.core.processing_activity_id | URI | Verwijzing naar een Register met meer informatie over de Verwerkingsactiviteit.
+  - *De bron bevestigt het veld als URI en verwijzing naar een Register. De claim voegt 'conform AVG Art. 30' toe; de bron vermeldt AVG Art. 30 in de context van het Register van Verwerkingsactiviteiten maar koppelt dat niet expliciet aan dit attribuut als eis.*
+
+### `ls-logboek-0016` — SKILL.md:101 *(§ Core Attributes (dpl.core namespace))*
+
+> `dpl.core.data_subject_id_type` (string) is een verplicht attribuut. Mogelijke waarden zijn: BSN, personeelsnummer, URI, of een ander organisatiespecifiek type.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > dpl.core.data_subject_id_type | String | Type van de identificerende code, zoals BSN, personeelsnummer, of een URI naar een Register dat het type specificeert.
+  - *De bron bevestigt het veld en noemt BSN, personeelsnummer en URI als voorbeelden. De claim voegt 'of een ander organisatiespecifiek type' toe, wat de bron niet expliciet noemt maar impliciet open laat. De kern (verplicht, string, genoemde voorbeelden) is ondersteund.*
+
+### `ls-logboek-0017` — SKILL.md:102 *(§ Core Attributes (dpl.core namespace))*
+
+> `dpl.core.foreign_operation.processor` (URL) is een optioneel attribuut met een link naar de externe applicatie of organisatie betrokken bij een cross-organisatie verwerking.
+
+**Type:** factual_assertion  ·  **Modaliteit:** MAY  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > dpl.core.foreign_operation.processor | URL | Link naar externe applicatie
+  - *De bron bevestigt het veld als URL en 'link naar externe applicatie'. De claim voegt 'of organisatie betrokken bij een cross-organisatie verwerking' toe; de bron zegt alleen 'externe applicatie', niet expliciet 'organisatie'.*
+
+### `ls-logboek-0026` — SKILL.md:356 *(§ Verplichte Velden Validatie)*
+
+> Een logregel MOET minimaal bevatten: trace_id, span_id, name, start_time, end_time, status, dpl.core.processing_activity_id, dpl.core.data_subject_id en dpl.core.data_subject_id_type.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen verplichte velden
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > De interface MOET de volgende velden implementeren: trace_id [...] verplicht, span_id [...] verplicht, status [...] verplicht, name [...] verplicht, start_time [...] verplicht, end_time [...] verplicht [...] dpl.core.processing_activity_id [...] dpl.core.data_subject_id [...] dpl.core.data_subject_id_type
+  - *De bron bevestigt al deze velden als verplicht. Echter: dpl.core.data_subject_id en dpl.core.data_subject_id_type zijn verplicht 'voor dataverwerkingen met persoonsdata' (§3.3.1.1); voor dataverwerkingen zonder persoonsdata geldt dit niet. De claim stelt dat een logregel ALTIJD alle negen velden moet bevatten, wat de bron niet onvoorwaardelijk zo stelt.*
+
+### `ls-logboek-0027` — SKILL.md:366 *(§ Verplichte Velden Validatie)*
+
+> Als een verplicht veld ontbreekt, MOET de software een standaardwaarde invullen om runtime-fouten te voorkomen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen verplichte velden
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Bijvoorbeeld als name leeg is, moet deze automatisch worden gevuld met een waarde zodat er in ieder geval op dit punt geen fout kan optreden.
+  - *De bron noemt dit principe specifiek alleen voor het veld 'name', niet als algemene regel voor alle verplichte velden. De claim is breder dan wat de bron stelt.*
+
+### `ls-logboek-0030` — reference.md:11 *(§ Architectuur - Kernprincipes)*
+
+> Het Logboek verwijst naar het Register van Verwerkingsactiviteiten (AVG Art. 30) via `dpl.core.processing_activity_id`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen architectuur
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Iedere Dataverwerking van persoonsdata betreft een Verwerkingsactiviteit die in het Register van Verwerkingsactiviteiten moet zijn opgenomen. De Applicatie MOET in de Logregel een verwijzing naar de juiste Verwerkingsactiviteit in het Register van Verwerkingsactiviteiten opnemen in het veld dpl.core.processing_activity_id.
+  - *De bron bevestigt de verwijzing via dpl.core.processing_activity_id en de relatie met het Register van Verwerkingsactiviteiten (AVG art. 30), maar de claim stelt dat het 'Logboek' verwijst naar het register, terwijl de bron stelt dat de 'Applicatie' de verwijzing opneemt in de Logregel. Dat is een nuanceverschil in architecturele attributie.*
+
+### `ls-logboek-0033` — reference.md:21 *(§ Inkomende requests)*
+
+> Bij inkomende requests moet de `traceparent` header worden geparsed, het ontvangen `trace_id` gebruikt voor de eigen logregel, en de ontvangen `span_id` opgeslagen als `parent_span_id` in het eigen log record.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Als de Applicatie een verzoek van een andere Applicatie kan ontvangen, MOET de Applicatie metadata volgens de W3C Trace Context standaard kunnen verwerken en gebruiken in de eigen Trace(s). Metadata verkregen via W3C Trace Context MOET in attributes meegenomen worden als velden die beginnen met dpl.core.foreign_operation.
+  - *De bron bevestigt verwerking van W3C Trace Context metadata bij inkomende requests en gebruik ervan in de eigen trace, maar specificeert niet expliciet het parsen van een 'traceparent' header, en stelt dat metadata wordt opgeslagen als dpl.core.foreign_operation-velden, niet letterlijk als parent_span_id. De claim is specifieker dan de bron.*
+
+### `ls-logboek-0036` — reference.md:42 *(§ Header formaat)*
+
+> In het W3C Trace Context header formaat is `trace_id` 32 hex karakters (16 bytes) uniek per verwerkingsketen, en `span_id` 16 hex karakters (8 bytes) uniek per actie.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > trace_id 16 byte verplicht ... span_id 8 byte verplicht
+  - *De bron bevestigt de groottes (16 byte voor trace_id, 8 byte voor span_id), maar noemt niet het hex-formaat (32 resp. 16 hex karakters) en niet de context 'uniek per verwerkingsketen' / 'uniek per actie' in deze exacte bewoording.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (19)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-logboek-0001` — SKILL.md:37 *(§ Versiemodel)*
+
+> De normatieve hoofdspecificatie logboek-dataverwerkingen heeft sinds 9 april 2026 een vastgestelde versie v1.0.0.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen hoofdspecificatie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Logboek dataverwerkingen 1.0.0 Logius Standaard Vastgestelde versie 09 april 2026
+
+### `ls-logboek-0005` — SKILL.md:76 *(§ Log Record Structuur)*
+
+> Het veld `span_id` (8 bytes) is verplicht in elk log record en bevat een uniek action ID binnen een verwerking.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > span_id | 8 byte | verplicht [...] Unieke identificerende code van Actie binnen de Dataverwerking.
+
+### `ls-logboek-0006` — SKILL.md:77 *(§ Log Record Structuur)*
+
+> Het veld `parent_span_id` (8 bytes) is optioneel en bevat het ID van de aanroepende actie voor parent-child relaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** MAY  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > parent_span_id | 8 byte | optioneel [...] Unieke identificerende code aanroepende Actie. Dit geldt voor zowel binnen de huidige applicatie als bij een aanroep van een andere applicatie.
+
+### `ls-logboek-0007` — SKILL.md:78 *(§ Log Record Structuur)*
+
+> Het veld `status` (enum: Unset, Ok, of Error) is verplicht in elk log record.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > status | enum | verplicht [...] Het veld status is een enumeratie die de volgende waarden kan bevatten: Unset [...] Ok [...] Error
+
+### `ls-logboek-0008` — SKILL.md:79 *(§ Log Record Structuur)*
+
+> Het veld `name` (string, mensleesbare actienaam) is verplicht in elk log record.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > name | string | verplicht [...] Naam van de specifieke Actie binnen de Dataverwerking. Dit is een tekstuele beschrijving bestemd voor mensen, niet voor machines.
+
+### `ls-logboek-0011` — SKILL.md:82 *(§ Log Record Structuur)*
+
+> Het veld `resource` (object, systeem- en applicatie-identificatie) is optioneel in elk log record.
+
+**Type:** factual_assertion  ·  **Modaliteit:** MAY  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > resource | object | optioneel
+
+### `ls-logboek-0012` — SKILL.md:83 *(§ Log Record Structuur)*
+
+> Het veld `attributes` (object, verwerkingsmetadata in de `dpl` namespace) is verplicht in elk log record.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen log record structuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > attributes | object | verplicht [...] Het veld attributes is een object, opgebouwd uit velden in een namespace met prefix dpl (data processing log).
+
+### `ls-logboek-0014` — SKILL.md:100 *(§ Core Attributes (dpl.core namespace))*
+
+> `dpl.core.data_subject_id` (string) is een verplicht attribuut met de unieke, versleutelde identificerende code van de betrokkene.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > dpl.core.data_subject_id | String | Unieke, versleutelde identificerende code van de Betrokkene.
+
+### `ls-logboek-0015` — SKILL.md:100 *(§ Core Attributes (dpl.core namespace))*
+
+> De specificatie BEVEELT AAN (SHOULD) om `dpl.core.data_subject_id` te pseudonimiseren.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Het wordt AANBEVOLEN om de identificerende code te pseudonimiseren.
+  - *AANBEVOLEN correspondeert met SHOULD conform BCP 14 / RFC 2119.*
+
+### `ls-logboek-0018` — SKILL.md:115 *(§ Core Attributes (dpl.core namespace))*
+
+> De specificatie schrijft geen specifiek pseudonimiseringsalgoritme voor `dpl.core.data_subject_id` voor.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen dpl.core namespace
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Het wordt AANBEVOLEN om de identificerende code te pseudonimiseren.
+  - *De bron beveelt pseudonimisering aan maar schrijft geen specifiek algoritme voor. De claim is een negatieve bewering (geen algoritme voorgeschreven) die consistent is met de brontekst.*
+
+### `ls-logboek-0019` — SKILL.md:147 *(§ Protocol)*
+
+> De standaard schrijft geen specifiek transportprotocol voor, maar beveelt OpenTelemetry Protocol (OTLP) aan als transportprotocol voor het aanleveren van logregels aan het Logboek.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Logboek Dataverwerkingen protocol
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > De protocollen die worden gebruikt tussen applicatie en logboek [...] worden niet voorgeschreven in de standaard. [...] Het is AANBEVOLEN om het OpenTelemetry Protocol (OTLP) te gebruiken in de interactie tussen Applicatie en Logboek.
+
+### `ls-logboek-0020` — SKILL.md:151 *(§ Protocol)*
+
+> Het Logboek MOET TLS kunnen afdwingen (capability-eis aan de software); of TLS-connecties daadwerkelijk worden toegepast is een organisatie-keuze.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen protocol
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Het Logboek MOET TLS kunnen afdwingen. [...] Als er software wordt geschreven dat een Logboek component implementeert, dan moet dit TLS kunnen ondersteunen. Of TLS connecties daadwerkelijk worden toegepast door organisaties die de software gebruiken, is de keuze van de organisatie zelf.
+
+### `ls-logboek-0021` — SKILL.md:152 *(§ Protocol)*
+
+> Het Logboek MOET elke schrijfactie bevestigen met een bevestigingsbericht (acknowledgement).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen protocol
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Het Logboek MOET het wegschrijven van elke logregel bevestigen.
+
+### `ls-logboek-0024` — SKILL.md:328 *(§ Status Waarden en Wanneer te Gebruiken)*
+
+> Status `Unset` wordt gebruikt wanneer een verwerking is afgerond zonder systeemfout, ook als er geen resultaat is (bijv. persoon niet gevonden in BRP).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen foutafhandeling
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Unset: De standaardwaarde voor elke status is Unset. Dit betekent dat de dataverwerking is uitgevoerd zonder interne fout. Deze waarde wordt toegepast wanneer de dataverwerking technisch correct is afgerond, ook als er geen resultaat beschikbaar is of wanneer de invoer onvolledig was.
+
+### `ls-logboek-0025` — SKILL.md:330 *(§ Status Waarden en Wanneer te Gebruiken)*
+
+> Status `Error` wordt gebruikt bij een systeemfout tijdens verwerking (bijv. database timeout, API onbereikbaar). Een gebruikersannulering is GEEN error.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logboek Dataverwerkingen foutafhandeling
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Error: De waarde Error wordt toegekend bij fouten die zijn ontstaan binnen het systeem dat de dataverwerking uitvoert, zoals interne fouten of mislukte uitvoeringen door technische oorzaken. [...] wanneer een gebruiker een verwerking bewust afbreekt, wordt dit niet als een fout beschouwd.
+  - *De bron bevestigt beide onderdelen van de claim: Error voor systeemfouten, en gebruikersannulering is geen Error.*
+
+### `ls-logboek-0028` — SKILL.md:366 *(§ Verplichte Velden Validatie)*
+
+> Log sampling is NIET toegestaan bij Logboek Dataverwerkingen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logboek Dataverwerkingen verplichte velden
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > De Applicatie MAG NIET gebruik maken van Log Sampling.
+
+### `ls-logboek-0029` — reference.md:9 *(§ Architectuur - Kernprincipes)*
+
+> Elke verwerkingsverantwoordelijke beheert een eigen Logboek; een applicatie logt uitsluitend de eigen verwerkingsactiviteiten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen architectuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Belangrijk uitgangspunt is dat een Verantwoordelijke alleen Logregels bijhoudt voor Dataverwerkingen die onder eigen verantwoordelijkheid plaatsvinden.
+
+### `ls-logboek-0031` — reference.md:12 *(§ Architectuur - Kernprincipes)*
+
+> Er wordt geen inhoudelijke data gedeeld tussen organisaties; alleen Trace-metadata (trace_id, span_id) wordt meegegeven om verwerkingen over organisatiegrenzen te correleren.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logboek Dataverwerkingen architectuur
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Er wordt met de standaard geen inhoudelijke informatie over Dataverwerkingen uitgewisseld tussen Verantwoordelijken. De informatie die wordt uitgewisseld is beperkt tot zogenaamde Trace-informatie waarmee Logregels van de ene Verantwoordelijke gerelateerd kunnen worden aan Logregels bij de andere Verantwoordelijke.
+
+### `ls-logboek-0034` — reference.md:27 *(§ Uitgaande requests)*
+
+> Bij uitgaande requests moet een `traceparent` header worden toegevoegd met het actieve `trace_id` en een nieuw gegenereerd `span_id`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logboek Dataverwerkingen W3C Trace Context integratie
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0](https://gitdocumentatie.logius.nl/publicatie/logboek/dataverwerkingen/1.0.0)
+  > Als de Applicatie een verzoek aan een andere Applicatie kan versturen, MOET de Applicatie metadata volgens de W3C Trace Context standaard meegeven aan dit verzoek.
+  - *De bron zegt dat W3C Trace Context metadata moet worden meegegeven bij uitgaande requests, maar specificeert niet het exacte header-formaat (traceparent) of dat er een nieuw span_id moet worden gegenereerd. De kern van de claim wordt ondersteund.*
+
+</details>

--- a/skills/ls-notif/audit.md
+++ b/skills/ls-notif/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-notif — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,84 +7,27 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 13 | 46% |
+| UNSUPPORTED_ASSERTION | 5 | 20% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 1 | 4% |
-| UNGROUNDED | 11 | 39% |
+| PARTIALLY_GROUNDED | 10 | 40% |
+| UNGROUNDED | 2 | 8% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 3 | 11% |
+| GROUNDED | 8 | 32% |
 
-*Geverifieerd met sonnet, 10 calls, $0.7333.*
+*Geverifieerd met sonnet, 11 calls, $0.8515.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (13)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (5)
 
-### `ls-notif-0001` — SKILL.md:34 *(§ Versiemodel)*
+### `ls-notif-0009` — SKILL.md:69 *(§ Optionele attributen)*
 
-> Het NL GOV profiel voor CloudEvents heeft een vastgestelde versie (v1.1 DEF).
+> Het `time` attribuut is het tijdstip van logging/registratie van het event in RFC 3339 formaat, niet noodzakelijk het moment van de werkelijke gebeurtenis.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profile for CloudEvents - optionele attributen
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v1.1') en geen inhoudelijke tekst over versies of vaststellingen.*
-
-### `ls-notif-0002` — SKILL.md:36 *(§ Versiemodel)*
-
-> Op het Forum Standaardisatie staat CloudEvents v1.0 als verplicht ('pas-toe-of-leg-uit'), goedgekeurd OBDO 25-11-2025.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / NL GOV profiel voor CloudEvents
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v0.0.1') en is verder leeg/onbruikbaar. Geen inhoud beschikbaar om deze claim te verifiëren.*
-
-### `ls-notif-0003` — SKILL.md:36 *(§ Versiemodel)*
-
-> Versie v1.1 is de meest recente DEF van Logius voor het NL GOV profiel voor CloudEvents.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-
-### `ls-notif-0004` — SKILL.md:47 *(§ Repositories)*
-
-> Abonneren WV v0.0.1 is gepubliceerd op gitdocumentatie.logius.nl maar is nog niet vastgesteld als standaard.
-
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Abonneren API-specificatie
-
-<details><summary>8x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents](https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents)
-  - *De bron behandelt de Abonneren API-specificatie of gitdocumentatie.logius.nl niet. De bron is de GitHub repository pagina voor NL-GOV-profile-for-CloudEvents.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents](https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents)
-  - *De bron behandelt het NL-GOV-profile-for-CloudEvents specificatie, niet de Abonneren API-specificatie of Abonneren WV v0.0.1. Er is geen vermelding van een Abonneren-standaard of versienummer in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/CloudEvents-NL-Guidelines](https://github.com/logius-standaarden/CloudEvents-NL-Guidelines)
-  - *De brontekst betreft de CloudEvents-NL-Guidelines repository op GitHub. Er is geen informatie over de Abonneren API-specificatie of Abonneren WV v0.0.1 in de aangeleverde tekst.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/CloudEvents-NL-Guidelines](https://logius-standaarden.github.io/CloudEvents-NL-Guidelines)
-  - *De brontekst behandelt de CloudEvents-NL-Guidelines handreiking, niet de Abonneren API-specificatie. Geen vermelding van 'Abonneren WV v0.0.1' of publicatiestatus daarvan.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Notificatieservices](https://github.com/logius-standaarden/Notificatieservices)
-  - *De bron vermeldt een 'Concept API-specificatie voor geautomatiseerd abonneren' maar geeft geen versienummer (v0.0.1) of publicatielocatie (gitdocumentatie.logius.nl). Er staat ook niets over de vaststelling als standaard.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Abonneren](https://github.com/logius-standaarden/Abonneren)
-  - *De brontekst betreft de GitHub-repository 'Abonneren' van Logius-standaarden. Er staat geen vermelding van een versienummer (v0.0.1), publicatie op gitdocumentatie.logius.nl, of de vaststelling als standaard.*
-</details>
-
-### `ls-notif-0011` — SKILL.md:70 *(§ Optionele attributen)*
-
-> Het optionele attribuut `dataref` verwijst naar een externe locatie waar de volledige event payload beschikbaar is en implementeert het Claim Check Pattern voor grote payloads.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents - optionele attributen
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
+  - *De bron is RFC 3339 zelf, die het datum/tijdformaat definieert. De claim gaat over hoe CloudEvents het `time` attribuut semantisch invult (logging/registratie vs. werkelijke gebeurtenis). RFC 3339 bevat geen informatie over CloudEvents of de betekenis van specifieke attributen daarin.*
 
 ### `ls-notif-0013` — SKILL.md:76 *(§ Notificatieservices API)*
 
@@ -93,9 +36,9 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Notificatieservices API
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+  - *De bron bevat geen informatie over een Notificatieservices API, OpenAPI 3.x specificatie of een centraal endpoint voor het publiceren van events.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bespreekt technologieën en aanbevelingen, maar bevat geen specificatie van een Notificatieservices API als OpenAPI 3.x met een centraal endpoint.*
 
 ### `ls-notif-0015` — SKILL.md:108 *(§ Abonneren)*
 
@@ -104,155 +47,250 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Notificatieservices API
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+  - *De bron bevat geen informatie over een OpenAPI-specificatie met endpoints zoals POST /events of pull/polling-endpoints.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bevat geen beschrijving van een OpenAPI-specificatie met specifieke endpoints zoals `POST /events` of het ontbreken van pull/polling-endpoints.*
 
-### `ls-notif-0019` — SKILL.md:308 *(§ Notificatieservice Error Responses)*
+### `ls-notif-0020` — reference.md:50 *(§ Authenticatie en autorisatie)*
 
-> Bij een HTTP 403-respons van de notificatieservice ontbreekt de scope `notifications.distribute`.
+> De Notificatieservices API maakt gebruik van JWT Bearer Tokens voor authenticatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Notificatieservices API - foutafhandeling
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Notificatieservices API - authenticatie
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+  - *De bron bevat geen informatie over JWT Bearer Tokens of authenticatiemechanismen voor de Notificatieservices API.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron noemt OAuth/OIDC in algemene zin als onderdeel van security-aandachtspunten, maar bevat geen specificatie dat de Notificatieservices API JWT Bearer Tokens gebruikt voor authenticatie.*
 
-### `ls-notif-0021` — reference.md:21 *(§ Kernconcepten)*
+### `ls-notif-0023` — reference.md:17 *(§ Type Systeem)*
 
-> CloudEvents is een CNCF standaard voor het beschrijven van events in een cloud-omgeving.
+> CloudEvents definieert het Timestamp type als datum en tijd conform RFC 3339.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents kernstandaard
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents type systeem
+
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
+  - *De bron is RFC 3339 zelf. De claim gaat over hoe CloudEvents het Timestamp type definieert en welke standaard het daarvoor gebruikt. RFC 3339 bevat geen informatie over CloudEvents of de typedefinities daarin.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (10)
+
+### `ls-notif-0001` — SKILL.md:34 *(§ Versiemodel)*
+
+> Het NL GOV profiel voor CloudEvents heeft een vastgestelde versie (v1.1 DEF).
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profile for CloudEvents
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > NL GOV profile for CloudEvents 1.1 Notificatieservices Logius Standard Definitive version March 17, 2026
+  - *De bron bevestigt een definitieve versie 1.1, maar de claim zegt 'v1.1 DEF' als aanduiding. De versie en definitieve status kloppen, de exacte afkorting 'DEF' staat er niet in maar is een redelijke parafrase.*
+
+### `ls-notif-0002` — SKILL.md:36 *(§ Versiemodel)*
+
+> Op het Forum Standaardisatie staat CloudEvents v1.0 als verplicht ('pas-toe-of-leg-uit'), goedgekeurd OBDO 25-11-2025.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / NL GOV profile for CloudEvents
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  > Verplicht ('Pas toe leg uit') [...] Versie 1.1 [...] Specificatiedocument NL GOV profile for CloudEvents 1.0
+  - *De bron bevestigt dat de standaard op de 'Pas toe of leg uit'-lijst staat (verplicht), wat de status-claim ondersteunt. Echter: de versie in de registratie is 1.1 (niet 1.0), al verwijst het specificatiedocument naar versie 1.0. De datum van OBDO-goedkeuring (25-11-2025) staat niet in de brontekst; de Forumadvies-datum suggereert 20250924 (september 2025), maar een expliciete OBDO-datum ontbreekt volledig. De claim is dus deels ondersteund (verplicht-status) maar de specifieke versie en OBDO-datum kunnen niet worden bevestigd.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *De bron bevat geen informatie over Forum Standaardisatie, pas-toe-of-leg-uit status, OBDO of goedkeuringsdatum 25-11-2025.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De brontekst vermeldt CloudEvents en het NL GOV-profiel, maar bevat geen informatie over Forum Standaardisatie, de 'pas-toe-of-leg-uit' status, of een OBDO-goedkeuring op 25-11-2025.*
+
+### `ls-notif-0003` — SKILL.md:47 *(§ Repositories)*
+
+> Abonneren WV v0.0.1 is gepubliceerd op gitdocumentatie.logius.nl maar is nog niet vastgesteld.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Abonneren standaard
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  > Dit is een werkversie die op elk moment kan worden gewijzigd, verwijderd of vervangen door andere documenten. Het is geen door het TO goedgekeurde consultatieversie.
+  - *De bron bevestigt dat het document een werkversie is op gitdocumentatie.logius.nl en niet is vastgesteld. Het versienummer v0.0.1 wordt echter niet expliciet vermeld in de brontekst.*
+<details><summary>7x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+  - *De bron bevat geen informatie over 'Abonneren WV v0.0.1' of publicatiestatus daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents](https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents)
+  - *De brontekst betreft de GitHub-repository van het NL-GOV-profile-for-CloudEvents. Er wordt geen melding gemaakt van een 'Abonneren' standaard, werkversie v0.0.1, of gitdocumentatie.logius.nl. De enige release die wordt vermeld is 'Release 1.1' van het CloudEvents profiel zelf.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents](https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents)
+  - *De brontekst behandelt uitsluitend het NLgov profile for CloudEvents. Er is geen vermelding van 'Abonneren WV v0.0.1' of een abonneer-standaard op gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/CloudEvents-NL-Guidelines](https://github.com/logius-standaarden/CloudEvents-NL-Guidelines)
+  - *De aangeleverde brontekst betreft de GitHub-pagina van CloudEvents-NL-Guidelines. Er is geen vermelding van 'Abonneren WV v0.0.1', gitdocumentatie.logius.nl, of de vaststellingsstatus van een Abonneren-standaard.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/CloudEvents-NL-Guidelines](https://logius-standaarden.github.io/CloudEvents-NL-Guidelines)
+  - *De brontekst gaat over de CloudEvents NL Guidelines (HTTP Protocol Binding, JSON Event Format, Webhook pattern). Er is geen informatie over een 'Abonneren' werkversie v0.0.1 of de publicatiestatus daarvan op gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Notificatieservices](https://github.com/logius-standaarden/Notificatieservices)
+  - *De brontekst vermeldt een 'Concept API-specificatie voor geautomatiseerd abonneren' maar bevat geen informatie over 'Abonneren WV v0.0.1', publicatie op gitdocumentatie.logius.nl, of de vaststellingsstatus daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Abonneren](https://github.com/logius-standaarden/Abonneren)
+  - *De aangeleverde brontekst is de GitHub-repositorypagina van Logius-standaarden/Abonneren. Er staat geen informatie over een versienummer (v0.0.1), een publicatie op gitdocumentatie.logius.nl, of een vaststellingsstatus. De tekst beschrijft alleen de repository-inhoud en de README-samenvatting.*
+</details>
+
+### `ls-notif-0005` — SKILL.md:58 *(§ Verplichte attributen)*
+
+> Het `source` attribuut in het NL GOV profiel schrijft URN-notatie voor met de `nld` namespace. Formaat: `urn:nld:oin:<OIN>:systeem:<systeemnaam>`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profile for CloudEvents - verplichte attributen
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > SHOULD be a URN notation with 'nld' as namespace identifier. SHOULD contain consecutive a unique identifier of: the organization that publishes the event the source system that publishes the event. [...] Examples: urn:nld:oin:00000001823288444000:systeem:BRP-component
+  - *De bron ondersteunt URN-notatie met 'nld' namespace en geeft het voorbeeld-formaat urn:nld:oin:<OIN>:systeem:<systeemnaam>. Echter: de bron gebruikt SHOULD, niet MUST voor deze URN-notatie. De claim stelt 'schrijft voor' wat de indruk wekt van een harde verplichting.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron noemt het NL GOV-profiel voor CloudEvents in het kader van Digilevering/Solace, maar bevat geen specificaties over URN-notatie, de `nld` namespace of het formaat van het `source` attribuut.*
 
-### `ls-notif-0024` — reference.md:44 *(§ Niet aanbevolen technologieën)*
+### `ls-notif-0007` — SKILL.md:60 *(§ Verplichte attributen)*
 
-> WebSub wordt niet aanbevolen vanwege verouderde status, beperkte ondersteuning en community.
+> Het `type` attribuut gebruikt Reverse Domain Name Notation. Versioning gebeurt met een `v` prefix: `nl.brp.verhuizing.v2`. Types worden geregistreerd in een centraal register.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Aanbevolen technologieën voor notificatieservices
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profile for CloudEvents - verplichte attributen
+
+- **PARTIALLY_SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > MUST be Reverse domain name notation [...] If versioning is used, the type attribute MUST only include a single version number, prefixed by the letter v
+  - *Reverse DNS notatie en 'v' prefix voor versioning worden bevestigd. Het voorbeeld 'nl.brp.verhuizing.v2' past bij de spec. Maar een 'centraal register' voor types wordt nergens in de bron vermeld.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De bron bevat geen normtekst over het `type` attribuut, Reverse Domain Name Notation, versioning met een `v` prefix, of een centraal register voor types.*
+
+### `ls-notif-0011` — SKILL.md:71 *(§ Optionele attributen)*
+
+> Het `sequence` attribuut is een CloudEvents extensie-attribuut (CNCF Sequence-extensie, niet in de kernspec) dat het NL GOV profiel overneemt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profile for CloudEvents - optionele attributen
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > Two of the extension attributes included by CloudEvents ('dataref' and 'sequence') are included as optional attributes in the CloudEvents-NL profile because it is foreseen that there is often a need to use these attributes.
+  - *De bron bevestigt dat 'sequence' een extensie-attribuut is dat het NL GOV profiel overneemt. De claim noemt specifiek 'CNCF Sequence-extensie, niet in de kernspec' — de bron zegt het is een extensie maar noemt niet expliciet 'CNCF Sequence-extensie' als naam.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De bron bevat geen informatie over het `sequence` attribuut als CloudEvents extensie-attribuut.*
+
+### `ls-notif-0016` — SKILL.md:122 *(§ Security & Privacy)*
+
+> Context-attributen (zoals `source`, `type`, `subject`) mogen nooit persoonsgegevens of gevoelige informatie bevatten; gebruik hiervoor de versleutelde `data`-payload.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Security & Privacy - notificaties
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > Sensitive information SHOULD NOT be carried or represented in context attributes. CloudEvent producers, consumers, and intermediaries MAY introspect and log context attributes.
+  - *De bron zegt SHOULD NOT voor gevoelige informatie in context-attributen, niet MUST NOT zoals de claim stelt. Dit is een relevant verschil in modaliteit. De verwijzing naar versleutelde data-payload komt ook voor ('Domain specific event data SHOULD be encrypted') maar is niet direct gekoppeld als vereiste tegenhanger.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De bron bevat geen normtekst over het verbod op persoonsgegevens in context-attributen zoals `source`, `type` of `subject`.*
+
+### `ls-notif-0017` — SKILL.md:123 *(§ Security & Privacy)*
+
+> Wanneer de payload gevoelige gegevens bevat, moet deze versleuteld worden (end-to-end encryptie).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Security & Privacy - notificaties
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > Domain specific event data SHOULD be encrypted to restrict visibility to trusted parties. The mechanism employed for such encryption is an agreement between producers and consumers and thus outside the scope of this specification.
+  - *De bron zegt SHOULD be encrypted, niet MUST. De claim stelt MUST. Bovendien spreekt de bron niet specifiek van 'end-to-end encryptie' als term.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De bron bevat geen normtekst over verplichte end-to-end encryptie van gevoelige payloads.*
+
+### `ls-notif-0018` — SKILL.md:124 *(§ Security & Privacy)*
+
+> Alle communicatie tussen bronnen, notificatieservices en afnemers moet plaatsvinden over TLS (minimaal versie 1.2).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Security & Privacy - notificaties
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > Protocol level security SHOULD be employed to ensure the trusted and secure exchange of CloudEvents.
+  - *De bron beveelt protocol-level security aan (SHOULD) maar noemt TLS noch een minimale versie (1.2). De claim stelt MUST en specificeert TLS minimaal 1.2, wat de bron niet bevestigt.*
+- **PARTIALLY_SUPPORTED** (low) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  > Integration with federated identity and authorization frameworks (e.g., OAuth 2.0 / OIDC for authentication, fine-grained RBAC/ABAC policies) is crucial to govern who can subscribe and consume what data.
+  - *De bron noemt beveiligingsmechanismen en verwijst naar mutual TLS in de context van AMQP ('mutual TLS, SASL-authenticatie'), maar bevat geen expliciete eis dat alle communicatie over TLS minimaal versie 1.2 moet plaatsvinden.*
+
+### `ls-notif-0024` — reference.md:15 *(§ Type Systeem)*
+
+> CloudEvents URI type is een absolute URI conform RFC 3986; URI-reference is een URI of relatieve referentie conform RFC 3986.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents type systeem
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc3986.txt](https://www.rfc-editor.org/rfc/rfc3986.txt)
+  > A URI is an identifier consisting of a sequence of characters matching the syntax rule named <URI> in Section 3. [...] URI-reference = URI / relative-ref [...] A URI-reference is either a URI or a relative reference.
+  - *De bron ondersteunt volledig dat een URI een absolute URI is conform RFC 3986 en dat URI-reference een URI of relatieve referentie is. Wat de bron NIET bevestigt is het CloudEvents-specifieke deel: dat het 'type' attribuut in CloudEvents een absolute URI moet zijn. De bron definieert alleen de algemene URI-syntaxis, niet hoe CloudEvents dit toepast. Het deel over URI-reference als 'URI of relatieve referentie' is letterlijk ondersteund; het deel over CloudEvents URI type als absolute URI vereist kennis van de CloudEvents-specificatie zelf.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (2)
+
+### `ls-notif-0019` — SKILL.md:308 *(§ Foutafhandeling)*
+
+> De scope `notifications.distribute` is vereist voor publicerende systemen om events te publiceren via de Notificatieservices API.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Notificatieservices API - autorisatie
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+  - *De bron bevat geen informatie over OAuth scopes, autorisatie of de scope 'notifications.distribute'.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bevat geen informatie over een OAuth scope `notifications.distribute` of autorisatievereisten voor de Notificatieservices API.*
 
-### `ls-notif-0025` — reference.md:45 *(§ Niet aanbevolen technologieën)*
+### `ls-notif-0021` — reference.md:50 *(§ Authenticatie en autorisatie)*
 
-> MQTT wordt niet aanbevolen voor overheidsnotificaties omdat het primair gericht is op IoT-toepassingen.
+> Publicerende systemen hebben een JWT token nodig met de scope `notifications.distribute`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Aanbevolen technologieën voor notificatieservices
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Notificatieservices API - authenticatie
 
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+  - *De bron bevat geen informatie over JWT tokens of de scope 'notifications.distribute'.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bevat geen normtekst over een JWT token vereiste met scope `notifications.distribute` voor publicerende systemen.*
 
-### `ls-notif-0026` — reference.md:46 *(§ Niet aanbevolen technologieën)*
+## GROUNDED — minstens één bron ondersteunt de claim (8)
 
-> GraphQL Subscriptions wordt niet aanbevolen vanwege te sterke koppeling aan specifieke API-implementaties.
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Aanbevolen technologieën voor notificatieservices
+### `ls-notif-0004` — SKILL.md:57 *(§ Verplichte attributen)*
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+> Het `id` attribuut moet een unieke event-identifier zijn; de combinatie `source` + `id` moet globaal uniek zijn.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profile for CloudEvents - verplichte attributen
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > Identifies the event. Producers MUST ensure that source + id is unique for each distinct event. [...] MUST be a non-empty string MUST be unique within the scope of the producer
+  - *De bron spreekt van 'unique within the scope of the producer' en 'source + id is unique for each distinct event'. De claim zegt 'globaal uniek' wat iets sterker is, maar de combinatie source+id dekt dit af.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bespreekt CloudEvents en CNCF CloudEvents + Subscription API als technologie, maar bevat geen normtekst over het `id` attribuut of de gecombineerde uniciteit van `source` + `id`.*
 
-### `ls-notif-0028` — reference.md:25 *(§ Kernconcepten)*
+### `ls-notif-0006` — SKILL.md:59 *(§ Verplichte attributen)*
 
-> De event source wordt geïdentificeerd via OIN in URN-notatie (nld namespace).
+> Het `specversion` attribuut moet `"1.0"` zijn.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents - kernconcepten
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profile for CloudEvents - verplichte attributen
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > Compliant event producers MUST use a value of 1.0 when referring to this version of the specification.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bevat geen normtekst over het `specversion` attribuut.*
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+### `ls-notif-0008` — SKILL.md:66 *(§ Optionele attributen)*
 
-### `ls-notif-0010` — SKILL.md:69 *(§ Optionele attributen)*
+> JSON (`application/json`) wordt aanbevolen als standaardformaat voor het `datacontenttype` attribuut.
 
-> Het optionele attribuut `time` bevat het tijdstip in RFC 3339 formaat. Dit is het tijdstip van logging/registratie van het event, niet noodzakelijk het moment van de werkelijke gebeurtenis.
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NL GOV profile for CloudEvents - optionele attributen
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents - optionele attributen
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
-  > date-time = full-date "T" full-time [...] The following profile of ISO 8601 [ISO8601] dates SHOULD be used in new protocols on the Internet.
-  - *RFC 3339 definieert het datum/tijdformaat dat door het `time` attribuut gebruikt wordt. De bron bevestigt dat RFC 3339 een tijdstempelformaat definieert, maar de specifieke claim dat `time` het tijdstip van logging/registratie betreft (niet de werkelijke gebeurtenis) is een semantische beschrijving die niet in RFC 3339 voorkomt — RFC 3339 gaat uitsluitend over het formaat, niet over de betekenis van specifieke CloudEvents-attributen.*
-
-## UNGROUNDED — geen bron ondersteunt de claim (11)
-
-### `ls-notif-0005` — SKILL.md:57 *(§ Verplichte attributen)*
-
-> Het `id` attribuut is verplicht: een unieke event-identifier; bij voorkeur een persistent domeinspecifiek ID, anders een UUID (v4). De combinatie `source` + `id` moet globaal uniek zijn.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - verplichte attributen
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > JSON-format SHOULD be used (see API Design Rules ). Part of this is the intention to name JSON as the primary representation format for APIs. Because APIs play an important role in communicating events (e.g., when using the webhook pattern) the JSON format is preferred to use for payload data.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bevat geen normtekst over het `datacontenttype` attribuut of een aanbeveling voor JSON.*
 
-### `ls-notif-0006` — SKILL.md:58 *(§ Verplichte attributen)*
+### `ls-notif-0010` — SKILL.md:70 *(§ Optionele attributen)*
 
-> Het `source` attribuut is verplicht en het NL GOV profiel schrijft URN-notatie voor met de `nld` namespace. Formaat: `urn:nld:oin:<OIN>:systeem:<systeemnaam>`.
+> Het `dataref` attribuut implementeert het Claim Check Pattern voor grote payloads die niet in het event zelf passen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - verplichte attributen
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profile for CloudEvents - optionele attributen
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > A reference to a location where the event payload is stored. [...] Known as the 'Claim Check Pattern', this attribute MAY be used for a variety of purposes, including: If the Data is too large to be included in the message, the data is not present, and the consumer can retrieve it using this attribute.
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bevat geen informatie over het `dataref` attribuut of het Claim Check Pattern.*
 
-### `ls-notif-0007` — SKILL.md:59 *(§ Verplichte attributen)*
+### `ls-notif-0012` — SKILL.md:72 *(§ Optionele attributen)*
 
-> Het `specversion` attribuut is verplicht en moet de waarde `"1.0"` hebben.
+> Het `sequencetype` attribuut: indien aanwezig MOET het een niet-lege string zijn.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - verplichte attributen
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profile for CloudEvents - optionele attributen
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > sequencetype Type: String [...] Constraints: OPTIONAL If present, MUST be a non-empty string
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-
-### `ls-notif-0008` — SKILL.md:60 *(§ Verplichte attributen)*
-
-> Het `type` attribuut is verplicht en moet in Reverse Domain Name Notation worden opgegeven. Versioning gebeurt met een `v` prefix (bijv. `nl.brp.verhuizing.v2`). Types worden geregistreerd in een centraal register.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - verplichte attributen
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-
-### `ls-notif-0009` — SKILL.md:66 *(§ Optionele attributen)*
-
-> Het optionele attribuut `datacontenttype` geeft het media type van de event data payload aan; JSON (`application/json`) wordt aanbevolen als standaardformaat.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NL GOV profiel voor CloudEvents - optionele attributen
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-
-### `ls-notif-0012` — SKILL.md:71 *(§ Optionele attributen)*
-
-> `sequence` en `sequencetype` zijn NL GOV extensie-attributen (niet in de CNCF-kernspec). `sequencetype` is verplicht als `sequence` wordt gebruikt.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - optionele attributen
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bevat geen normtekst over het `sequencetype` attribuut.*
 
 ### `ls-notif-0014` — SKILL.md:104 *(§ Abonneren)*
 
@@ -260,105 +298,34 @@
 
 **Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Abonneren - aflevermodellen
 
+- **SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  > Push-model Directe notificaties bij verandering; geen onnodige polling nodig [...] Asynchroon Ontkoppeling van systemen in tijd (Niet wachten op polling-cycli of batchjobs)
+  - *De bron ondersteunt het push-model als voordelig vanwege directe notificaties en geen polling, wat aansluit bij de claim. De expliciete kwalificatie 'aanbevolen aflevermodel' of de specifieke termen 'lage latency' en 'efficiënter resourcegebruik' staan echter niet letterlijk in de bron. De strekking is wel consistent.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+  - *De bron bespreekt het publish-subscribe patroon en webhook in appendix A, maar doet geen aanbeveling over push vs. pull als aflevermodel op basis van latency of resourcegebruik.*
+
+### `ls-notif-0022` — SKILL.md:57 *(§ Verplichte attributen)*
+
+> Het `id` attribuut heeft bij voorkeur een persistent (domeinspecifiek) ID; wanneer geen persistent ID beschikbaar is, gebruik een UUID (v4).
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NL GOV profile for CloudEvents - verplichte attributen
+
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > If an ID is available that can persistently identify the event, producers MUST use that ID. [...] If no ID is available that can persistently identify the event producers SHOULD use a random ID: SHOULD use a UUID.
+  - *De bron bevestigt de voorkeur voor persistent ID en UUID als fallback. De claim noemt 'UUID (v4)' specifiek, de bron zegt alleen 'UUID' zonder versieaanduiding — klein verschil maar de strekking klopt.*
 - **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+  - *De bron bevat geen normtekst over het `id` attribuut, persistent IDs of het gebruik van UUID v4 als fallback.*
 
-### `ls-notif-0016` — SKILL.md:122 *(§ Security & Privacy)*
+### `ls-notif-0025` — SKILL.md:25 *(§ CloudEvents & Notificaties)*
 
-> Context-attributen (zoals `source`, `type`, `subject`) mogen nooit persoonsgegevens of gevoelige informatie bevatten; gebruik hiervoor de versleutelde `data`-payload.
+> Het NL GOV profiel voor CloudEvents is gebaseerd op de internationale CNCF CloudEvents specificatie v1.0.1.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Security & Privacy - CloudEvents NL GOV profiel
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profile for CloudEvents
 
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-
-### `ls-notif-0017` — SKILL.md:123 *(§ Security & Privacy)*
-
-> Wanneer de payload gevoelige gegevens bevat, moet deze versleuteld worden (end-to-end encryptie).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Security & Privacy - CloudEvents NL GOV profiel
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-
-### `ls-notif-0018` — SKILL.md:124 *(§ Security & Privacy)*
-
-> Alle communicatie tussen bronnen, notificatieservices en afnemers moet plaatsvinden over TLS (minimaal versie 1.2).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Security & Privacy - CloudEvents NL GOV profiel
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-
-### `ls-notif-0020` — reference.md:50 *(§ Authenticatie en autorisatie)*
-
-> De Notificatieservices API maakt gebruik van JWT Bearer Tokens voor authenticatie. Publicerende systemen hebben een token nodig met de scope `notifications.distribute`.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Notificatieservices API - authenticatie
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-
-## GROUNDED — minstens één bron ondersteunt de claim (3)
-
-<details>
-<summary>Klap uit voor alle GROUNDED claims</summary>
-
-### `ls-notif-0022` — reference.md:17 *(§ Type Systeem)*
-
-> Het `time` attribuut gebruikt het Timestamp type conform RFC 3339.
-
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents type systeem
-
-- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
-  > date-time = full-date "T" full-time [...] This document defines a date and time format for use in Internet protocols that is a profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
-  - *RFC 3339 definieert het Timestamp-formaat (date-time) dat gebruikt wordt in Internet protocollen. De claim dat het `time` attribuut het Timestamp type conform RFC 3339 gebruikt is consistent met de inhoud van deze bron, die precies dat formaat specificeert.*
-
-### `ls-notif-0023` — reference.md:16 *(§ Type Systeem)*
-
-> URI-reference is een URI of relatieve referentie conform RFC 3986.
-
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents type systeem
-
-- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc3986.txt](https://www.rfc-editor.org/rfc/rfc3986.txt)
-  > URI-reference = URI / relative-ref ... A URI-reference is either a URI or a relative reference. If the URI-reference's prefix does not match the syntax of a scheme followed by its colon separator, then the URI-reference is a relative reference.
-
-### `ls-notif-0027` — SKILL.md:42 *(§ Repositories)*
-
-> Het NL GOV profiel voor CloudEvents is gepubliceerd onder CC-BY-4.0 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL-GOV-profile-for-CloudEvents repository
-
-- **SUPPORTED** (high) — [https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents](https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents)
-  > License CC-BY-4.0 license
-  - *De GitHub repository pagina vermeldt expliciet 'CC-BY-4.0 license' als licentie voor het NL GOV profiel voor CloudEvents.*
-- **SUPPORTED** (high) — [https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents](https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents)
-  > This document is licensed under Creative Commons Attribution 4.0 International Public License
-- **SUPPORTED** (high) — [https://logius-standaarden.github.io/CloudEvents-NL-Guidelines](https://logius-standaarden.github.io/CloudEvents-NL-Guidelines)
-  > Dit document valt onder de volgende licentie: Creative Commons Attribution 4.0 International Public License
-  - *De bron vermeldt expliciet CC BY 4.0, wat overeenkomt met CC-BY-4.0. De claim stelt 'NL GOV profiel voor CloudEvents' maar de bron is de bijbehorende Guidelines — beide vallen onder dezelfde licentie.*
-<details><summary>5x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
-  - *Aangelevelde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
-- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
-  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/CloudEvents-NL-Guidelines](https://github.com/logius-standaarden/CloudEvents-NL-Guidelines)
-  - *De repository heeft een LICENSE-bestand en verwijst naar een 'View license' link, maar de aangeleverde brontekst bevat geen expliciete tekst over de licentiesoort (CC-BY-4.0 of anders). De licentie-inhoud is niet weergegeven in de aangeleverde tekst.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Notificatieservices](https://github.com/logius-standaarden/Notificatieservices)
-  - *De bron bevat geen informatie over licenties. De CC-BY-4.0 licentie wordt nergens vermeld in de aangeleverde tekst.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Abonneren](https://github.com/logius-standaarden/Abonneren)
-  - *De brontekst gaat over de Abonneren-repository, niet over het NL GOV profiel voor CloudEvents. Er is geen vermelding van CloudEvents of een CC-BY-4.0 licentie in deze bron.*
-</details>
+- **SUPPORTED** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  > This profile is based on CloudEvents - Version 1.0.1 as published by the Serverless Working Group of the Cloud Native Computing Foundation.
+- **PARTIALLY_SUPPORTED** (medium) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  > CNCF CloudEvents + Subscription API Gestandaardiseerde eventstructuur + abonnementsbeheer, bevordert interoperabiliteit en leveranciersonafhankelijke, cloud-native eventafhandeling.
+  - *De bron bevestigt dat CloudEvents een CNCF-standaard is en verwijst naar interoperabiliteit, maar vermeldt het specifieke versienummer v1.0.1 niet. De claim dat het NL GOV profiel hierop gebaseerd is, wordt ook niet expliciet bevestigd — de bron noemt het NL GOV-profiel alleen in de context van Solace/Digilevering.*
 
 </details>

--- a/skills/ls-notif/audit.md
+++ b/skills/ls-notif/audit.md
@@ -1,0 +1,364 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-notif — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 13 | 46% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 1 | 4% |
+| UNGROUNDED | 11 | 39% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 3 | 11% |
+
+*Geverifieerd met sonnet, 10 calls, $0.7333.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (13)
+
+### `ls-notif-0001` — SKILL.md:34 *(§ Versiemodel)*
+
+> Het NL GOV profiel voor CloudEvents heeft een vastgestelde versie (v1.1 DEF).
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v1.1') en geen inhoudelijke tekst over versies of vaststellingen.*
+
+### `ls-notif-0002` — SKILL.md:36 *(§ Versiemodel)*
+
+> Op het Forum Standaardisatie staat CloudEvents v1.0 als verplicht ('pas-toe-of-leg-uit'), goedgekeurd OBDO 25-11-2025.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / NL GOV profiel voor CloudEvents
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding ('Redirecting to v0.0.1') en is verder leeg/onbruikbaar. Geen inhoud beschikbaar om deze claim te verifiëren.*
+
+### `ls-notif-0003` — SKILL.md:36 *(§ Versiemodel)*
+
+> Versie v1.1 is de meest recente DEF van Logius voor het NL GOV profiel voor CloudEvents.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+
+### `ls-notif-0004` — SKILL.md:47 *(§ Repositories)*
+
+> Abonneren WV v0.0.1 is gepubliceerd op gitdocumentatie.logius.nl maar is nog niet vastgesteld als standaard.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Abonneren API-specificatie
+
+<details><summary>8x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents](https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents)
+  - *De bron behandelt de Abonneren API-specificatie of gitdocumentatie.logius.nl niet. De bron is de GitHub repository pagina voor NL-GOV-profile-for-CloudEvents.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents](https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents)
+  - *De bron behandelt het NL-GOV-profile-for-CloudEvents specificatie, niet de Abonneren API-specificatie of Abonneren WV v0.0.1. Er is geen vermelding van een Abonneren-standaard of versienummer in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/CloudEvents-NL-Guidelines](https://github.com/logius-standaarden/CloudEvents-NL-Guidelines)
+  - *De brontekst betreft de CloudEvents-NL-Guidelines repository op GitHub. Er is geen informatie over de Abonneren API-specificatie of Abonneren WV v0.0.1 in de aangeleverde tekst.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/CloudEvents-NL-Guidelines](https://logius-standaarden.github.io/CloudEvents-NL-Guidelines)
+  - *De brontekst behandelt de CloudEvents-NL-Guidelines handreiking, niet de Abonneren API-specificatie. Geen vermelding van 'Abonneren WV v0.0.1' of publicatiestatus daarvan.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Notificatieservices](https://github.com/logius-standaarden/Notificatieservices)
+  - *De bron vermeldt een 'Concept API-specificatie voor geautomatiseerd abonneren' maar geeft geen versienummer (v0.0.1) of publicatielocatie (gitdocumentatie.logius.nl). Er staat ook niets over de vaststelling als standaard.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Abonneren](https://github.com/logius-standaarden/Abonneren)
+  - *De brontekst betreft de GitHub-repository 'Abonneren' van Logius-standaarden. Er staat geen vermelding van een versienummer (v0.0.1), publicatie op gitdocumentatie.logius.nl, of de vaststelling als standaard.*
+</details>
+
+### `ls-notif-0011` — SKILL.md:70 *(§ Optionele attributen)*
+
+> Het optionele attribuut `dataref` verwijst naar een externe locatie waar de volledige event payload beschikbaar is en implementeert het Claim Check Pattern voor grote payloads.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents - optionele attributen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0013` — SKILL.md:76 *(§ Notificatieservices API)*
+
+> De Notificatieservices API is gespecificeerd als OpenAPI 3.x en biedt een centraal endpoint voor het publiceren van events.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Notificatieservices API
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0015` — SKILL.md:108 *(§ Abonneren)*
+
+> De huidige Notificatieservices OpenAPI-specificatie bevat alleen push-endpoints voor events (`POST /events`); er zijn geen pull/polling-endpoints voor het ophalen van events.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Notificatieservices API
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0019` — SKILL.md:308 *(§ Notificatieservice Error Responses)*
+
+> Bij een HTTP 403-respons van de notificatieservice ontbreekt de scope `notifications.distribute`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Notificatieservices API - foutafhandeling
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0021` — reference.md:21 *(§ Kernconcepten)*
+
+> CloudEvents is een CNCF standaard voor het beschrijven van events in een cloud-omgeving.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents kernstandaard
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0024` — reference.md:44 *(§ Niet aanbevolen technologieën)*
+
+> WebSub wordt niet aanbevolen vanwege verouderde status, beperkte ondersteuning en community.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Aanbevolen technologieën voor notificatieservices
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0025` — reference.md:45 *(§ Niet aanbevolen technologieën)*
+
+> MQTT wordt niet aanbevolen voor overheidsnotificaties omdat het primair gericht is op IoT-toepassingen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Aanbevolen technologieën voor notificatieservices
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0026` — reference.md:46 *(§ Niet aanbevolen technologieën)*
+
+> GraphQL Subscriptions wordt niet aanbevolen vanwege te sterke koppeling aan specifieke API-implementaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Aanbevolen technologieën voor notificatieservices
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0028` — reference.md:25 *(§ Kernconcepten)*
+
+> De event source wordt geïdentificeerd via OIN in URN-notatie (nld namespace).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents - kernconcepten
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+
+### `ls-notif-0010` — SKILL.md:69 *(§ Optionele attributen)*
+
+> Het optionele attribuut `time` bevat het tijdstip in RFC 3339 formaat. Dit is het tijdstip van logging/registratie van het event, niet noodzakelijk het moment van de werkelijke gebeurtenis.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL GOV profiel voor CloudEvents - optionele attributen
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
+  > date-time = full-date "T" full-time [...] The following profile of ISO 8601 [ISO8601] dates SHOULD be used in new protocols on the Internet.
+  - *RFC 3339 definieert het datum/tijdformaat dat door het `time` attribuut gebruikt wordt. De bron bevestigt dat RFC 3339 een tijdstempelformaat definieert, maar de specifieke claim dat `time` het tijdstip van logging/registratie betreft (niet de werkelijke gebeurtenis) is een semantische beschrijving die niet in RFC 3339 voorkomt — RFC 3339 gaat uitsluitend over het formaat, niet over de betekenis van specifieke CloudEvents-attributen.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (11)
+
+### `ls-notif-0005` — SKILL.md:57 *(§ Verplichte attributen)*
+
+> Het `id` attribuut is verplicht: een unieke event-identifier; bij voorkeur een persistent domeinspecifiek ID, anders een UUID (v4). De combinatie `source` + `id` moet globaal uniek zijn.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - verplichte attributen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0006` — SKILL.md:58 *(§ Verplichte attributen)*
+
+> Het `source` attribuut is verplicht en het NL GOV profiel schrijft URN-notatie voor met de `nld` namespace. Formaat: `urn:nld:oin:<OIN>:systeem:<systeemnaam>`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - verplichte attributen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0007` — SKILL.md:59 *(§ Verplichte attributen)*
+
+> Het `specversion` attribuut is verplicht en moet de waarde `"1.0"` hebben.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - verplichte attributen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0008` — SKILL.md:60 *(§ Verplichte attributen)*
+
+> Het `type` attribuut is verplicht en moet in Reverse Domain Name Notation worden opgegeven. Versioning gebeurt met een `v` prefix (bijv. `nl.brp.verhuizing.v2`). Types worden geregistreerd in een centraal register.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - verplichte attributen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0009` — SKILL.md:66 *(§ Optionele attributen)*
+
+> Het optionele attribuut `datacontenttype` geeft het media type van de event data payload aan; JSON (`application/json`) wordt aanbevolen als standaardformaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NL GOV profiel voor CloudEvents - optionele attributen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0012` — SKILL.md:71 *(§ Optionele attributen)*
+
+> `sequence` en `sequencetype` zijn NL GOV extensie-attributen (niet in de CNCF-kernspec). `sequencetype` is verplicht als `sequence` wordt gebruikt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NL GOV profiel voor CloudEvents - optionele attributen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0014` — SKILL.md:104 *(§ Abonneren)*
+
+> Push-model (webhook) is het aanbevolen aflevermodel vanwege lage latency en efficiënter resourcegebruik.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Abonneren - aflevermodellen
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0016` — SKILL.md:122 *(§ Security & Privacy)*
+
+> Context-attributen (zoals `source`, `type`, `subject`) mogen nooit persoonsgegevens of gevoelige informatie bevatten; gebruik hiervoor de versleutelde `data`-payload.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Security & Privacy - CloudEvents NL GOV profiel
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0017` — SKILL.md:123 *(§ Security & Privacy)*
+
+> Wanneer de payload gevoelige gegevens bevat, moet deze versleuteld worden (end-to-end encryptie).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Security & Privacy - CloudEvents NL GOV profiel
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0018` — SKILL.md:124 *(§ Security & Privacy)*
+
+> Alle communicatie tussen bronnen, notificatieservices en afnemers moet plaatsvinden over TLS (minimaal versie 1.2).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Security & Privacy - CloudEvents NL GOV profiel
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+### `ls-notif-0020` — reference.md:50 *(§ Authenticatie en autorisatie)*
+
+> De Notificatieservices API maakt gebruik van JWT Bearer Tokens voor authenticatie. Publicerende systemen hebben een token nodig met de scope `notifications.distribute`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Notificatieservices API - authenticatie
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangeleverde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (3)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-notif-0022` — reference.md:17 *(§ Type Systeem)*
+
+> Het `time` attribuut gebruikt het Timestamp type conform RFC 3339.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents type systeem
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc3339.txt](https://www.rfc-editor.org/rfc/rfc3339.txt)
+  > date-time = full-date "T" full-time [...] This document defines a date and time format for use in Internet protocols that is a profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+  - *RFC 3339 definieert het Timestamp-formaat (date-time) dat gebruikt wordt in Internet protocollen. De claim dat het `time` attribuut het Timestamp type conform RFC 3339 gebruikt is consistent met de inhoud van deze bron, die precies dat formaat specificeert.*
+
+### `ls-notif-0023` — reference.md:16 *(§ Type Systeem)*
+
+> URI-reference is een URI of relatieve referentie conform RFC 3986.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents type systeem
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc3986.txt](https://www.rfc-editor.org/rfc/rfc3986.txt)
+  > URI-reference = URI / relative-ref ... A URI-reference is either a URI or a relative reference. If the URI-reference's prefix does not match the syntax of a scheme followed by its colon separator, then the URI-reference is a relative reference.
+
+### `ls-notif-0027` — SKILL.md:42 *(§ Repositories)*
+
+> Het NL GOV profiel voor CloudEvents is gepubliceerd onder CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NL-GOV-profile-for-CloudEvents repository
+
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents](https://github.com/logius-standaarden/NL-GOV-profile-for-CloudEvents)
+  > License CC-BY-4.0 license
+  - *De GitHub repository pagina vermeldt expliciet 'CC-BY-4.0 license' als licentie voor het NL GOV profiel voor CloudEvents.*
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents](https://logius-standaarden.github.io/NL-GOV-profile-for-CloudEvents)
+  > This document is licensed under Creative Commons Attribution 4.0 International Public License
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/CloudEvents-NL-Guidelines](https://logius-standaarden.github.io/CloudEvents-NL-Guidelines)
+  > Dit document valt onder de volgende licentie: Creative Commons Attribution 4.0 International Public License
+  - *De bron vermeldt expliciet CC BY 4.0, wat overeenkomt met CC-BY-4.0. De claim stelt 'NL GOV profiel voor CloudEvents' maar de bron is de bijbehorende Guidelines — beide vallen onder dezelfde licentie.*
+<details><summary>5x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/cloudevents-nl)
+  - *Aangelevelde brontekst was leeg of onbruikbaar — alleen redirect-melding aanwezig.*
+- **NOT_FOUND** (high) — [https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren](https://gitdocumentatie.logius.nl/publicatie/notificatieservices/abonneren)
+  - *De aangeleverde brontekst bevat alleen een redirect-melding en is verder leeg/onbruikbaar.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/CloudEvents-NL-Guidelines](https://github.com/logius-standaarden/CloudEvents-NL-Guidelines)
+  - *De repository heeft een LICENSE-bestand en verwijst naar een 'View license' link, maar de aangeleverde brontekst bevat geen expliciete tekst over de licentiesoort (CC-BY-4.0 of anders). De licentie-inhoud is niet weergegeven in de aangeleverde tekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Notificatieservices](https://github.com/logius-standaarden/Notificatieservices)
+  - *De bron bevat geen informatie over licenties. De CC-BY-4.0 licentie wordt nergens vermeld in de aangeleverde tekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Abonneren](https://github.com/logius-standaarden/Abonneren)
+  - *De brontekst gaat over de Abonneren-repository, niet over het NL GOV profiel voor CloudEvents. Er is geen vermelding van CloudEvents of een CC-BY-4.0 licentie in deze bron.*
+</details>
+
+</details>

--- a/skills/ls-pub/audit.md
+++ b/skills/ls-pub/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls-pub — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,486 +7,431 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 2 | 5% |
-| CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 9 | 24% |
-| UNGROUNDED | 2 | 5% |
-| NO_SOURCE | 22 | 58% |
+| UNSUPPORTED_ASSERTION | 2 | 6% |
+| CONTRADICTED | 1 | 3% |
+| PARTIALLY_GROUNDED | 6 | 17% |
+| UNGROUNDED | 2 | 6% |
+| NO_SOURCE | 21 | 60% |
 | UNVERIFIABLE | 0 | 0% |
-| KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 3 | 8% |
+| KNOWN_DISCREPANCY | 1 | 3% |
+| GROUNDED | 2 | 6% |
 
-*Geverifieerd met sonnet, 12 calls, $0.6263.*
+*Geverifieerd met sonnet, 9 calls, $0.4697.*
 
 ## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (2)
 
-### `ls-pub-0008` — SKILL.md:50 *(§ Repositories)*
+### `ls-pub-0009` — SKILL.md:51 *(§ Repositories)*
 
-> ReSpec-template-Logius valt onder CC0-1.0 licentie.
+> De `Openbare-Consultaties` repo bevat gepubliceerde consultatieversies (CV) en heeft licentie CC-BY-4.0.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec-template-Logius repository
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden repositories
 
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *Bron status: unsupported*
 - **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
   - *Bron status: unsupported*
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
-  - *Bron status: unsupported*
-<details><summary>11x NOT_FOUND (klap uit)</summary>
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/logius-standaarden/Openbare-Consultaties/main/LICENSE](https://raw.githubusercontent.com/logius-standaarden/Openbare-Consultaties/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/logius-standaarden/Openbare-Consultaties/master/LICENSE](https://raw.githubusercontent.com/logius-standaarden/Openbare-Consultaties/master/LICENSE)
+  - *Bron status: unreachable*
+<details><summary>4x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
-  - *De bron bevat geen informatie over een ReSpec-template-Logius repository of de CC0-1.0 licentie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
+  - *De bron vermeldt de Openbare-Consultaties repo niet en geeft geen informatie over consultatieversies of bijbehorende licenties.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
-  - *De bron gaat over de ReSpec-repo, niet over ReSpec-template-Logius. CC0-1.0 wordt nergens vermeld.*
+  - *De brontekst bevat geen informatie over een 'Openbare-Consultaties' repo, consultatieversies of CC-BY-4.0 licentie.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  - *De bron gaat over de ReSpec-template repository, niet over een 'ReSpec-template-Logius' repository. CC0-1.0 wordt niet genoemd.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  - *De brontekst vermeldt wel dat de repository een LICENSE-bestand heeft ('View license'), maar de inhoud van die licentie wordt niet weergegeven. Er staat enkel 'View license' zonder de naam CC0-1.0 te noemen.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
-  - *De brontekst bevat geen informatie over ReSpec-template-Logius of CC0-1.0 licentie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
-  - *De brontekst bevat geen informatie over ReSpec-template-Logius of CC0-1.0 licentie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
-  - *De brontekst bevat geen informatie over ReSpec-template-Logius of een CC0-1.0 licentie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
-  - *De brontekst vermeldt geen CC0-1.0 licentie of ReSpec-template-Logius repository. De pagina verwijst wel naar een ReSpec-template als bronrepository ('Generated from Logius-standaarden/ReSpec-template'), maar licentie-informatie ontbreekt.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
-  - *De brontekst bevat geen informatie over ReSpec-template-Logius of CC0-1.0 licentie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
-  - *De brontekst bevat geen informatie over ReSpec-template-Logius of CC0-1.0 licentie.*
+  - *De bron behandelt de ReSpec-template repo; een 'Openbare-Consultaties' repo of consultatieversies (CV) worden niet genoemd.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De bron gaat over de ReSpec-template-Logius repo, niet over een 'Openbare-Consultaties' repo. Geen relevante informatie aanwezig.*
 </details>
 
-### `ls-pub-0034` — SKILL.md:159 *(§ Nieuw Document Starten)*
+### `ls-pub-0010` — SKILL.md:54 *(§ Repositories)*
 
-> Na push naar GitHub bouwt CI/CD automatisch HTML en PDF.
+> De `tech-radar` repo heeft MIT-licentie en is gepubliceerd op logius-standaarden.github.io/tech-radar/.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec CI/CD pipeline
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden repositories
 
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *Bron status: unsupported*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
+  - *Bron status: unsupported*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/logius-standaarden/tech-radar/main/LICENSE](https://raw.githubusercontent.com/logius-standaarden/tech-radar/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/logius-standaarden/tech-radar/master/LICENSE](https://raw.githubusercontent.com/logius-standaarden/tech-radar/master/LICENSE)
+  - *Bron status: unreachable*
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
+  - *De bron vermeldt de tech-radar repo niet en geeft geen informatie over MIT-licentie of publicatie-URL.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
+  - *De brontekst bevat geen informatie over een 'tech-radar' repo, MIT-licentie of logius-standaarden.github.io/tech-radar/.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron behandelt de ReSpec-template repo; een 'tech-radar' repo, MIT-licentie of logius-standaarden.github.io/tech-radar/ worden niet vermeld.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  - *De brontekst toont wel een .github-map wat op CI/CD wijst, maar er is geen informatie over automatisch bouwen van HTML en PDF na een push.*
+  - *De bron gaat over de ReSpec-template-Logius repo, niet over een 'tech-radar' repo. Geen informatie over MIT-licentie of publicatie-URL.*
+</details>
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (9)
+## CONTRADICTED — bron spreekt de claim expliciet tegen (1)
+
+### `ls-pub-0013` — SKILL.md:71 *(§ ReSpec Configuratie (`js/config.mjs`))*
+
+> Nieuwe documenten gebruiken ES-module formaat (`config.mjs`); oudere repos kunnen nog `config.js` bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** ReSpec configuratie
+
+- **CONTRADICTED** (medium) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  > "De configuratie files bevat informatie over de organisatie en over de status van het document. [...] De files zijn gesplitst in 2 files: een [config.js](js/config.js]"
+  - *De bron verwijst expliciet naar config.js; ES-module formaat of config.mjs wordt niet genoemd. De bron suggereert dat config.js het huidige formaat is, zonder vermelding van een nieuwer ES-module formaat. Dit is een gedeeltelijke tegenspraak: de bron kent alleen config.js, niet config.mjs.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
+  > In `js/config.mjs` moet het volgende staan: ```js import { loadRespecWithConfiguration } from "https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs"; loadRespecWithConfiguration({ ... }); ```
+  - *De bron bevestigt het ES-module formaat (config.mjs) als het huidige patroon. De claim over 'oudere repos kunnen nog config.js bevatten' wordt niet bevestigd noch tegengesproken in de bron.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (6)
 
 ### `ls-pub-0005` — SKILL.md:46 *(§ Repositories)*
 
-> De centrale publicatie-repo bevat alle vastgestelde standaarden en publiceert naar gitdocumentatie.logius.nl zonder directory listing.
+> De centrale publicatie-repo `publicatie` bevat alle vastgestelde standaarden en heeft licentie CC-BY-4.0.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie repository
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden repositories
 
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/logius-standaarden/publicatie/main/LICENSE](https://raw.githubusercontent.com/logius-standaarden/publicatie/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/logius-standaarden/publicatie/master/LICENSE](https://raw.githubusercontent.com/logius-standaarden/publicatie/master/LICENSE)
+  - *Bron status: unreachable*
 - **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
   > De inhoud van deze repository wordt dagelijks gepubliceerd naar gitdocumentatie.logius.nl/publicatie.
-  - *De bron bevestigt publicatie naar gitdocumentatie.logius.nl, maar niet specifiek naar gitdocumentatie.logius.nl zonder directory listing. Ook wordt niet expliciet gesteld dat alle vastgestelde standaarden zijn opgenomen; de repo bevat wel een uitgebreide lijst van standaarden (ADR, OAuth, Digikoppeling, FSC, etc.).*
+  - *De bron bevestigt dat de repo standaarden bevat en publiceert, maar vermeldt geen licentie (CC-BY-4.0) en spreekt niet expliciet van 'alle vastgestelde standaarden'.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *Bron status: unsupported*
 - **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
   - *Bron status: unsupported*
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
-  - *Bron status: unsupported*
-<details><summary>10x NOT_FOUND (klap uit)</summary>
+<details><summary>3x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
-  - *De bron is de GitHub-pagina van de Logius ReSpec-repo. Er staat niets over een centrale publicatie-repo, vastgestelde standaarden of gitdocumentatie.logius.nl.*
+  - *De brontekst gaat over de Logius-standaarden/respec repository. Er is geen informatie over een centrale 'publicatie' repo, vastgestelde standaarden of CC-BY-4.0 licentie.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  - *De bron beschrijft de ReSpec-template repository. Er staat niets over een centrale publicatie-repo, gitdocumentatie.logius.nl, of directory listing.*
+  - *De bron gaat over de ReSpec-template repo, niet over een centrale 'publicatie' repo. Er is geen informatie over een repo met die naam of bijbehorende licentie.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  - *De brontekst beschrijft alleen de ReSpec-template-Logius repository. Er is geen informatie over een centrale publicatie-repo of gitdocumentatie.logius.nl.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
-  - *De brontekst betreft de Openbare-Consultaties repository van Logius. Er is geen informatie over een centrale publicatie-repo die naar gitdocumentatie.logius.nl publiceert of over directory listing.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
-  - *De brontekst gaat over openbare consultaties van Logius. Er is geen informatie over een centrale publicatie-repo, gitdocumentatie.logius.nl of directory listing.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
-  - *De brontekst beschrijft de Automatisering-repo en noemt publicatie naar logius.nl, maar geeft geen informatie over directory listing of de centrale publicatie-repo met vastgestelde standaarden op gitdocumentatie.logius.nl.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
-  - *De brontekst beschrijft een test-repository voor automatisering-verificatie. Er staat niets over een centrale publicatie-repo, vastgestelde standaarden, of gitdocumentatie.logius.nl.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
-  - *De brontekst gaat over de tech-radar repository van Logius, niet over een centrale publicatie-repo of gitdocumentatie.logius.nl.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
-  - *De brontekst gaat over de Tech Radar en beschrijft de vier ringen en het doel ervan. Er is geen informatie over een centrale publicatie-repo, vastgestelde standaarden, of gitdocumentatie.logius.nl.*
+  - *De brontekst beschrijft de ReSpec-template-Logius repo, niet een centrale publicatie-repo genaamd 'publicatie'. Geen informatie over CC-BY-4.0 licentie van die repo.*
 </details>
 
 ### `ls-pub-0006` — SKILL.md:46 *(§ Repositories)*
 
-> De publicatie-repo en Publicatie-Preview-repo vallen onder CC-BY-4.0 licentie.
+> De `publicatie` repo publiceert naar gitdocumentatie.logius.nl zonder directory listing.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie repositories licenties
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden repositories
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  > License CC-BY-4.0 license
-  - *De bron bevestigt dat de ReSpec-template repo onder CC-BY-4.0 valt. Er is geen informatie over een aparte 'Publicatie-Preview-repo' of een centrale publicatie-repo met dezelfde licentie.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
+  > De inhoud van deze repository wordt dagelijks gepubliceerd naar gitdocumentatie.logius.nl/publicatie.
+  - *De bron bevestigt publicatie naar gitdocumentatie.logius.nl/publicatie, maar vermeldt niets over het al dan niet aanwezig zijn van een directory listing.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *Bron status: unsupported*
 - **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
   - *Bron status: unsupported*
 - **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
   - *Bron status: unsupported*
-<details><summary>10x NOT_FOUND (klap uit)</summary>
+<details><summary>4x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
-  - *De brontekst (GitHub README en paginalijst) bevat geen informatie over licenties van de publicatie-repo of een Publicatie-Preview-repo.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
-  - *De bron vermeldt geen licentie-informatie over publicatie-repo's. De ReSpec-repo zelf toont een eigen licentie (via 'View license'), maar CC-BY-4.0 wordt nergens genoemd.*
+  - *De brontekst bevat geen informatie over een 'publicatie' repo of gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron behandelt de ReSpec-template repo; gitdocumentatie.logius.nl of een 'publicatie' repo wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  - *De brontekst vermeldt geen licentie-informatie voor publicatie-repo of Publicatie-Preview-repo.*
+  - *De bron gaat over de ReSpec-template-Logius repo en bevat geen informatie over publicatie naar gitdocumentatie.logius.nl.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
-  - *De brontekst bevat geen informatie over licenties van publicatie-repos. De Openbare-Consultaties repo vermeldt geen CC-BY-4.0 licentie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
-  - *De brontekst bevat geen informatie over licenties van publicatie-repos.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
-  - *De brontekst bevat geen informatie over licenties van de publicatie-repo of Publicatie-Preview-repo.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
-  - *De brontekst vermeldt geen CC-BY-4.0 licentie voor publicatie-repo's. De repository heeft wel een LICENSE-bestand maar de inhoud daarvan is niet weergegeven in de aangeleverde tekst.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
-  - *De brontekst bevat geen informatie over CC-BY-4.0 licenties voor publicatie-repos.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
-  - *De brontekst bevat geen informatie over licenties van publicatie-repos.*
+  - *De brontekst beschrijft de openbare consultaties repository van Logius. Er is geen enkele vermelding van een `publicatie` repo, gitdocumentatie.logius.nl, of directory listing.*
 </details>
 
 ### `ls-pub-0007` — SKILL.md:48 *(§ Repositories)*
 
-> De Logius ReSpec-repo is een fork van de W3C ReSpec documentatie-tool en valt onder de W3C Software License.
+> De Logius `respec` repo is een fork van W3C ReSpec met aangepaste huisstijl en heeft W3C Software License.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec repository
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden repositories
 
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *Bron status: unsupported*
 - **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
-  > Logius-standaarden / respec Public forked from speced/respec
-  - *De bron bevestigt dat de Logius ReSpec-repo een fork is van speced/respec (de W3C ReSpec tool). De W3C Software License wordt echter niet expliciet vermeld in de aangeleverde brontekst; alleen 'View license' staat er zonder verdere details.*
+  > forked from speced/respec [...] ReSpec is a tool for writing W3C specifications and other technical documents.
+  - *De bron bevestigt dat de Logius respec repo een fork is van speced/respec (de W3C ReSpec). Er is echter geen expliciete vermelding van 'aangepaste huisstijl' of 'W3C Software License'. De LICENSE link is aanwezig maar de inhoud ervan is niet weergegeven in de brontekst.*
 - **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
   - *Bron status: unsupported*
 - **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
   - *Bron status: unsupported*
-<details><summary>10x NOT_FOUND (klap uit)</summary>
+<details><summary>4x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
-  - *De bron gaat over de publicatie-repository van Logius-standaarden. Er is geen informatie over een ReSpec-repo, een fork van W3C ReSpec, of de W3C Software License.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
+  - *De bron (de publicatie-repo) bevat een map 'respec' maar geeft geen informatie over de respec-repo zelf, de relatie tot W3C ReSpec, de huisstijl, of de licentie.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  - *De bron beschrijft de ReSpec-template, niet de Logius ReSpec-repo zelf. Er staat niets over een fork van W3C ReSpec of de W3C Software License.*
+  - *De bron gaat over de ReSpec-template, niet over een 'respec' repo die een fork van W3C ReSpec zou zijn. W3C Software License wordt niet vermeld.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  - *De brontekst bevat geen informatie over de Logius ReSpec-repo als fork van W3C ReSpec of over de W3C Software License.*
+  - *De bron beschrijft de ReSpec-template-Logius repo, niet de 'respec' repo als fork van W3C ReSpec. Geen informatie over W3C Software License.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
-  - *De brontekst bevat geen informatie over een ReSpec-repo, een fork van W3C ReSpec, of de W3C Software License.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
-  - *De brontekst bevat geen informatie over een Logius ReSpec-repo of de W3C ReSpec tool.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
-  - *De brontekst maakt geen melding van de Logius ReSpec-repo, een fork van W3C ReSpec, of de W3C Software License.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
-  - *De brontekst gaat over de automatisering-test repository, niet over de Logius ReSpec-repo of een fork van W3C ReSpec. Geen vermelding van W3C Software License.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
-  - *De brontekst gaat over de tech-radar repository, niet over een ReSpec-repo of W3C Software License.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
-  - *De brontekst maakt geen melding van ReSpec, W3C, of licenties.*
+  - *De brontekst bevat geen informatie over een `respec` repository, W3C ReSpec forks, huisstijl-aanpassingen, of W3C Software License.*
 </details>
 
-### `ls-pub-0012` — SKILL.md:71 *(§ ReSpec Configuratie (js/config.mjs))*
+### `ls-pub-0014` — SKILL.md:84 *(§ ReSpec Configuratie (`js/config.mjs`))*
 
-> Nieuwe ReSpec-documenten gebruiken ES-module formaat (config.mjs); oudere repos kunnen nog config.js bevatten.
+> `pubDomain` accepteert alleen de waarden: `api`, `bomos`, `dk`, `fsc`, `ftv`, `logboek` of `notificatieservices`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec configuratie
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
-  > In `js/config.mjs` moet het volgende staan: `import { loadRespecWithConfiguration } from "https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs";`
-  - *De bron bevestigt dat nieuwe documenten config.mjs gebruiken, maar zegt niets over oudere repos met config.js. Alleen het nieuwe formaat is gedocumenteerd.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  - *De bron noemt config.js als configuratiebestand maar vermeldt geen ES-module formaat, config.mjs, of onderscheid tussen nieuwe en oudere repos.*
-
-### `ls-pub-0015` — SKILL.md:85 *(§ ReSpec Configuratie (js/config.mjs))*
-
-> De ReSpec configuratieparameter shortName moet in kebab-case zijn: alleen kleine letters, gescheiden door streepjes.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius ReSpec configuratie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ReSpec configuratie pubDomain
 
 - **PARTIALLY_SUPPORTED** (high) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
-  > if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(config.shortName)) { utils.showError(`Invalid shortName. Must be in kebab-case (only lowercase letters and potentially separated by dashes), but was "${config.shortName}"`); }
-  - *De bron bevestigt kebab-case en kleine letters. De claim zegt 'gescheiden door streepjes' maar laat cijfers weg; de bron staat ook cijfers toe ([a-z0-9]+). Deels ondersteund: de kern klopt, maar cijfers in shortName worden door de claim niet vermeld.*
+  > const ACCEPTED_DOMAINS = ['api', 'bomos', 'dk', 'digimelding', 'fsc', 'ftv', 'logboek', 'notificatieservices'];
+  - *De bron bevat 'digimelding' als geaccepteerd domein, maar de claim noemt dit niet. De claim mist dus één geldige waarde.*
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  - *De bron noemt geen shortName parameter of vereisten omtrent kebab-case naamgeving.*
+  - *De bron verwijst voor configuratieopties naar de 'Logius ReSpec wiki' maar geeft geen details over pubDomain of toegestane waarden daarvoor.*
 
-### `ls-pub-0016` — SKILL.md:94 *(§ ReSpec Configuratie (js/config.mjs))*
+### `ls-pub-0016` — SKILL.md:94 *(§ ReSpec Configuratie (`js/config.mjs`))*
 
-> Oudere ReSpec-repos gebruiken config.js met 'var respecConfig = { ... }' syntax en bevatten soms extra velden zoals content, alternateFormats en postProcess.
+> Oudere repos gebruiken `config.js` met `var respecConfig = { ... }` syntax en kunnen extra velden bevatten zoals `content`, `alternateFormats` en `postProcess`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec configuratie oudere repos
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ReSpec configuratie legacy
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  > De files zijn gesplitst in 2 files: een [config.js](js/config.js] en een organisation config. [...] content: {"ch01": "informative", "mermaid": ""}, [...] Er wordt automatisch een PDF versie als alternatief format aangemaakt.
-  - *De bron bevestigt het gebruik van config.js en toont het content-veld. Het veld alternateFormats wordt indirect bevestigd via de PDF-generatie. De exacte 'var respecConfig = { ... }' syntax en het postProcess-veld worden niet expliciet vermeld.*
+  > "De files zijn gesplitst in 2 files: een [config.js](js/config.js]" en "content: {"ch01": "informative", "mermaid": ""}, Deze code voegt 2 markdown files toe" en "alternateFormats" wordt indirect aangeduid: "Er wordt automatisch een PDF versie als alternatief format aangemaakt."
+  - *De bron bevestigt config.js en het 'content' veld. 'alternateFormats' wordt niet expliciet als configuratieveld genoemd maar PDF als alternatief formaat wel. 'var respecConfig = { ... }' syntax en 'postProcess' worden niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
-  - *De bron is de organisation-config.mjs zelf en beschrijft uitsluitend het nieuwe ES-module formaat. Over oudere repos met config.js, 'var respecConfig = { ... }' syntax, of extra velden zoals content en postProcess staat niets in deze bron.*
+  - *De bron beschrijft alleen het huidige ES-module formaat (config.mjs). Informatie over legacy config.js syntax met 'var respecConfig', 'content', 'alternateFormats' als legacy-velden, of 'postProcess' als legacy-patroon staat niet in de bron.*
 
-### `ls-pub-0017` — SKILL.md:109 *(§ GitHub Actions Workflows (Automatisering repo))*
+### `ls-pub-0035` — reference.md:9 *(§ Tech Radar)*
 
-> Alle standaarden-repos roepen centrale workflows aan uit de Automatisering repo (logius-standaarden/Automatisering).
+> De Tech Radar heeft vier ringen: Adopt (bewezen, aanbevolen), Trial (actief getest), Assess (wordt onderzocht), Hold (niet aanbevolen, wordt uitgefaseerd).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius GitHub Actions workflows
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
-  > In de repository van iedere ReSpec-publicatie is een script te vinden dat de volgende handelingen uitvoert: Genereer statische HTML-pagina Controleer op WCAG-criteria Genereer PDF-bestand Publiceer naar logius.nl via Logius-standaarden/publicatie
-  - *De bron bevestigt dat standaarden-repos gebruik maken van de Automatisering-repo (logius-standaarden/Automatisering) via centrale publicatiescripts. De claim spreekt specifiek van 'centrale workflows aanroepen' (GitHub Actions), wat impliciet wordt ondersteund door de beschrijving van gedeelde scripts, maar de bron specificeert niet expliciet dat het om GitHub Actions workflows gaat die centraal worden aangeroepen.*
-- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
-  - *De brontekst beschrijft GitHub Actions workflows voor WCAG-checks en link-checks in de automatisering-test repo zelf, maar vermeldt nergens dat standaarden-repos centrale workflows aanroepen uit een Automatisering-repo. De workflows draaien 'zodra er een aanpassing gedaan wordt aan de main branch', maar er staat niets over een centrale Automatisering-repo als bron.*
-
-### `ls-pub-0031` — SKILL.md:156 *(§ Nieuw Document Starten)*
-
-> Voor een nieuw document moet ReSpec-template-Logius als basis worden gebruikt.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Logius nieuw ReSpec document starten
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  > "ReSpec template Logius - Template voor Afdeling Standaarden."
-  - *De bron bevestigt dat de repository een template is voor Logius Afdeling Standaarden, wat de claim ondersteunt dat het als basis dient voor nieuwe documenten. De normatieve SHOULD-formulering ('moet worden gebruikt') wordt niet expliciet bevestigd.*
-
-### `ls-pub-0038` — reference.md:9 *(§ Tech Radar)*
-
-> De Tech Radar gebruikt vier ringen: Adopt (bewezen, actief aanbevolen), Trial (veelbelovend, actief getest), Assess (interessant, onderzocht), Hold (niet aanbevolen voor nieuw gebruik, wordt uitgefaseerd).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius Tech Radar
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Tech Radar Logius standaarden
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
-  > ADOPT — Technologies we have high confidence in to serve our purpose [...] recommended to be widely used. TRIAL — Technologies that we have seen work with success [...] ASSESS — Technologies that are promising and have clear potential value-add [...] HOLD — Technologies not recommended to be used for new projects.
-  - *De vier ringen en hun globale betekenis worden bevestigd. De claim dat Hold-technologieën 'worden uitgefaseerd' wordt echter niet ondersteund: de bron zegt expliciet 'usually can be continued for existing projects', wat eerder 'niet aanbevolen voor nieuw gebruik maar niet actief uitgefaseerd' impliceert.*
+  > We use four rings with the following semantics: ADOPT — Technologies we have high confidence in to serve our purpose [...] TRIAL — Technologies that we have seen work with success in project work [...] ASSESS — Technologies that are promising and have clear potential value-add [...] HOLD — Technologies not recommended to be used for new projects.
+  - *De vier ringen bestaan en de beschrijvingen van Adopt, Trial en Assess kloppen grotendeels. Echter: de claim zegt Hold betekent 'wordt uitgefaseerd', maar de bron zegt expliciet 'usually can be continued for existing projects' — Hold betekent niet per se uitfasering, alleen geen nieuwe projecten. Dat is een nuanceverschil maar geen directe tegenspraak. Verder: de omschrijvingen in de bron gaan over 'Zalando production environment' (kopie van de Zalando-tekst), wat niet klopt met de Logius-context, maar dat is een bronkwestie, niet een claim-verificatiekwestie.*
 
 ## UNGROUNDED — geen bron ondersteunt de claim (2)
 
-### `ls-pub-0032` — SKILL.md:157 *(§ Nieuw Document Starten)*
+### `ls-pub-0030` — SKILL.md:157 *(§ Nieuw Document Starten)*
 
-> pubDomain accepteert alleen de waarden: api, bomos, dk, fsc, ftv, logboek of notificatieservices.
+> `pubDomain` accepteert alleen `api`, `bomos`, `dk`, `fsc`, `ftv`, `logboek` of `notificatieservices`.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius ReSpec configuratie pubDomain
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nieuw ReSpec document opstarten
 
-*Mogelijk relevant in conflicts.md (§ pubDomain `ftv` (Federatieve Toegang Verlening)): conflicts.md vermeldt dat 'ftv' in maart 2026 als nieuw pubDomain is toegevoegd, wat de lijst beïnvloedt. De volledige geaccepteerde waardelijst wordt niet beschreven; alleen 'ftv' als toevoeging en 'dk' als context worden genoemd.*
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  - *De brontekst bevat geen ReSpec-configuratieopties of toegestane waarden voor pubDomain.*
-
-### `ls-pub-0033` — SKILL.md:157 *(§ Nieuw Document Starten)*
-
-> shortName moet in kebab-case zijn: alleen kleine letters, gescheiden door streepjes (bijv. rest-api).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius ReSpec configuratie shortName
+*Mogelijk relevant in conflicts.md (§ pubDomain `ftv` (Federatieve Toegang Verlening)): conflicts.md noemt de toevoeging van pubDomain 'ftv' in maart 2026 en beschrijft de verhuizing van 'authorization-decision-log' van 'dk' naar 'ftv'. Dat raakt het onderwerp pubDomains, maar geeft geen exhaustieve lijst van toegestane waarden en bevestigt/weerspreekt de claim over de volledige set niet.*
 
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  - *De brontekst bevat geen informatie over de shortName-configuratie of kebab-case vereisten.*
+  - *De brontekst bevat geen configuratie-details over `pubDomain` of de toegestane waarden ervan. De inhoud van index.html of andere configuratiebestanden is niet weergegeven.*
 
-## NO_SOURCE — geen kandidaat-bron gevonden (22)
+### `ls-pub-0031` — SKILL.md:157 *(§ Nieuw Document Starten)*
+
+> `shortName` moet in kebab-case zijn (alleen kleine letters, gescheiden door streepjes, bijv. `rest-api`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Nieuw ReSpec document opstarten
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst bevat geen informatie over `shortName` of vereisten voor kebab-case notatie. De inhoud van configuratiebestanden is niet weergegeven.*
+
+## NO_SOURCE — geen kandidaat-bron gevonden (21)
 
 ### `ls-pub-0001` — SKILL.md:37 *(§ Versiemodel van standaarden)*
 
-> specStatus 'WV' (Werkversie/draft) publiceert naar logius-standaarden.github.io.
+> specStatus `WV` (Werkversie/draft) wordt gepubliceerd op `logius-standaarden.github.io`.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie-tooling versiemodel
 
 
 ### `ls-pub-0002` — SKILL.md:38 *(§ Versiemodel van standaarden)*
 
-> specStatus 'CV' (Consultatieversie) publiceert naar logius-standaarden.github.io/Openbare-Consultaties/ en wordt automatisch ingesteld op consultatie/* branches.
+> specStatus `CV` (Consultatieversie) wordt gepubliceerd op `logius-standaarden.github.io/Openbare-Consultaties/`, automatisch op `consultatie/*` branches.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie-tooling versiemodel
 
 
 ### `ls-pub-0003` — SKILL.md:39 *(§ Versiemodel van standaarden)*
 
-> specStatus 'VV' (Versie ter vaststelling) publiceert naar gitdocumentatie.logius.nl.
+> specStatus `VV` (Versie ter vaststelling) wordt gepubliceerd op `gitdocumentatie.logius.nl`.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie-tooling versiemodel
 
 
 ### `ls-pub-0004` — SKILL.md:40 *(§ Versiemodel van standaarden)*
 
-> specStatus 'DEF' (Vastgestelde versie) publiceert naar gitdocumentatie.logius.nl.
+> specStatus `DEF` (Vastgestelde versie) wordt gepubliceerd op `gitdocumentatie.logius.nl`.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie-tooling versiemodel
 
 
-### `ls-pub-0010` — SKILL.md:58 *(§ ReSpec Documentatie-systeem)*
+### `ls-pub-0011` — SKILL.md:58 *(§ ReSpec Documentatie-systeem)*
 
-> ReSpec genereert technische specificaties als HTML en PDF vanuit Markdown. Logius gebruikt een eigen fork met aangepaste huisstijl.
+> ReSpec genereert technische specificaties als HTML en PDF vanuit Markdown.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec documentatie-systeem
-
-
-### `ls-pub-0011` — SKILL.md:62 *(§ Hoe ReSpec werkt)*
-
-> Het ReSpec hoofdbestand index.html laadt de ReSpec-engine en verwijst via data-include naar losse Markdown-bestanden per hoofdstuk.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec documentatie-systeem
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ReSpec documentatie-systeem
 
 
-### `ls-pub-0018` — SKILL.md:113 *(§ build.yml - Document Generatie)*
+### `ls-pub-0012` — SKILL.md:62 *(§ Hoe ReSpec werkt)*
 
-> build.yml detecteert consultatie/* branches en overschrijft automatisch specStatus naar 'cv' via sed op config.mjs.
+> Het hoofdbestand `index.html` laadt de ReSpec-engine en verwijst via `data-include` naar losse Markdown-bestanden per hoofdstuk.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius build.yml workflow
-
-
-### `ls-pub-0019` — SKILL.md:114 *(§ build.yml - Document Generatie)*
-
-> HTML generatie in build.yml gebruikt het commando: npx respec --localhost --src index.html --out ~/static/index.html --haltonwarn.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius build.yml workflow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** ReSpec documentatie-systeem
 
 
-### `ls-pub-0020` — SKILL.md:115 *(§ build.yml - Document Generatie)*
+### `ls-pub-0017` — SKILL.md:113 *(§ build.yml - Document Generatie)*
 
-> PDF generatie in build.yml verloopt via Puppeteer/headless Chrome met scripts/pdf.js.
+> Op `consultatie/*` branches wordt `specStatus` automatisch overschreven naar `"cv"` via sed op `config.mjs` in de build.yml workflow.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius build.yml workflow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions build.yml workflow
 
 
-### `ls-pub-0021` — SKILL.md:118 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+### `ls-pub-0018` — SKILL.md:114 *(§ build.yml - Document Generatie)*
 
-> check.yml voert drie parallelle checks uit: WCAG check, markdown lint en link validatie.
+> HTML generatie in build.yml gebruikt `npx respec --localhost --src index.html --out ~/static/index.html --haltonwarn`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius check.yml workflow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions build.yml workflow
+
+
+### `ls-pub-0019` — SKILL.md:115 *(§ build.yml - Document Generatie)*
+
+> PDF generatie in build.yml gebeurt via Puppeteer/headless Chrome met `scripts/pdf.js`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions build.yml workflow
+
+
+### `ls-pub-0020` — SKILL.md:120 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+
+> De WCAG check in check.yml gebruikt `npx @axe-core/cli http://localhost:8080/index.html --tags wcag2aa`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions check.yml workflow
+
+
+### `ls-pub-0021` — SKILL.md:120 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+
+> axe-core dekt automatisch ~30% van WCAG-criteria; handmatige toetsing blijft nodig voor volledige WCAG-conformiteit.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WCAG accessibility check
 
 
 ### `ls-pub-0022` — SKILL.md:120 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
 
-> WCAG check in check.yml gebruikt: npx @axe-core/cli http://localhost:8080/index.html --tags wcag2aa.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius check.yml WCAG check
-
-
-### `ls-pub-0023` — SKILL.md:120 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
-
-> axe-core dekt geautomatiseerd circa 30% van de WCAG-criteria; handmatige toetsing blijft nodig.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius WCAG check met axe-core
-
-
-### `ls-pub-0024` — SKILL.md:120 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
-
 > axe-core implementeert gestandaardiseerde W3C ACT Rules; alternatieven zijn Alfa (Siteimprove) en QualWeb.
 
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius WCAG tooling
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** WCAG accessibility tooling
 
 
-### `ls-pub-0025` — SKILL.md:121 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+### `ls-pub-0023` — SKILL.md:121 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
 
-> Markdown lint in check.yml gebruikt: npx markdownlint-cli sections/.
+> Markdown lint in check.yml gebruikt `npx markdownlint-cli sections/`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius check.yml markdown lint
-
-
-### `ls-pub-0026` — SKILL.md:127 *(§ publish.yml - Publicatie)*
-
-> publish.yml publiceert bij push naar main/master naar de centrale publicatie-repo (gitdocumentatie.logius.nl).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publish.yml workflow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions check.yml workflow
 
 
-### `ls-pub-0027` — SKILL.md:128 *(§ publish.yml - Publicatie)*
+### `ls-pub-0024` — SKILL.md:127 *(§ publish.yml - Publicatie)*
 
-> publish.yml publiceert bij push naar develop naar GitHub Pages van de standaarden-repo zelf.
+> publish.yml publiceert bij push naar `main`/`master` naar de centrale `publicatie` repo (gitdocumentatie.logius.nl).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publish.yml workflow
-
-
-### `ls-pub-0028` — SKILL.md:129 *(§ publish.yml - Publicatie)*
-
-> publish.yml publiceert bij een pull request een preview naar de Publicatie-Preview repo.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publish.yml workflow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions publish.yml workflow
 
 
-### `ls-pub-0029` — SKILL.md:130 *(§ publish.yml - Publicatie)*
+### `ls-pub-0025` — SKILL.md:128 *(§ publish.yml - Publicatie)*
 
-> publish.yml publiceert bij consultatie/* branches naar de Openbare-Consultaties repo.
+> publish.yml publiceert bij push naar `develop` naar GitHub Pages van de standaarden-repo zelf.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publish.yml workflow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions publish.yml workflow
 
 
-### `ls-pub-0030` — SKILL.md:134 *(§ link-checker.yml - Gepubliceerde Links Controleren)*
+### `ls-pub-0026` — SKILL.md:129 *(§ publish.yml - Publicatie)*
+
+> publish.yml publiceert bij pull requests een preview naar de `Publicatie-Preview` repo.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions publish.yml workflow
+
+
+### `ls-pub-0027` — SKILL.md:130 *(§ publish.yml - Publicatie)*
+
+> publish.yml publiceert `consultatie/*` branches naar de `Openbare-Consultaties` repo.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions publish.yml workflow
+
+
+### `ls-pub-0028` — SKILL.md:134 *(§ link-checker.yml - Gepubliceerde Links Controleren)*
 
 > link-checker.yml controleert periodiek of de gepubliceerde versie op gitdocumentatie.logius.nl geen dode links bevat en stuurt een e-mail bij gevonden fouten.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius link-checker.yml workflow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** GitHub Actions link-checker.yml workflow
 
 
-### `ls-pub-0035` — SKILL.md:169 *(§ Checks Lokaal Draaien)*
+### `ls-pub-0032` — SKILL.md:169 *(§ Checks Lokaal Draaien)*
 
-> axe-core test automatisch circa 30% van de WCAG 2.1 AA criteria; een groene check betekent niet dat het document volledig voldoet aan EN 301 549 / WCAG 2.1 AA.
+> axe-core checkt automatisch ~30% van de WCAG-criteria; een groene check betekent NIET volledige conformiteit aan EN 301 549 / WCAG 2.1 AA.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logius WCAG check interpretatie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Lokale WCAG accessibility check
 
 
-### `ls-pub-0036` — SKILL.md:171 *(§ Checks Lokaal Draaien)*
+### `ls-pub-0033` — SKILL.md:171 *(§ Checks Lokaal Draaien)*
 
 > Handmatige toetsing op alle 55 succescriteria in WCAG 2.1 AA blijft nodig, ook na een groene axe-core check.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius WCAG handmatige toetsing
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** WCAG 2.1 AA conformiteit
 
 
-### `ls-pub-0037` — SKILL.md:196 *(§ Consultatie Branch Gedrag)*
+### `ls-pub-0034` — SKILL.md:196 *(§ Consultatie Branch Gedrag)*
 
-> Op consultatie/* branches wordt specStatus automatisch overschreven naar 'cv'; na merge naar main wordt specStatus uit js/config.mjs gebruikt.
+> Na merge van een `consultatie/*` branch naar `main` wordt `specStatus` uit `js/config.mjs` gebruikt.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius consultatie branch gedrag
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Consultatie Branch Gedrag
 
 
-## GROUNDED — minstens één bron ondersteunt de claim (3)
+## KNOWN_DISCREPANCY — gedocumenteerd in conflicts.md (1)
+
+### `ls-pub-0008` — SKILL.md:50 *(§ Repositories)*
+
+> De `ReSpec-template-Logius` repo heeft licentie CC0-1.0.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden repositories
+
+**Erkend in conflicts.md** *(§ Licentie-status GitHub-repositories)*: conflicts.md tabel 'Licentie-status GitHub-repositories' documenteert expliciet: ReSpec-template-Logius heeft GitHub LICENSE 'W3C Software License' en gepubliceerde licentie 'CC0-1.0 (ReSpec)', status 'Afwijkend'. De claim beschrijft de gepubliceerde licentie; de discrepantie met de GitHub LICENSE is gedocumenteerd.
+
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *Bron status: unsupported*
+- **CONTRADICTED** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  > CC-BY-4.0 license (vermeld in de repository header en footer van de bron: 'License CC-BY-4.0 license')
+  - *De claim stelt CC0-1.0, maar de bron toont expliciet CC-BY-4.0 als licentie van deze ReSpec-template repo. De repo heet overigens 'ReSpec-template', niet 'ReSpec-template-Logius', maar dit is de meest overeenkomstige repo in de bron.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
+  - *Bron status: unsupported*
+- **CONTRADICTED** (high) — [https://raw.githubusercontent.com/logius-standaarden/respec/main/LICENSE](https://raw.githubusercontent.com/logius-standaarden/respec/main/LICENSE)
+  > The W3C SOFTWARE NOTICE AND LICENSE (W3C) https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document ... Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work
+  - *De bron toont de W3C Software Notice and License, niet CC0-1.0. CC0-1.0 is een publiek domein-verklaring zonder voorwaarden, terwijl deze licentie expliciet attribuutverplichtingen oplegt (o.a. volledige tekst meenemen, copyright-statement bij wijzigingen). Dit is een directe tegenstelling met de claim dat de licentie CC0-1.0 is.*
+- **CONTRADICTED** (high) — [https://raw.githubusercontent.com/logius-standaarden/respec/master/LICENSE](https://raw.githubusercontent.com/logius-standaarden/respec/master/LICENSE)
+  > The W3C SOFTWARE NOTICE AND LICENSE (W3C) https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document ... Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work...
+  - *De bron toont een W3C Software and Document License, niet CC0-1.0. CC0-1.0 is een publiek domein-verklaring zonder enige voorwaarden, terwijl deze licentie expliciete naamsvermelding- en meldingsverplichtingen oplegt. De claim dat de repo CC0-1.0 heeft wordt direct tegengesproken door de aanwezigheid van deze W3C-licentie.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
+  - *De bron vermeldt de ReSpec-template-Logius repo noch enige licentie-informatie daarvoor.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
+  - *De brontekst gaat over de respec repository, niet over 'ReSpec-template-Logius'. Geen informatie over CC0-1.0 licentie.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst vermeldt dat er een LICENSE-bestand aanwezig is, maar de inhoud van dat bestand wordt niet weergegeven. 'View license' is een link maar de tekst ervan is niet opgenomen in de bron. Er kan niet worden vastgesteld of het CC0-1.0 is.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (2)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `ls-pub-0009` — SKILL.md:54 *(§ Repositories)*
+### `ls-pub-0015` — SKILL.md:85 *(§ ReSpec Configuratie (`js/config.mjs`))*
 
-> De tech-radar repository valt onder de MIT licentie.
+> `shortName` moet kebab-case zijn: alleen kleine letters, gescheiden door streepjes (bijv. `rest-api`).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius tech-radar repository
-
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
-  - *Bron status: unsupported*
-- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
-  - *Bron status: unsupported*
-- **SUPPORTED** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
-  > MIT license ... License MIT license
-  - *De brontekst vermeldt expliciet dat de tech-radar repository onder de MIT licentie valt.*
-<details><summary>10x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
-  - *De bron bevat geen informatie over een tech-radar repository of de MIT licentie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
-  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
-  - *De bron gaat over de ReSpec-repo. De tech-radar repository en MIT-licentie worden niet vermeld.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  - *De bron behandelt de ReSpec-template repository. Er is geen vermelding van een tech-radar repository of MIT licentie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
-  - *De brontekst behandelt de ReSpec-template-Logius repository, niet de tech-radar repository.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
-  - *De brontekst bevat geen informatie over een tech-radar repository of MIT licentie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
-  - *De brontekst bevat geen informatie over een tech-radar repository of MIT licentie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
-  - *De brontekst bevat geen informatie over een tech-radar repository of MIT licentie.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
-  - *De brontekst gaat niet over een tech-radar repository of MIT licentie.*
-- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
-  - *De brontekst bevat geen informatie over de licentie van de tech-radar repository zelf.*
-</details>
-
-### `ls-pub-0013` — SKILL.md:75 *(§ ReSpec Configuratie (js/config.mjs))*
-
-> De ReSpec config.mjs laadt ReSpec via https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec configuratie
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** ReSpec configuratie shortName
 
 - **SUPPORTED** (high) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
-  > import { loadRespecWithConfiguration } from "https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs";
+  > if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(config.shortName)) { utils.showError(`Invalid shortName. Must be in kebab-case (only lowercase letters and potentially separated by dashes), but was "${config.shortName}"`); }
 - **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  - *De bron vermeldt dat er een organisation config bestaat die 'centraal gepubliceerd' staat en automatisch wordt ingeladen, maar noemt geen specifieke URL zoals https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs.*
+  - *shortName of kebab-case vereisten worden niet besproken in de bron.*
 
-### `ls-pub-0014` — SKILL.md:84 *(§ ReSpec Configuratie (js/config.mjs))*
+### `ls-pub-0029` — SKILL.md:156 *(§ Nieuw Document Starten)*
 
-> De ReSpec configuratieparameter pubDomain accepteert alleen de waarden: api, bomos, dk, fsc, ftv, logboek of notificatieservices.
+> Voor een nieuw document moet `ReSpec-template-Logius` als basis worden gebruikt.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius ReSpec configuratie
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Nieuw ReSpec document opstarten
 
-- **SUPPORTED** (high) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
-  > const ACCEPTED_DOMAINS = ['api', 'bomos', 'dk', 'digimelding', 'fsc', 'ftv', 'logboek', 'notificatieservices']; if (!ACCEPTED_DOMAINS.includes(config.pubDomain)) { utils.showError(`Invalid pubDomain. Must be one of ${ACCEPTED_DOMAINS}, but was "${config.pubDomain}"`); }
-  - *De bron bevat ook 'digimelding' in de lijst, wat de claim niet noemt. De claim is dus iets onvolledig, maar niet onjuist — SUPPORTED omdat de genoemde waarden kloppen en de validatie duidelijk is.*
-- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
-  - *De bron noemt de configuratie van ReSpec documenten en verwijst naar de Logius ReSpec wiki voor meer informatie, maar bespreekt de parameter pubDomain of toegestane waarden niet.*
+- **SUPPORTED** (medium) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  > "ReSpec template Logius Template voor Afdeling Standaarden." en "Generated from Logius-standaarden/ReSpec-template"
+  - *De repo presenteert zichzelf expliciet als template voor Afdeling Standaarden en is als GitHub template repository aangemerkt ('Public template'), wat het gebruik als basis voor nieuwe documenten ondersteunt.*
 
 </details>

--- a/skills/ls-pub/audit.md
+++ b/skills/ls-pub/audit.md
@@ -1,0 +1,492 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls-pub — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 2 | 5% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 9 | 24% |
+| UNGROUNDED | 2 | 5% |
+| NO_SOURCE | 22 | 58% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 3 | 8% |
+
+*Geverifieerd met sonnet, 12 calls, $0.6263.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (2)
+
+### `ls-pub-0008` — SKILL.md:50 *(§ Repositories)*
+
+> ReSpec-template-Logius valt onder CC0-1.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec-template-Logius repository
+
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
+  - *Bron status: unsupported*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
+  - *Bron status: unsupported*
+<details><summary>11x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
+  - *De bron bevat geen informatie over een ReSpec-template-Logius repository of de CC0-1.0 licentie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
+  - *De bron gaat over de ReSpec-repo, niet over ReSpec-template-Logius. CC0-1.0 wordt nergens vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron gaat over de ReSpec-template repository, niet over een 'ReSpec-template-Logius' repository. CC0-1.0 wordt niet genoemd.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst vermeldt wel dat de repository een LICENSE-bestand heeft ('View license'), maar de inhoud van die licentie wordt niet weergegeven. Er staat enkel 'View license' zonder de naam CC0-1.0 te noemen.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
+  - *De brontekst bevat geen informatie over ReSpec-template-Logius of CC0-1.0 licentie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
+  - *De brontekst bevat geen informatie over ReSpec-template-Logius of CC0-1.0 licentie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
+  - *De brontekst bevat geen informatie over ReSpec-template-Logius of een CC0-1.0 licentie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
+  - *De brontekst vermeldt geen CC0-1.0 licentie of ReSpec-template-Logius repository. De pagina verwijst wel naar een ReSpec-template als bronrepository ('Generated from Logius-standaarden/ReSpec-template'), maar licentie-informatie ontbreekt.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
+  - *De brontekst bevat geen informatie over ReSpec-template-Logius of CC0-1.0 licentie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
+  - *De brontekst bevat geen informatie over ReSpec-template-Logius of CC0-1.0 licentie.*
+</details>
+
+### `ls-pub-0034` — SKILL.md:159 *(§ Nieuw Document Starten)*
+
+> Na push naar GitHub bouwt CI/CD automatisch HTML en PDF.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec CI/CD pipeline
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst toont wel een .github-map wat op CI/CD wijst, maar er is geen informatie over automatisch bouwen van HTML en PDF na een push.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (9)
+
+### `ls-pub-0005` — SKILL.md:46 *(§ Repositories)*
+
+> De centrale publicatie-repo bevat alle vastgestelde standaarden en publiceert naar gitdocumentatie.logius.nl zonder directory listing.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie repository
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
+  > De inhoud van deze repository wordt dagelijks gepubliceerd naar gitdocumentatie.logius.nl/publicatie.
+  - *De bron bevestigt publicatie naar gitdocumentatie.logius.nl, maar niet specifiek naar gitdocumentatie.logius.nl zonder directory listing. Ook wordt niet expliciet gesteld dat alle vastgestelde standaarden zijn opgenomen; de repo bevat wel een uitgebreide lijst van standaarden (ADR, OAuth, Digikoppeling, FSC, etc.).*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
+  - *Bron status: unsupported*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
+  - *Bron status: unsupported*
+<details><summary>10x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
+  - *De bron is de GitHub-pagina van de Logius ReSpec-repo. Er staat niets over een centrale publicatie-repo, vastgestelde standaarden of gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron beschrijft de ReSpec-template repository. Er staat niets over een centrale publicatie-repo, gitdocumentatie.logius.nl, of directory listing.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst beschrijft alleen de ReSpec-template-Logius repository. Er is geen informatie over een centrale publicatie-repo of gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
+  - *De brontekst betreft de Openbare-Consultaties repository van Logius. Er is geen informatie over een centrale publicatie-repo die naar gitdocumentatie.logius.nl publiceert of over directory listing.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
+  - *De brontekst gaat over openbare consultaties van Logius. Er is geen informatie over een centrale publicatie-repo, gitdocumentatie.logius.nl of directory listing.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
+  - *De brontekst beschrijft de Automatisering-repo en noemt publicatie naar logius.nl, maar geeft geen informatie over directory listing of de centrale publicatie-repo met vastgestelde standaarden op gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
+  - *De brontekst beschrijft een test-repository voor automatisering-verificatie. Er staat niets over een centrale publicatie-repo, vastgestelde standaarden, of gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
+  - *De brontekst gaat over de tech-radar repository van Logius, niet over een centrale publicatie-repo of gitdocumentatie.logius.nl.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
+  - *De brontekst gaat over de Tech Radar en beschrijft de vier ringen en het doel ervan. Er is geen informatie over een centrale publicatie-repo, vastgestelde standaarden, of gitdocumentatie.logius.nl.*
+</details>
+
+### `ls-pub-0006` — SKILL.md:46 *(§ Repositories)*
+
+> De publicatie-repo en Publicatie-Preview-repo vallen onder CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie repositories licenties
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  > License CC-BY-4.0 license
+  - *De bron bevestigt dat de ReSpec-template repo onder CC-BY-4.0 valt. Er is geen informatie over een aparte 'Publicatie-Preview-repo' of een centrale publicatie-repo met dezelfde licentie.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
+  - *Bron status: unsupported*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
+  - *Bron status: unsupported*
+<details><summary>10x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
+  - *De brontekst (GitHub README en paginalijst) bevat geen informatie over licenties van de publicatie-repo of een Publicatie-Preview-repo.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
+  - *De bron vermeldt geen licentie-informatie over publicatie-repo's. De ReSpec-repo zelf toont een eigen licentie (via 'View license'), maar CC-BY-4.0 wordt nergens genoemd.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst vermeldt geen licentie-informatie voor publicatie-repo of Publicatie-Preview-repo.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
+  - *De brontekst bevat geen informatie over licenties van publicatie-repos. De Openbare-Consultaties repo vermeldt geen CC-BY-4.0 licentie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
+  - *De brontekst bevat geen informatie over licenties van publicatie-repos.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
+  - *De brontekst bevat geen informatie over licenties van de publicatie-repo of Publicatie-Preview-repo.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
+  - *De brontekst vermeldt geen CC-BY-4.0 licentie voor publicatie-repo's. De repository heeft wel een LICENSE-bestand maar de inhoud daarvan is niet weergegeven in de aangeleverde tekst.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
+  - *De brontekst bevat geen informatie over CC-BY-4.0 licenties voor publicatie-repos.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
+  - *De brontekst bevat geen informatie over licenties van publicatie-repos.*
+</details>
+
+### `ls-pub-0007` — SKILL.md:48 *(§ Repositories)*
+
+> De Logius ReSpec-repo is een fork van de W3C ReSpec documentatie-tool en valt onder de W3C Software License.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec repository
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
+  > Logius-standaarden / respec Public forked from speced/respec
+  - *De bron bevestigt dat de Logius ReSpec-repo een fork is van speced/respec (de W3C ReSpec tool). De W3C Software License wordt echter niet expliciet vermeld in de aangeleverde brontekst; alleen 'View license' staat er zonder verdere details.*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
+  - *Bron status: unsupported*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
+  - *Bron status: unsupported*
+<details><summary>10x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
+  - *De bron gaat over de publicatie-repository van Logius-standaarden. Er is geen informatie over een ReSpec-repo, een fork van W3C ReSpec, of de W3C Software License.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron beschrijft de ReSpec-template, niet de Logius ReSpec-repo zelf. Er staat niets over een fork van W3C ReSpec of de W3C Software License.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst bevat geen informatie over de Logius ReSpec-repo als fork van W3C ReSpec of over de W3C Software License.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
+  - *De brontekst bevat geen informatie over een ReSpec-repo, een fork van W3C ReSpec, of de W3C Software License.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
+  - *De brontekst bevat geen informatie over een Logius ReSpec-repo of de W3C ReSpec tool.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
+  - *De brontekst maakt geen melding van de Logius ReSpec-repo, een fork van W3C ReSpec, of de W3C Software License.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
+  - *De brontekst gaat over de automatisering-test repository, niet over de Logius ReSpec-repo of een fork van W3C ReSpec. Geen vermelding van W3C Software License.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
+  - *De brontekst gaat over de tech-radar repository, niet over een ReSpec-repo of W3C Software License.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
+  - *De brontekst maakt geen melding van ReSpec, W3C, of licenties.*
+</details>
+
+### `ls-pub-0012` — SKILL.md:71 *(§ ReSpec Configuratie (js/config.mjs))*
+
+> Nieuwe ReSpec-documenten gebruiken ES-module formaat (config.mjs); oudere repos kunnen nog config.js bevatten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec configuratie
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
+  > In `js/config.mjs` moet het volgende staan: `import { loadRespecWithConfiguration } from "https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs";`
+  - *De bron bevestigt dat nieuwe documenten config.mjs gebruiken, maar zegt niets over oudere repos met config.js. Alleen het nieuwe formaat is gedocumenteerd.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron noemt config.js als configuratiebestand maar vermeldt geen ES-module formaat, config.mjs, of onderscheid tussen nieuwe en oudere repos.*
+
+### `ls-pub-0015` — SKILL.md:85 *(§ ReSpec Configuratie (js/config.mjs))*
+
+> De ReSpec configuratieparameter shortName moet in kebab-case zijn: alleen kleine letters, gescheiden door streepjes.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius ReSpec configuratie
+
+- **PARTIALLY_SUPPORTED** (high) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
+  > if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(config.shortName)) { utils.showError(`Invalid shortName. Must be in kebab-case (only lowercase letters and potentially separated by dashes), but was "${config.shortName}"`); }
+  - *De bron bevestigt kebab-case en kleine letters. De claim zegt 'gescheiden door streepjes' maar laat cijfers weg; de bron staat ook cijfers toe ([a-z0-9]+). Deels ondersteund: de kern klopt, maar cijfers in shortName worden door de claim niet vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron noemt geen shortName parameter of vereisten omtrent kebab-case naamgeving.*
+
+### `ls-pub-0016` — SKILL.md:94 *(§ ReSpec Configuratie (js/config.mjs))*
+
+> Oudere ReSpec-repos gebruiken config.js met 'var respecConfig = { ... }' syntax en bevatten soms extra velden zoals content, alternateFormats en postProcess.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec configuratie oudere repos
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  > De files zijn gesplitst in 2 files: een [config.js](js/config.js] en een organisation config. [...] content: {"ch01": "informative", "mermaid": ""}, [...] Er wordt automatisch een PDF versie als alternatief format aangemaakt.
+  - *De bron bevestigt het gebruik van config.js en toont het content-veld. Het veld alternateFormats wordt indirect bevestigd via de PDF-generatie. De exacte 'var respecConfig = { ... }' syntax en het postProcess-veld worden niet expliciet vermeld.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
+  - *De bron is de organisation-config.mjs zelf en beschrijft uitsluitend het nieuwe ES-module formaat. Over oudere repos met config.js, 'var respecConfig = { ... }' syntax, of extra velden zoals content en postProcess staat niets in deze bron.*
+
+### `ls-pub-0017` — SKILL.md:109 *(§ GitHub Actions Workflows (Automatisering repo))*
+
+> Alle standaarden-repos roepen centrale workflows aan uit de Automatisering repo (logius-standaarden/Automatisering).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius GitHub Actions workflows
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
+  > In de repository van iedere ReSpec-publicatie is een script te vinden dat de volgende handelingen uitvoert: Genereer statische HTML-pagina Controleer op WCAG-criteria Genereer PDF-bestand Publiceer naar logius.nl via Logius-standaarden/publicatie
+  - *De bron bevestigt dat standaarden-repos gebruik maken van de Automatisering-repo (logius-standaarden/Automatisering) via centrale publicatiescripts. De claim spreekt specifiek van 'centrale workflows aanroepen' (GitHub Actions), wat impliciet wordt ondersteund door de beschrijving van gedeelde scripts, maar de bron specificeert niet expliciet dat het om GitHub Actions workflows gaat die centraal worden aangeroepen.*
+- **NOT_FOUND** (medium) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
+  - *De brontekst beschrijft GitHub Actions workflows voor WCAG-checks en link-checks in de automatisering-test repo zelf, maar vermeldt nergens dat standaarden-repos centrale workflows aanroepen uit een Automatisering-repo. De workflows draaien 'zodra er een aanpassing gedaan wordt aan de main branch', maar er staat niets over een centrale Automatisering-repo als bron.*
+
+### `ls-pub-0031` — SKILL.md:156 *(§ Nieuw Document Starten)*
+
+> Voor een nieuw document moet ReSpec-template-Logius als basis worden gebruikt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Logius nieuw ReSpec document starten
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  > "ReSpec template Logius - Template voor Afdeling Standaarden."
+  - *De bron bevestigt dat de repository een template is voor Logius Afdeling Standaarden, wat de claim ondersteunt dat het als basis dient voor nieuwe documenten. De normatieve SHOULD-formulering ('moet worden gebruikt') wordt niet expliciet bevestigd.*
+
+### `ls-pub-0038` — reference.md:9 *(§ Tech Radar)*
+
+> De Tech Radar gebruikt vier ringen: Adopt (bewezen, actief aanbevolen), Trial (veelbelovend, actief getest), Assess (interessant, onderzocht), Hold (niet aanbevolen voor nieuw gebruik, wordt uitgefaseerd).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius Tech Radar
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
+  > ADOPT — Technologies we have high confidence in to serve our purpose [...] recommended to be widely used. TRIAL — Technologies that we have seen work with success [...] ASSESS — Technologies that are promising and have clear potential value-add [...] HOLD — Technologies not recommended to be used for new projects.
+  - *De vier ringen en hun globale betekenis worden bevestigd. De claim dat Hold-technologieën 'worden uitgefaseerd' wordt echter niet ondersteund: de bron zegt expliciet 'usually can be continued for existing projects', wat eerder 'niet aanbevolen voor nieuw gebruik maar niet actief uitgefaseerd' impliceert.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (2)
+
+### `ls-pub-0032` — SKILL.md:157 *(§ Nieuw Document Starten)*
+
+> pubDomain accepteert alleen de waarden: api, bomos, dk, fsc, ftv, logboek of notificatieservices.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius ReSpec configuratie pubDomain
+
+*Mogelijk relevant in conflicts.md (§ pubDomain `ftv` (Federatieve Toegang Verlening)): conflicts.md vermeldt dat 'ftv' in maart 2026 als nieuw pubDomain is toegevoegd, wat de lijst beïnvloedt. De volledige geaccepteerde waardelijst wordt niet beschreven; alleen 'ftv' als toevoeging en 'dk' als context worden genoemd.*
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst bevat geen ReSpec-configuratieopties of toegestane waarden voor pubDomain.*
+
+### `ls-pub-0033` — SKILL.md:157 *(§ Nieuw Document Starten)*
+
+> shortName moet in kebab-case zijn: alleen kleine letters, gescheiden door streepjes (bijv. rest-api).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius ReSpec configuratie shortName
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst bevat geen informatie over de shortName-configuratie of kebab-case vereisten.*
+
+## NO_SOURCE — geen kandidaat-bron gevonden (22)
+
+### `ls-pub-0001` — SKILL.md:37 *(§ Versiemodel van standaarden)*
+
+> specStatus 'WV' (Werkversie/draft) publiceert naar logius-standaarden.github.io.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie-tooling versiemodel
+
+
+### `ls-pub-0002` — SKILL.md:38 *(§ Versiemodel van standaarden)*
+
+> specStatus 'CV' (Consultatieversie) publiceert naar logius-standaarden.github.io/Openbare-Consultaties/ en wordt automatisch ingesteld op consultatie/* branches.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie-tooling versiemodel
+
+
+### `ls-pub-0003` — SKILL.md:39 *(§ Versiemodel van standaarden)*
+
+> specStatus 'VV' (Versie ter vaststelling) publiceert naar gitdocumentatie.logius.nl.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie-tooling versiemodel
+
+
+### `ls-pub-0004` — SKILL.md:40 *(§ Versiemodel van standaarden)*
+
+> specStatus 'DEF' (Vastgestelde versie) publiceert naar gitdocumentatie.logius.nl.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publicatie-tooling versiemodel
+
+
+### `ls-pub-0010` — SKILL.md:58 *(§ ReSpec Documentatie-systeem)*
+
+> ReSpec genereert technische specificaties als HTML en PDF vanuit Markdown. Logius gebruikt een eigen fork met aangepaste huisstijl.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec documentatie-systeem
+
+
+### `ls-pub-0011` — SKILL.md:62 *(§ Hoe ReSpec werkt)*
+
+> Het ReSpec hoofdbestand index.html laadt de ReSpec-engine en verwijst via data-include naar losse Markdown-bestanden per hoofdstuk.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec documentatie-systeem
+
+
+### `ls-pub-0018` — SKILL.md:113 *(§ build.yml - Document Generatie)*
+
+> build.yml detecteert consultatie/* branches en overschrijft automatisch specStatus naar 'cv' via sed op config.mjs.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius build.yml workflow
+
+
+### `ls-pub-0019` — SKILL.md:114 *(§ build.yml - Document Generatie)*
+
+> HTML generatie in build.yml gebruikt het commando: npx respec --localhost --src index.html --out ~/static/index.html --haltonwarn.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius build.yml workflow
+
+
+### `ls-pub-0020` — SKILL.md:115 *(§ build.yml - Document Generatie)*
+
+> PDF generatie in build.yml verloopt via Puppeteer/headless Chrome met scripts/pdf.js.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius build.yml workflow
+
+
+### `ls-pub-0021` — SKILL.md:118 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+
+> check.yml voert drie parallelle checks uit: WCAG check, markdown lint en link validatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius check.yml workflow
+
+
+### `ls-pub-0022` — SKILL.md:120 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+
+> WCAG check in check.yml gebruikt: npx @axe-core/cli http://localhost:8080/index.html --tags wcag2aa.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius check.yml WCAG check
+
+
+### `ls-pub-0023` — SKILL.md:120 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+
+> axe-core dekt geautomatiseerd circa 30% van de WCAG-criteria; handmatige toetsing blijft nodig.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius WCAG check met axe-core
+
+
+### `ls-pub-0024` — SKILL.md:120 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+
+> axe-core implementeert gestandaardiseerde W3C ACT Rules; alternatieven zijn Alfa (Siteimprove) en QualWeb.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius WCAG tooling
+
+
+### `ls-pub-0025` — SKILL.md:121 *(§ check.yml - Kwaliteitschecks (3 parallelle checks))*
+
+> Markdown lint in check.yml gebruikt: npx markdownlint-cli sections/.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius check.yml markdown lint
+
+
+### `ls-pub-0026` — SKILL.md:127 *(§ publish.yml - Publicatie)*
+
+> publish.yml publiceert bij push naar main/master naar de centrale publicatie-repo (gitdocumentatie.logius.nl).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publish.yml workflow
+
+
+### `ls-pub-0027` — SKILL.md:128 *(§ publish.yml - Publicatie)*
+
+> publish.yml publiceert bij push naar develop naar GitHub Pages van de standaarden-repo zelf.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publish.yml workflow
+
+
+### `ls-pub-0028` — SKILL.md:129 *(§ publish.yml - Publicatie)*
+
+> publish.yml publiceert bij een pull request een preview naar de Publicatie-Preview repo.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publish.yml workflow
+
+
+### `ls-pub-0029` — SKILL.md:130 *(§ publish.yml - Publicatie)*
+
+> publish.yml publiceert bij consultatie/* branches naar de Openbare-Consultaties repo.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius publish.yml workflow
+
+
+### `ls-pub-0030` — SKILL.md:134 *(§ link-checker.yml - Gepubliceerde Links Controleren)*
+
+> link-checker.yml controleert periodiek of de gepubliceerde versie op gitdocumentatie.logius.nl geen dode links bevat en stuurt een e-mail bij gevonden fouten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius link-checker.yml workflow
+
+
+### `ls-pub-0035` — SKILL.md:169 *(§ Checks Lokaal Draaien)*
+
+> axe-core test automatisch circa 30% van de WCAG 2.1 AA criteria; een groene check betekent niet dat het document volledig voldoet aan EN 301 549 / WCAG 2.1 AA.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Logius WCAG check interpretatie
+
+
+### `ls-pub-0036` — SKILL.md:171 *(§ Checks Lokaal Draaien)*
+
+> Handmatige toetsing op alle 55 succescriteria in WCAG 2.1 AA blijft nodig, ook na een groene axe-core check.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius WCAG handmatige toetsing
+
+
+### `ls-pub-0037` — SKILL.md:196 *(§ Consultatie Branch Gedrag)*
+
+> Op consultatie/* branches wordt specStatus automatisch overschreven naar 'cv'; na merge naar main wordt specStatus uit js/config.mjs gebruikt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius consultatie branch gedrag
+
+
+## GROUNDED — minstens één bron ondersteunt de claim (3)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-pub-0009` — SKILL.md:54 *(§ Repositories)*
+
+> De tech-radar repository valt onder de MIT licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius tech-radar repository
+
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template](https://logius-standaarden.github.io/ReSpec-template)
+  - *Bron status: unsupported*
+- **SOURCE_UNAVAILABLE** (high) — [https://logius-standaarden.github.io/ReSpec-template-Logius](https://logius-standaarden.github.io/ReSpec-template-Logius)
+  - *Bron status: unsupported*
+- **SUPPORTED** (high) — [https://github.com/logius-standaarden/tech-radar](https://github.com/logius-standaarden/tech-radar)
+  > MIT license ... License MIT license
+  - *De brontekst vermeldt expliciet dat de tech-radar repository onder de MIT licentie valt.*
+<details><summary>10x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/publicatie](https://github.com/logius-standaarden/publicatie)
+  - *De bron bevat geen informatie over een tech-radar repository of de MIT licentie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Publicatie-Preview](https://logius-standaarden.github.io/Publicatie-Preview)
+  - *aangeleverde brontekst was leeg of onbruikbaar (alleen 'Loading...')*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/respec](https://github.com/logius-standaarden/respec)
+  - *De bron gaat over de ReSpec-repo. De tech-radar repository en MIT-licentie worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron behandelt de ReSpec-template repository. Er is geen vermelding van een tech-radar repository of MIT licentie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template-Logius](https://github.com/logius-standaarden/ReSpec-template-Logius)
+  - *De brontekst behandelt de ReSpec-template-Logius repository, niet de tech-radar repository.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Openbare-Consultaties](https://github.com/logius-standaarden/Openbare-Consultaties)
+  - *De brontekst bevat geen informatie over een tech-radar repository of MIT licentie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/Openbare-Consultaties](https://logius-standaarden.github.io/Openbare-Consultaties)
+  - *De brontekst bevat geen informatie over een tech-radar repository of MIT licentie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/Automatisering](https://github.com/logius-standaarden/Automatisering)
+  - *De brontekst bevat geen informatie over een tech-radar repository of MIT licentie.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/automatisering-test](https://github.com/logius-standaarden/automatisering-test)
+  - *De brontekst gaat niet over een tech-radar repository of MIT licentie.*
+- **NOT_FOUND** (high) — [https://logius-standaarden.github.io/tech-radar](https://logius-standaarden.github.io/tech-radar)
+  - *De brontekst bevat geen informatie over de licentie van de tech-radar repository zelf.*
+</details>
+
+### `ls-pub-0013` — SKILL.md:75 *(§ ReSpec Configuratie (js/config.mjs))*
+
+> De ReSpec config.mjs laadt ReSpec via https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius ReSpec configuratie
+
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
+  > import { loadRespecWithConfiguration } from "https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs";
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron vermeldt dat er een organisation config bestaat die 'centraal gepubliceerd' staat en automatisch wordt ingeladen, maar noemt geen specifieke URL zoals https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs.*
+
+### `ls-pub-0014` — SKILL.md:84 *(§ ReSpec Configuratie (js/config.mjs))*
+
+> De ReSpec configuratieparameter pubDomain accepteert alleen de waarden: api, bomos, dk, fsc, ftv, logboek of notificatieservices.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Logius ReSpec configuratie
+
+- **SUPPORTED** (high) — [https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs](https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs)
+  > const ACCEPTED_DOMAINS = ['api', 'bomos', 'dk', 'digimelding', 'fsc', 'ftv', 'logboek', 'notificatieservices']; if (!ACCEPTED_DOMAINS.includes(config.pubDomain)) { utils.showError(`Invalid pubDomain. Must be one of ${ACCEPTED_DOMAINS}, but was "${config.pubDomain}"`); }
+  - *De bron bevat ook 'digimelding' in de lijst, wat de claim niet noemt. De claim is dus iets onvolledig, maar niet onjuist — SUPPORTED omdat de genoemde waarden kloppen en de validatie duidelijk is.*
+- **NOT_FOUND** (high) — [https://github.com/logius-standaarden/ReSpec-template](https://github.com/logius-standaarden/ReSpec-template)
+  - *De bron noemt de configuratie van ReSpec documenten en verwijst naar de Logius ReSpec wiki voor meer informatie, maar bespreekt de parameter pubDomain of toegestane waarden niet.*
+
+</details>

--- a/skills/ls/audit.md
+++ b/skills/ls/audit.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD052 MD034 MD013 -->
+<!-- markdownlint-disable MD052 MD034 MD013 MD038 -->
 # Audit ls — 2026-05-17
 
 > Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
@@ -7,16 +7,16 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 4 | 14% |
+| UNSUPPORTED_ASSERTION | 4 | 20% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 2 | 7% |
+| PARTIALLY_GROUNDED | 2 | 10% |
 | UNGROUNDED | 0 | 0% |
-| NO_SOURCE | 16 | 57% |
+| NO_SOURCE | 7 | 35% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 6 | 21% |
+| GROUNDED | 7 | 35% |
 
-*Geverifieerd met sonnet, 8 calls, $0.4827.*
+*Geverifieerd met sonnet, 8 calls, $0.4954.*
 
 ## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (4)
 
@@ -27,63 +27,63 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden organisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *De brontekst betreft de pagina van Forum Standaardisatie over open standaarden. Er is geen informatie over Logius, GitHub repositories, of github.com/logius-standaarden.*
+  - *De brontekst is de pagina van Forum Standaardisatie over open standaarden. Er staat niets over Logius GitHub repositories of het aantal daarvan.*
 
 ### `ls-0002` — SKILL.md:25 *(§ Logius Standaarden - Overzicht)*
 
-> De Logius-standaarden plugin bevat skills voor 77 van de 88 repositories, verdeeld over 9 domeinen.
+> De plugin bevat skills voor 77 van de 88 Logius repositories, verdeeld over 9 domeinen.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden plugin
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *De brontekst betreft de pagina van Forum Standaardisatie over open standaarden. Er is geen informatie over een Logius-standaarden plugin, skills, repositories of domeinen.*
+  - *De brontekst bevat geen informatie over een plugin, skills, of Logius repositories. De bron is niet relevant voor deze claim.*
 
 ### `ls-0017` — SKILL.md:42 *(§ Forum Standaardisatie Status)*
 
-> BOMOS staat niet op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie omdat het een raamwerk is, geen interoperabiliteitsstandaard.
+> BOMOS staat niet op de Forum Standaardisatie lijst omdat het een raamwerk is, geen interoperabiliteitsstandaard.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status BOMOS
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / BOMOS
 
 <details><summary>7x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *BOMOS komt in de bron niet voor.*
+  - *BOMOS wordt niet genoemd in deze bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. BOMOS wordt niet genoemd.*
+  - *BOMOS wordt niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). BOMOS wordt niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). BOMOS wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. BOMOS wordt niet behandeld.*
+  - *De bron gaat uitsluitend over het NL GOV Assurance profile for OAuth 2.0. BOMOS wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. BOMOS wordt niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. BOMOS wordt nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  - *De brontekst gaat over NLCIUS. BOMOS wordt niet vermeld.*
+  - *De bron gaat uitsluitend over NLCIUS. BOMOS wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  - *BOMOS wordt in deze bron niet behandeld.*
+  - *BOMOS wordt niet genoemd in deze bron.*
 </details>
 
 ### `ls-0018` — SKILL.md:42 *(§ Forum Standaardisatie Status)*
 
-> Logboek staat niet op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie omdat het nog in ontwikkeling is.
+> Logboek staat niet op de Forum Standaardisatie lijst omdat het in ontwikkeling is.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status Logboek
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / Logboek
 
 <details><summary>7x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *Logboek Dataverwerkingen komt in de bron niet voor.*
+  - *Logboek Dataverwerkingen wordt niet genoemd in deze bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. Logboek Dataverwerkingen wordt niet genoemd.*
+  - *Logboek Dataverwerkingen wordt niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Logboek wordt niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Logboek wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. Logboek Dataverwerkingen wordt niet behandeld.*
+  - *De bron gaat uitsluitend over het NL GOV Assurance profile for OAuth 2.0. Logboek Dataverwerkingen wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. Logboek wordt niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. Logboek wordt nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  - *De brontekst gaat over NLCIUS. Logboek Dataverwerkingen wordt niet vermeld.*
+  - *De bron gaat uitsluitend over NLCIUS. Logboek Dataverwerkingen wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  - *Logboek Dataverwerkingen wordt in deze bron niet behandeld.*
+  - *Logboek Dataverwerkingen wordt niet genoemd in deze bron.*
 </details>
 
 ## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (2)
@@ -92,167 +92,104 @@
 
 > CloudEvents v1.0 staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status CloudEvents
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / CloudEvents
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  > Verplicht ('Pas toe leg uit') [...] Volledige naam NL GOV profile for CloudEvents Versie 1.1
-  - *De bron bevestigt dat het NL GOV profile for CloudEvents verplicht ('pas toe of leg uit') is, maar de huidige versie is 1.1, niet 1.0 zoals de claim stelt. De claim dat het verplicht is klopt, maar de versieaanduiding 'v1.0' klopt niet met de bron.*
+  > Verplicht ('Pas toe leg uit') ... Volledige naam NL GOV profile for CloudEvents Versie 1.1
+  - *De bron bevestigt dat 'NL GOV profile for CloudEvents' op de 'Pas toe of leg uit'-lijst staat als verplichte standaard. De claim noemt echter 'CloudEvents v1.0', terwijl de bron versie 1.1 vermeldt. Het specificatiedocument verwijst nog naar versie 1.0, maar de huidige geregistreerde versie is 1.1.*
 <details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *CloudEvents komt in de bron niet voor.*
+  - *CloudEvents wordt niet genoemd in deze bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. CloudEvents wordt niet genoemd.*
+  - *CloudEvents wordt niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). CloudEvents wordt niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). CloudEvents wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. CloudEvents wordt niet behandeld.*
+  - *De bron gaat uitsluitend over het NL GOV Assurance profile for OAuth 2.0. CloudEvents wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  - *De brontekst gaat over NLCIUS. CloudEvents wordt niet vermeld.*
+  - *De bron gaat uitsluitend over NLCIUS. CloudEvents wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  - *CloudEvents wordt in deze bron niet behandeld.*
+  - *CloudEvents wordt niet genoemd in deze bron.*
 </details>
 
 ### `ls-0016` — SKILL.md:41 *(§ Forum Standaardisatie Status)*
 
-> Peppol BIS is aanbevolen door het Forum Standaardisatie (niet verplicht).
+> Peppol BIS staat op de 'aanbevolen'-lijst van het Forum Standaardisatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status Peppol BIS
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / Peppol BIS
 
 - **PARTIALLY_SUPPORTED** (low) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
   > Relatie met andere standaarden Peppol BIS
-  - *Peppol BIS wordt enkel genoemd als gerelateerde standaard, niet met een expliciete aanbevolen-status. De bron zegt niet dat Peppol BIS 'aanbevolen' is door Forum Standaardisatie; dat oordeel staat niet in deze brontekst.*
+  - *Peppol BIS wordt enkel genoemd als gerelateerde standaard. De bron vermeldt geen lijststatus van Peppol BIS zelf ('aanbevolen' of anderszins). Niet te verifiëren uit deze bron.*
 <details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *Peppol BIS komt in de bron niet voor.*
+  - *Peppol BIS wordt niet genoemd in deze bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. Peppol BIS wordt niet genoemd.*
+  - *Peppol BIS wordt niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Peppol BIS wordt niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Peppol BIS wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. Peppol BIS wordt niet behandeld.*
+  - *De bron gaat uitsluitend over het NL GOV Assurance profile for OAuth 2.0. Peppol BIS wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. Peppol BIS wordt niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. Peppol BIS wordt nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  - *Peppol BIS wordt in deze bron niet behandeld.*
+  - *Peppol BIS wordt niet genoemd in deze bron.*
 </details>
 
-## NO_SOURCE — geen kandidaat-bron gevonden (16)
+## NO_SOURCE — geen kandidaat-bron gevonden (7)
 
 ### `ls-0003` — SKILL.md:29 *(§ Versiemodel)*
 
-> Logius-standaarden kennen twee publicatiekanalen: een vastgestelde versie (DEF) gepubliceerd op gitdocumentatie.logius.nl, en een werkversie (draft) gepubliceerd op logius-standaarden.github.io.
+> Logius-standaarden kennen twee publicatiekanalen: vastgestelde versie (DEF) op gitdocumentatie.logius.nl en werkversie (draft) op logius-standaarden.github.io.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius versiemodel
 
 
 ### `ls-0004` — SKILL.md:34 *(§ Versiemodel)*
 
-> OAuth-NL-profiel v1.1.0 heeft een vastgestelde publicatie (DEF) bij Logius.
+> OAuth-NL-profiel v1.1.0 heeft een vastgestelde publicatie (DEF).
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth NL profiel IAM domein
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth NL profiel
 
 
 ### `ls-0005` — SKILL.md:34 *(§ Versiemodel)*
 
-> OIDC-NLGOV v1.0.1 heeft een vastgestelde publicatie (DEF) bij Logius.
+> OIDC-NLGOV v1.0.1 heeft een vastgestelde publicatie (DEF).
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OpenID Connect NL GOV IAM domein
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OpenID Connect NL GOV
 
 
 ### `ls-0006` — SKILL.md:34 *(§ Versiemodel)*
 
-> FSC fsc-core v1.1.2 heeft een vastgestelde publicatie (DEF) bij Logius.
+> fsc-core v1.1.2 heeft een vastgestelde publicatie (DEF).
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Federated Service Connectivity
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Federated Service Connectivity
 
 
 ### `ls-0007` — SKILL.md:34 *(§ Versiemodel)*
 
-> FSC fsc-logging v1.0.0 heeft een vastgestelde publicatie (DEF) bij Logius.
+> fsc-logging v1.0.0 heeft een vastgestelde publicatie (DEF).
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Federated Service Connectivity
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** FSC Federated Service Connectivity
 
 
 ### `ls-0008` — SKILL.md:34 *(§ Versiemodel)*
 
-> CloudEvents NL GOV v1.1 heeft een vastgestelde publicatie (DEF) bij Logius.
+> CloudEvents NL GOV v1.1 heeft een vastgestelde publicatie (DEF).
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents Notificaties domein
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents & Notificaties
 
 
 ### `ls-0009` — SKILL.md:34 *(§ Versiemodel)*
 
 > Logboek en E-Gov domeinen publiceren vooralsnog alleen werkversies (geen vastgestelde DEF versie).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek en E-Gov domeinen
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen, E-Government Services
 
 
-### `ls-0020` — SKILL.md:50 *(§ Domeinen)*
-
-> Het Digikoppeling domein omvat 17 repositories en behandelt beveiligde gegevensuitwisseling (REST, ebMS2, WUS, GB) en OIN.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling domein
-
-
-### `ls-0021` — SKILL.md:51 *(§ Domeinen)*
-
-> Het API Design Rules domein omvat 9 repositories en behandelt de NL GOV API-standaard, Spectral linter en referentie-implementaties.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules domein
-
-
-### `ls-0022` — SKILL.md:52 *(§ Domeinen)*
-
-> Het IAM domein omvat 8 repositories en behandelt OAuth 2.0 NL, OpenID Connect, AuthZEN en SAML.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Identity & Access Management domein
-
-
-### `ls-0023` — SKILL.md:53 *(§ Domeinen)*
-
-> Het FSC domein omvat 7 repositories en behandelt een federatief netwerk met inway/outway, contracten en service directory.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Federated Service Connectivity domein
-
-
-### `ls-0024` — SKILL.md:54 *(§ Domeinen)*
-
-> Het Logboek Dataverwerkingen domein omvat 8 repositories en behandelt AVG-logging, OpenTelemetry en W3C Trace Context.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen domein
-
-
-### `ls-0025` — SKILL.md:55 *(§ Domeinen)*
-
-> Het CloudEvents & Notificaties domein omvat 4 repositories en behandelt het NL GOV CloudEvents profiel en pub/sub.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents en Notificaties domein
-
-
-### `ls-0026` — SKILL.md:56 *(§ Domeinen)*
-
-> Het BOMOS Governance domein omvat 10 repositories en behandelt het Beheer- en Ontwikkelmodel voor Open Standaarden.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Governance domein
-
-
-### `ls-0027` — SKILL.md:57 *(§ Domeinen)*
-
-> Het E-Government Services domein omvat 6 repositories en behandelt Terugmelding, Digimelding en e-procurement.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Government Services domein
-
-
-### `ls-0028` — SKILL.md:58 *(§ Domeinen)*
-
-> Het Publicatie & Tooling domein omvat 9 repositories en behandelt ReSpec, GitHub Actions, WCAG checks en markdown lint.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Publicatie en Tooling domein
-
-
-## GROUNDED — minstens één bron ondersteunt de claim (6)
+## GROUNDED — minstens één bron ondersteunt de claim (7)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
@@ -261,150 +198,176 @@
 
 > API Design Rules staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status API Design Rules
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / API Design Rules
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
   > Lijst status Verplicht ('Pas toe leg uit') [...] De standaard NLGov REST API Design Rules moet worden toegepast bij het aanbieden van REST API's ten behoeve van het ontsluiten van overheidsinformatie en/of functionaliteit.
 <details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. API Design Rules wordt niet genoemd.*
+  - *De bron gaat uitsluitend over Digikoppeling. API Design Rules worden niet vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). API Design Rules wordt niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). API Design Rules wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. API Design Rules wordt niet behandeld.*
+  - *De bron gaat uitsluitend over het NL GOV Assurance profile for OAuth 2.0. API Design Rules wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. API Design Rules wordt niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. API Design Rules wordt nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  - *De brontekst gaat over NLCIUS, niet over API Design Rules. API Design Rules wordt niet vermeld.*
+  - *De bron gaat uitsluitend over NLCIUS. API Design Rules wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  - *De bron gaat uitsluitend over het NL Gov Assurance Profile for OAuth 2.0 versie 1.1. API Design Rules wordt niet genoemd.*
+  - *De bron gaat uitsluitend over het intakeadvies voor OAuth NL profiel v1.1. API Design Rules wordt niet genoemd.*
 </details>
 
 ### `ls-0011` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
 
-> Digikoppeling staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard, inclusief FSC sinds 5 november 2025.
+> Digikoppeling (inclusief FSC sinds 5 november 2025) staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status Digikoppeling en FSC
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / Digikoppeling / FSC
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
   > Op 5 november 2025 heeft het Forum Standaardisatie op basis van aanvullend onderzoek ingestemd met het toekennen van de status 'Pas toe of leg uit' onder Uitstekend beheer aan de nieuwe versie van Digikoppeling (release 30/1/2025), met daarin opgenomen de standaard Federated Service Connectivity (FSC) in het Digikoppeling REST-API profiel.
 <details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *De bron gaat uitsluitend over REST API Design Rules. Digikoppeling wordt wel genoemd als gerelateerde standaard, maar er staat niets over de lijststatus van Digikoppeling of FSC.*
+  - *De bron gaat over REST API Design Rules, niet over Digikoppeling of FSC. Digikoppeling wordt wel genoemd als gerelateerde standaard, maar er staat niets over de lijststatus of FSC.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Digikoppeling en FSC worden niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Digikoppeling en FSC worden niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. Digikoppeling en FSC worden niet behandeld.*
+  - *De bron gaat uitsluitend over het NL GOV Assurance profile for OAuth 2.0. Digikoppeling en FSC worden niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. Digikoppeling en FSC worden niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. Digikoppeling en FSC worden nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  - *De brontekst gaat over NLCIUS. Digikoppeling en FSC worden niet vermeld.*
+  - *De bron gaat uitsluitend over NLCIUS. Digikoppeling en FSC worden niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  - *Digikoppeling en FSC worden in deze bron niet behandeld.*
+  - *Digikoppeling en FSC worden niet besproken in deze bron.*
 </details>
 
 ### `ls-0012` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
 
 > Authenticatie-standaarden (OIDC+SAML) staan op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status authenticatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / IAM
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  > Verplicht ('Pas toe leg uit') [...] Authenticatie-standaarden (OpenID.NLGov en SAML) moeten worden toegepast door aanbieders van identitydiensten [...] Datum van besluit 21-09-2023
-  - *De bron bevestigt expliciet de 'Verplicht (Pas toe of leg uit)'-status voor Authenticatie-standaarden (OpenID.NLGov en SAML).*
+  > Verplicht ('Pas toe leg uit') [...] Authenticatie-standaarden (OpenID.NLGov en SAML) moeten worden toegepast door aanbieders van identitydiensten [...] De 'Pas toe of leg uit'-verplichting van de Authenticatie-standaarden bestaat eruit dat aanbieders van identitydiensten [...] zowel OpenID.NLGov [...] als SAML dienen te ondersteunen.
+  - *De bron bevestigt expliciet de 'Verplicht (Pas toe of leg uit)'-status voor de combinatie OIDC (via OpenID.NLGov) en SAML.*
 <details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *De bron behandelt de lijststatus van OIDC/SAML niet.*
+  - *De bron behandelt REST API Design Rules. OIDC en SAML worden niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. OIDC en SAML worden niet genoemd.*
+  - *De bron behandelt Digikoppeling; OIDC en SAML worden niet vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. OIDC en SAML worden niet behandeld.*
+  - *De bron gaat uitsluitend over het NL GOV Assurance profile for OAuth 2.0. OIDC en SAML worden niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. Authenticatie-standaarden (OIDC+SAML) worden niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. OIDC en SAML worden nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  - *De brontekst gaat over NLCIUS. OIDC en SAML worden niet vermeld.*
+  - *De bron gaat uitsluitend over NLCIUS. OIDC en SAML worden niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  - *OIDC en SAML als 'pas-toe-of-leg-uit'-standaarden worden niet besproken. SAML wordt slechts terloops genoemd in het praktijkvoorbeeld.*
+  - *OIDC en SAML als verplichte standaarden worden niet besproken. SAML wordt slechts kort terloops vermeld in het praktijkvoorbeeld, niet als listingsstatus.*
 </details>
 
 ### `ls-0013` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
 
 > OAuth-NL-profiel v1.0 staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status OAuth NL profiel
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / OAuth NL profiel
 
+- **PARTIALLY_SUPPORTED** (low) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  > Relatie met andere standaarden [...] NL GOV Assurance profile for OAuth 2.0
+  - *De bron noemt 'NL GOV Assurance profile for OAuth 2.0' alleen als gerelateerde standaard, zonder informatie over lijststatus of versienummer. De claim over 'verplichte standaard op pas-toe-of-leg-uit' en 'v1.0' kan niet worden beoordeeld op basis van deze bron.*
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  > Verplicht ('Pas toe leg uit') [...] NL GOV Assurance Profile for OAuth 2.0 moet worden toegepast bij applicaties waarbij gebruikers of 'resource owners' impliciet of expliciet toestemming geven aan een dienst van een derde om namens deze toegang te krijgen tot gegevens via een REST API
-  - *De bron bevestigt dat de standaard de status 'Verplicht (Pas toe of leg uit)' heeft. De versie die op de lijst staat is aangeduid als '15 juli 2019' / 'v1.0', wat overeenkomt met de claim over v1.0.*
+  > Datum van besluit: 09-07-2020 [...] Verplicht ('Pas toe leg uit') [...] NL GOV Assurance Profile for OAuth 2.0 moet worden toegepast bij applicaties waarbij gebruikers of 'resource owners' impliciet of expliciet toestemming geven aan een dienst van een derde om namens deze toegang te krijgen tot gegevens via een REST API
+  - *De bron bevestigt dat NL GOV Assurance profile for OAuth 2.0 (v1.0, 15 juli 2019) op de 'Pas toe of leg uit'-lijst staat als verplichte standaard, besluit 09-07-2020.*
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
   > NL Gov Assurance profile for OAuth 2.0 is 15 juli 2019 opgenomen op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie.
-  - *De bron bevestigt dat (de voorgaande versie, v1.0) op de 'Pas toe of leg uit'-lijst staat. De formulering 'voorgaande versie staat dan ook op de Pas toe of leg uit-lijst' en de expliciete opnamedatum 15 juli 2019 ondersteunen de claim.*
-<details><summary>5x NOT_FOUND (klap uit)</summary>
+  - *De bron bevestigt expliciet dat v1.0 (de voorgaande versie) op de 'Pas toe of leg uit'-lijst staat.*
+<details><summary>4x NOT_FOUND (klap uit)</summary>
 
-- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *De bron noemt 'NL GOV Assurance profile for OAuth 2.0' als gerelateerde standaard, maar geeft geen informatie over de lijststatus of versie.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. OAuth-NL-profiel wordt niet genoemd.*
+  - *OAuth-NL-profiel komt niet voor in de bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). OAuth-NL-profiel wordt niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). OAuth-NL-profiel wordt niet als afzonderlijke standaard genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. OAuth-NL-profiel wordt niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. OAuth-NL-profiel wordt nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  - *De brontekst gaat over NLCIUS. OAuth-NL-profiel wordt niet vermeld.*
+  - *De bron gaat uitsluitend over NLCIUS. OAuth-NL-profiel wordt niet genoemd.*
 </details>
 
 ### `ls-0015` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
 
 > NLCIUS staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status NLCIUS
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / NLCIUS
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  > Lijst status [...] Verplicht ('Pas toe leg uit')
-  - *De bron vermeldt expliciet de lijststatus 'Verplicht (Pas toe of leg uit)' voor NLCIUS.*
+  > Verplicht ('Pas toe leg uit') [...] NLCIUS moet worden toegepast op de verzending van elektronische facturen door organisaties die deelnemen aan het economisch verkeer in Nederland
 <details><summary>6x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *NLCIUS komt in de bron niet voor.*
+  - *NLCIUS wordt niet genoemd in deze bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. NLCIUS wordt niet genoemd.*
+  - *NLCIUS wordt niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). NLCIUS wordt niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). NLCIUS wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. NLCIUS wordt niet behandeld.*
+  - *De bron gaat uitsluitend over het NL GOV Assurance profile for OAuth 2.0. NLCIUS wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. NLCIUS wordt niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. NLCIUS wordt nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  - *NLCIUS wordt in deze bron niet behandeld.*
+  - *NLCIUS wordt niet genoemd in deze bron.*
 </details>
 
 ### `ls-0019` — SKILL.md:44 *(§ Forum Standaardisatie Status)*
 
-> OAuth-NL-profiel v1.1 is vastgesteld door Logius (DEF), maar staat bij het Forum Standaardisatie nog 'in procedure' (intake goedgekeurd 24-09-2025); v1.0 is de verplichte versie.
+> OAuth-NL-profiel v1.1 is vastgesteld door Logius (DEF), maar op het Forum Standaardisatie nog 'in procedure'; de intake is goedgekeurd op 24-09-2025.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth NL profiel Forum Standaardisatie procedure
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / OAuth NL profiel v1.1
 
 - **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
-  > 24-09-2025: Het Forum Standaardisatie heeft op 24 september 2025 ingestemd met het intakeadvies NL GOV Assurance profile for OAuth 2.0 v1.1 om versie 1.1 van de standaard in procedure te nemen voor plaatsing op de 'Pas toe of leg uit'-lijst. Een volledig expertonderzoek is aangewezen om de standaard te toetsen aan de criteria voor opname op de lijst.
-  - *De bron bevestigt dat v1.1 nog 'in procedure' is (intake goedgekeurd 24-09-2025) en dat v1.0 de huidige verplichte versie is op de lijst (Datum van besluit: 09-07-2020, Versie: 15 juli 2019). Het deel over Logius-vaststelling (DEF) staat niet in deze bron, maar wordt ook niet tegengesproken.*
-- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
-  > Op 20 december 2024 heeft Logius het NL Gov Assurance profile for OAuth 2.0 versie 1.1 aangemeld voor plaatsing op de 'Pas toe of leg uit' lijst. [...] De Stuurgroep Open Standaarden adviseert het Forum Standaardisatie om de versie 1.1 van de standaard NL Gov Assurance profile for OAuth 2.0 in procedure te nemen. [...] De voorgaande versie staat dan ook op de 'Pas toe of leg uit'-lijst.
-  - *De bron is het intakeadvies van 29 augustus 2025 voor vergadering 24 september 2025, wat bevestigt dat v1.1 in procedure wordt genomen (intake goedgekeurd). De bron bevestigt ook dat v1.0 op de 'Pas toe of leg uit'-lijst staat. De claim dat v1.1 bij Logius als DEF vastgesteld is wordt niet expliciet bevestigd, maar de rest van de claim wordt volledig onderbouwd.*
+  > 24-09-2025: Het Forum Standaardisatie heeft op 24 september 2025 ingestemd met het intakeadvies NL GOV Assurance profile for OAuth 2.0 v1.1 om versie 1.1 van de standaard in procedure te nemen voor plaatsing op de 'Pas toe of leg uit'-lijst. Een volledig expertonderzoek is aangewezen om de standaard te toetsen aan de criteria voor opname op de lijst. Het onderzoek hiervoor loopt momenteel.
+  - *De bron bevestigt dat v1.1 'in procedure' is na intake-goedkeuring op 24-09-2025. De claim over Logius DEF-vaststelling wordt niet expliciet bevestigd in deze bron, maar het Forum-deel klopt volledig.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  > Op 20 december 2024 heeft Logius het NL Gov Assurance profile for OAuth 2.0 versie 1.1 aangemeld voor plaatsing op de 'Pas toe of leg uit' lijst. [...] Vergadering: Forum Standaardisatie woensdag 24 september 2025 [...] De Stuurgroep Open Standaarden adviseert het Forum Standaardisatie om de versie 1.1 van de standaard NL Gov Assurance profile for OAuth 2.0 in procedure te nemen.
+  - *De bron bevestigt dat de intake is geagendeerd voor 24 september 2025 en dat de Stuurgroep adviseert de standaard in procedure te nemen. De bron bevestigt niet dat de intake op die datum ook daadwerkelijk is goedgekeurd (het document is gedateerd 29 augustus 2025, dus vóór de vergadering). Of Logius de standaard intern als DEF heeft vastgesteld wordt niet vermeld.*
 <details><summary>5x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
-  - *De bron bevat geen informatie over OAuth-NL-profiel v1.1, de procedure bij Forum Standaardisatie, of de intake van 24-09-2025.*
+  - *OAuth-NL-profiel v1.1 en de intakeprocedure bij Forum Standaardisatie worden niet behandeld in deze bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
-  - *De bron gaat uitsluitend over Digikoppeling. OAuth-NL-profiel v1.1 en de procedure daarvoor worden niet genoemd.*
+  - *OAuth-NL-profiel v1.1 en intake-procedures worden niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
-  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). OAuth-NL-profiel v1.1 en de procedure daarvoor worden niet vermeld.*
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). OAuth-NL-profiel v1.1 wordt niet genoemd.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
-  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. OAuth-NL-profiel v1.1 en de procedure daarvoor worden niet vermeld.*
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. OAuth-NL-profiel v1.1 en de procedure daarvoor worden nergens vermeld.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
-  - *De brontekst gaat over NLCIUS. OAuth-NL-profiel v1.1 en de intakeprocedure bij Forum Standaardisatie worden niet vermeld.*
+  - *De bron gaat uitsluitend over NLCIUS. OAuth-NL-profiel v1.1 wordt niet genoemd.*
+</details>
+
+### `ls-0020` — SKILL.md:44 *(§ Forum Standaardisatie Status)*
+
+> Op het Forum Standaardisatie is OAuth-NL-profiel v1.0 de verplichte versie (niet v1.1).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Forum Standaardisatie / OAuth NL profiel
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  > Versie 15 juli 2019 [...] Specificatiedocument NL GOV Assurance profile for OAuth 2.0 v1.0 [...] Verplicht ('Pas toe leg uit') [...] Datum van besluit 09-07-2020
+  - *De bron toont dat de huidige verplichte versie op de lijst v1.0 is (15 juli 2019), terwijl v1.1 nog 'in procedure' is. Dit ondersteunt de claim dat v1.0 de verplichte versie is, niet v1.1.*
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  > NL Gov Assurance profile for OAuth 2.0 is 15 juli 2019 opgenomen op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie. [...] De voorgaande versie staat dan ook op de 'Pas toe of leg uit'-lijst.
+  - *De bron maakt duidelijk dat v1.0 de huidige verplichte versie is op de lijst, en v1.1 nog 'in procedure' is voor opname.*
+<details><summary>5x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *De bron gaat over REST API Design Rules. Er staat niets over welke versie van het OAuth NL profiel verplicht is.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *OAuth-NL-profiel (geen enkele versie) wordt vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). OAuth-NL-profiel (v1.0 noch v1.1) wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De bron gaat uitsluitend over 'NL GOV profile for CloudEvents'. OAuth-NL-profiel (v1.0 noch v1.1) wordt nergens vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De bron gaat uitsluitend over NLCIUS. OAuth-NL-profiel wordt niet genoemd.*
 </details>
 
 </details>

--- a/skills/ls/audit.md
+++ b/skills/ls/audit.md
@@ -1,0 +1,410 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit ls — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 4 | 14% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 2 | 7% |
+| UNGROUNDED | 0 | 0% |
+| NO_SOURCE | 16 | 57% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 6 | 21% |
+
+*Geverifieerd met sonnet, 8 calls, $0.4827.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (4)
+
+### `ls-0001` — SKILL.md:25 *(§ Logius Standaarden - Overzicht)*
+
+> Logius beheert 88 GitHub repositories onder github.com/logius-standaarden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden organisatie
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst betreft de pagina van Forum Standaardisatie over open standaarden. Er is geen informatie over Logius, GitHub repositories, of github.com/logius-standaarden.*
+
+### `ls-0002` — SKILL.md:25 *(§ Logius Standaarden - Overzicht)*
+
+> De Logius-standaarden plugin bevat skills voor 77 van de 88 repositories, verdeeld over 9 domeinen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius standaarden plugin
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst betreft de pagina van Forum Standaardisatie over open standaarden. Er is geen informatie over een Logius-standaarden plugin, skills, repositories of domeinen.*
+
+### `ls-0017` — SKILL.md:42 *(§ Forum Standaardisatie Status)*
+
+> BOMOS staat niet op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie omdat het een raamwerk is, geen interoperabiliteitsstandaard.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status BOMOS
+
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *BOMOS komt in de bron niet voor.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. BOMOS wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). BOMOS wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. BOMOS wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. BOMOS wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De brontekst gaat over NLCIUS. BOMOS wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *BOMOS wordt in deze bron niet behandeld.*
+</details>
+
+### `ls-0018` — SKILL.md:42 *(§ Forum Standaardisatie Status)*
+
+> Logboek staat niet op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie omdat het nog in ontwikkeling is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status Logboek
+
+<details><summary>7x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *Logboek Dataverwerkingen komt in de bron niet voor.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. Logboek Dataverwerkingen wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Logboek wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. Logboek Dataverwerkingen wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. Logboek wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De brontekst gaat over NLCIUS. Logboek Dataverwerkingen wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *Logboek Dataverwerkingen wordt in deze bron niet behandeld.*
+</details>
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (2)
+
+### `ls-0014` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
+
+> CloudEvents v1.0 staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status CloudEvents
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  > Verplicht ('Pas toe leg uit') [...] Volledige naam NL GOV profile for CloudEvents Versie 1.1
+  - *De bron bevestigt dat het NL GOV profile for CloudEvents verplicht ('pas toe of leg uit') is, maar de huidige versie is 1.1, niet 1.0 zoals de claim stelt. De claim dat het verplicht is klopt, maar de versieaanduiding 'v1.0' klopt niet met de bron.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *CloudEvents komt in de bron niet voor.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. CloudEvents wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). CloudEvents wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. CloudEvents wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De brontekst gaat over NLCIUS. CloudEvents wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *CloudEvents wordt in deze bron niet behandeld.*
+</details>
+
+### `ls-0016` — SKILL.md:41 *(§ Forum Standaardisatie Status)*
+
+> Peppol BIS is aanbevolen door het Forum Standaardisatie (niet verplicht).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status Peppol BIS
+
+- **PARTIALLY_SUPPORTED** (low) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  > Relatie met andere standaarden Peppol BIS
+  - *Peppol BIS wordt enkel genoemd als gerelateerde standaard, niet met een expliciete aanbevolen-status. De bron zegt niet dat Peppol BIS 'aanbevolen' is door Forum Standaardisatie; dat oordeel staat niet in deze brontekst.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *Peppol BIS komt in de bron niet voor.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. Peppol BIS wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Peppol BIS wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. Peppol BIS wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. Peppol BIS wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *Peppol BIS wordt in deze bron niet behandeld.*
+</details>
+
+## NO_SOURCE — geen kandidaat-bron gevonden (16)
+
+### `ls-0003` — SKILL.md:29 *(§ Versiemodel)*
+
+> Logius-standaarden kennen twee publicatiekanalen: een vastgestelde versie (DEF) gepubliceerd op gitdocumentatie.logius.nl, en een werkversie (draft) gepubliceerd op logius-standaarden.github.io.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logius versiemodel
+
+
+### `ls-0004` — SKILL.md:34 *(§ Versiemodel)*
+
+> OAuth-NL-profiel v1.1.0 heeft een vastgestelde publicatie (DEF) bij Logius.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth NL profiel IAM domein
+
+
+### `ls-0005` — SKILL.md:34 *(§ Versiemodel)*
+
+> OIDC-NLGOV v1.0.1 heeft een vastgestelde publicatie (DEF) bij Logius.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OpenID Connect NL GOV IAM domein
+
+
+### `ls-0006` — SKILL.md:34 *(§ Versiemodel)*
+
+> FSC fsc-core v1.1.2 heeft een vastgestelde publicatie (DEF) bij Logius.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Federated Service Connectivity
+
+
+### `ls-0007` — SKILL.md:34 *(§ Versiemodel)*
+
+> FSC fsc-logging v1.0.0 heeft een vastgestelde publicatie (DEF) bij Logius.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Federated Service Connectivity
+
+
+### `ls-0008` — SKILL.md:34 *(§ Versiemodel)*
+
+> CloudEvents NL GOV v1.1 heeft een vastgestelde publicatie (DEF) bij Logius.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents Notificaties domein
+
+
+### `ls-0009` — SKILL.md:34 *(§ Versiemodel)*
+
+> Logboek en E-Gov domeinen publiceren vooralsnog alleen werkversies (geen vastgestelde DEF versie).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek en E-Gov domeinen
+
+
+### `ls-0020` — SKILL.md:50 *(§ Domeinen)*
+
+> Het Digikoppeling domein omvat 17 repositories en behandelt beveiligde gegevensuitwisseling (REST, ebMS2, WUS, GB) en OIN.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Digikoppeling domein
+
+
+### `ls-0021` — SKILL.md:51 *(§ Domeinen)*
+
+> Het API Design Rules domein omvat 9 repositories en behandelt de NL GOV API-standaard, Spectral linter en referentie-implementaties.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** API Design Rules domein
+
+
+### `ls-0022` — SKILL.md:52 *(§ Domeinen)*
+
+> Het IAM domein omvat 8 repositories en behandelt OAuth 2.0 NL, OpenID Connect, AuthZEN en SAML.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Identity & Access Management domein
+
+
+### `ls-0023` — SKILL.md:53 *(§ Domeinen)*
+
+> Het FSC domein omvat 7 repositories en behandelt een federatief netwerk met inway/outway, contracten en service directory.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Federated Service Connectivity domein
+
+
+### `ls-0024` — SKILL.md:54 *(§ Domeinen)*
+
+> Het Logboek Dataverwerkingen domein omvat 8 repositories en behandelt AVG-logging, OpenTelemetry en W3C Trace Context.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Logboek Dataverwerkingen domein
+
+
+### `ls-0025` — SKILL.md:55 *(§ Domeinen)*
+
+> Het CloudEvents & Notificaties domein omvat 4 repositories en behandelt het NL GOV CloudEvents profiel en pub/sub.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** CloudEvents en Notificaties domein
+
+
+### `ls-0026` — SKILL.md:56 *(§ Domeinen)*
+
+> Het BOMOS Governance domein omvat 10 repositories en behandelt het Beheer- en Ontwikkelmodel voor Open Standaarden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** BOMOS Governance domein
+
+
+### `ls-0027` — SKILL.md:57 *(§ Domeinen)*
+
+> Het E-Government Services domein omvat 6 repositories en behandelt Terugmelding, Digimelding en e-procurement.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** E-Government Services domein
+
+
+### `ls-0028` — SKILL.md:58 *(§ Domeinen)*
+
+> Het Publicatie & Tooling domein omvat 9 repositories en behandelt ReSpec, GitHub Actions, WCAG checks en markdown lint.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Publicatie en Tooling domein
+
+
+## GROUNDED — minstens één bron ondersteunt de claim (6)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `ls-0010` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
+
+> API Design Rules staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status API Design Rules
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  > Lijst status Verplicht ('Pas toe leg uit') [...] De standaard NLGov REST API Design Rules moet worden toegepast bij het aanbieden van REST API's ten behoeve van het ontsluiten van overheidsinformatie en/of functionaliteit.
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. API Design Rules wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). API Design Rules wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. API Design Rules wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. API Design Rules wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De brontekst gaat over NLCIUS, niet over API Design Rules. API Design Rules wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *De bron gaat uitsluitend over het NL Gov Assurance Profile for OAuth 2.0 versie 1.1. API Design Rules wordt niet genoemd.*
+</details>
+
+### `ls-0011` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
+
+> Digikoppeling staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard, inclusief FSC sinds 5 november 2025.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status Digikoppeling en FSC
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  > Op 5 november 2025 heeft het Forum Standaardisatie op basis van aanvullend onderzoek ingestemd met het toekennen van de status 'Pas toe of leg uit' onder Uitstekend beheer aan de nieuwe versie van Digikoppeling (release 30/1/2025), met daarin opgenomen de standaard Federated Service Connectivity (FSC) in het Digikoppeling REST-API profiel.
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *De bron gaat uitsluitend over REST API Design Rules. Digikoppeling wordt wel genoemd als gerelateerde standaard, maar er staat niets over de lijststatus van Digikoppeling of FSC.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). Digikoppeling en FSC worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. Digikoppeling en FSC worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. Digikoppeling en FSC worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De brontekst gaat over NLCIUS. Digikoppeling en FSC worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *Digikoppeling en FSC worden in deze bron niet behandeld.*
+</details>
+
+### `ls-0012` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
+
+> Authenticatie-standaarden (OIDC+SAML) staan op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status authenticatie
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  > Verplicht ('Pas toe leg uit') [...] Authenticatie-standaarden (OpenID.NLGov en SAML) moeten worden toegepast door aanbieders van identitydiensten [...] Datum van besluit 21-09-2023
+  - *De bron bevestigt expliciet de 'Verplicht (Pas toe of leg uit)'-status voor Authenticatie-standaarden (OpenID.NLGov en SAML).*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *De bron behandelt de lijststatus van OIDC/SAML niet.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. OIDC en SAML worden niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. OIDC en SAML worden niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. Authenticatie-standaarden (OIDC+SAML) worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De brontekst gaat over NLCIUS. OIDC en SAML worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *OIDC en SAML als 'pas-toe-of-leg-uit'-standaarden worden niet besproken. SAML wordt slechts terloops genoemd in het praktijkvoorbeeld.*
+</details>
+
+### `ls-0013` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
+
+> OAuth-NL-profiel v1.0 staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status OAuth NL profiel
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  > Verplicht ('Pas toe leg uit') [...] NL GOV Assurance Profile for OAuth 2.0 moet worden toegepast bij applicaties waarbij gebruikers of 'resource owners' impliciet of expliciet toestemming geven aan een dienst van een derde om namens deze toegang te krijgen tot gegevens via een REST API
+  - *De bron bevestigt dat de standaard de status 'Verplicht (Pas toe of leg uit)' heeft. De versie die op de lijst staat is aangeduid als '15 juli 2019' / 'v1.0', wat overeenkomt met de claim over v1.0.*
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  > NL Gov Assurance profile for OAuth 2.0 is 15 juli 2019 opgenomen op de 'Pas toe of leg uit'-lijst van het Forum Standaardisatie.
+  - *De bron bevestigt dat (de voorgaande versie, v1.0) op de 'Pas toe of leg uit'-lijst staat. De formulering 'voorgaande versie staat dan ook op de Pas toe of leg uit-lijst' en de expliciete opnamedatum 15 juli 2019 ondersteunen de claim.*
+<details><summary>5x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *De bron noemt 'NL GOV Assurance profile for OAuth 2.0' als gerelateerde standaard, maar geeft geen informatie over de lijststatus of versie.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. OAuth-NL-profiel wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). OAuth-NL-profiel wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. OAuth-NL-profiel wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De brontekst gaat over NLCIUS. OAuth-NL-profiel wordt niet vermeld.*
+</details>
+
+### `ls-0015` — SKILL.md:40 *(§ Forum Standaardisatie Status)*
+
+> NLCIUS staat op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie als verplichte standaard.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie status NLCIUS
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  > Lijst status [...] Verplicht ('Pas toe leg uit')
+  - *De bron vermeldt expliciet de lijststatus 'Verplicht (Pas toe of leg uit)' voor NLCIUS.*
+<details><summary>6x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *NLCIUS komt in de bron niet voor.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. NLCIUS wordt niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). NLCIUS wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  - *De bron gaat uitsluitend over NL GOV Assurance profile for OAuth 2.0. NLCIUS wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. NLCIUS wordt niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  - *NLCIUS wordt in deze bron niet behandeld.*
+</details>
+
+### `ls-0019` — SKILL.md:44 *(§ Forum Standaardisatie Status)*
+
+> OAuth-NL-profiel v1.1 is vastgesteld door Logius (DEF), maar staat bij het Forum Standaardisatie nog 'in procedure' (intake goedgekeurd 24-09-2025); v1.0 is de verplichte versie.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** OAuth NL profiel Forum Standaardisatie procedure
+
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20)
+  > 24-09-2025: Het Forum Standaardisatie heeft op 24 september 2025 ingestemd met het intakeadvies NL GOV Assurance profile for OAuth 2.0 v1.1 om versie 1.1 van de standaard in procedure te nemen voor plaatsing op de 'Pas toe of leg uit'-lijst. Een volledig expertonderzoek is aangewezen om de standaard te toetsen aan de criteria voor opname op de lijst.
+  - *De bron bevestigt dat v1.1 nog 'in procedure' is (intake goedgekeurd 24-09-2025) en dat v1.0 de huidige verplichte versie is op de lijst (Datum van besluit: 09-07-2020, Versie: 15 juli 2019). Het deel over Logius-vaststelling (DEF) staat niet in deze bron, maar wordt ook niet tegengesproken.*
+- **SUPPORTED** (high) — [https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11)
+  > Op 20 december 2024 heeft Logius het NL Gov Assurance profile for OAuth 2.0 versie 1.1 aangemeld voor plaatsing op de 'Pas toe of leg uit' lijst. [...] De Stuurgroep Open Standaarden adviseert het Forum Standaardisatie om de versie 1.1 van de standaard NL Gov Assurance profile for OAuth 2.0 in procedure te nemen. [...] De voorgaande versie staat dan ook op de 'Pas toe of leg uit'-lijst.
+  - *De bron is het intakeadvies van 29 augustus 2025 voor vergadering 24 september 2025, wat bevestigt dat v1.1 in procedure wordt genomen (intake goedgekeurd). De bron bevestigt ook dat v1.0 op de 'Pas toe of leg uit'-lijst staat. De claim dat v1.1 bij Logius als DEF vastgesteld is wordt niet expliciet bevestigd, maar de rest van de claim wordt volledig onderbouwd.*
+<details><summary>5x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules)
+  - *De bron bevat geen informatie over OAuth-NL-profiel v1.1, de procedure bij Forum Standaardisatie, of de intake van 24-09-2025.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling)
+  - *De bron gaat uitsluitend over Digikoppeling. OAuth-NL-profiel v1.1 en de procedure daarvoor worden niet genoemd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden)
+  - *De brontekst gaat uitsluitend over Authenticatie-standaarden (OpenID.NLGov en SAML). OAuth-NL-profiel v1.1 en de procedure daarvoor worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents)
+  - *De brontekst gaat uitsluitend over het NL GOV profile for CloudEvents. OAuth-NL-profiel v1.1 en de procedure daarvoor worden niet vermeld.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/nlcius](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+  - *De brontekst gaat over NLCIUS. OAuth-NL-profiel v1.1 en de intakeprocedure bij Forum Standaardisatie worden niet vermeld.*
+</details>
+
+</details>


### PR DESCRIPTION
## Beschrijving

Voegt per skill een gegenereerde `audit.md` toe. De audit-pipeline detecteerde de verzonnen PDOK-API-key (skills-geo #232/#234) al, maar de bevinding stond alleen in een gitignore'd JSON die niemand opent. Committen maakt het zichtbaar in PR-review.

`UNSUPPORTED_ASSERTION` = stellige bewering zonder enige bronsteun. Hoog volume, bewust een triage-oppervlak — veel is waar-maar-onbronbaar; de checkbare specifieke claims zijn de interessante.

Workflow zit in aparte PR #608.

## Checklist

- [x] Geen hardcoded paden of persoonlijke gegevens
## Status: post-fix, niet meer stale

ls/audit.md en ls-iam/audit.md zijn opnieuw gegenereerd ná het mergen van #610 (FSC) en #611 (PKCE/registratie), met de cache-TTL-fix actief. Beide nu **0 CONTRADICTED** — de gefixte claims contradiceren niet langer omdat de skills nu de bron volgen. De overige 8 audit.md zijn snapshots van ongewijzigde skills uit de sweep. Branch gerebased op huidige main.