### PR TITLE
fix(ls): FSC staat sinds 5 nov 2025 wel op de Forum-lijst

### DIFF
--- a/skills/ls/SKILL.md
+++ b/skills/ls/SKILL.md
@@ -37,9 +37,9 @@ Niet alle standaarden hebben al een vastgestelde versie. De domeinen ADR, Digiko
 
 Niet alle Logius-standaarden staan op de 'pas-toe-of-leg-uit'-lijst van het Forum Standaardisatie:
 
-- **Verplicht**: [API Design Rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules), [Digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling), [Authenticatie-standaarden (OIDC+SAML)](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden), [OAuth-NL-profiel v1.0](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20), [CloudEvents v1.0](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents), [NLCIUS](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
+- **Verplicht**: [API Design Rules](https://www.forumstandaardisatie.nl/open-standaarden/rest-api-design-rules), [Digikoppeling](https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling) (inclusief FSC sinds 5 november 2025), [Authenticatie-standaarden (OIDC+SAML)](https://www.forumstandaardisatie.nl/open-standaarden/authenticatie-standaarden), [OAuth-NL-profiel v1.0](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20), [CloudEvents v1.0](https://www.forumstandaardisatie.nl/open-standaarden/nl-gov-profile-cloudevents), [NLCIUS](https://www.forumstandaardisatie.nl/open-standaarden/nlcius)
 - **Aanbevolen**: Peppol BIS
-- **Niet op de lijst**: BOMOS (raamwerk, geen interoperabiliteitsstandaard), FSC (onderdeel Digikoppeling), Logboek (in ontwikkeling), Digimelding/Terugmelding, e-procurement
+- **Niet op de lijst**: BOMOS (raamwerk, geen interoperabiliteitsstandaard), Logboek (in ontwikkeling), Digimelding/Terugmelding, e-procurement
 
 > OAuth-NL-profiel v1.1 is vastgesteld door Logius (DEF), maar op het Forum Standaardisatie nog ["in procedure"](https://www.forumstandaardisatie.nl/intakeadvies-nl-gov-assurance-profile-oauth-20-versie-11) (intake goedgekeurd 24-09-2025); v1.0 is de verplichte versie.
 


### PR DESCRIPTION
## Wat

In `skills/ls/SKILL.md` stond FSC onder **Niet op de lijst** ("FSC (onderdeel Digikoppeling)"). Verplaatst naar de **Verplicht**-regel als onderdeel van Digikoppeling, met de datum.

## Waarom

De claim was achterhaald. Het Forum Standaardisatie heeft op **5 november 2025** op basis van aanvullend onderzoek de status 'Pas toe of leg uit' toegekend aan de nieuwe Digikoppeling-versie (release 30-01-2025), waarin de standaard Federated Service Connectivity (FSC) is opgenomen.

Citaat van de bron:
> Op 5 november 2025 heeft het Forum Standaardisatie op basis van aanvullend onderzoek ingestemd met het toekennen van de status 'Pas toe of leg uit' onder Uitstekend beheer aan de nieuwe versie van Digikoppeling (release 30/1/2025), met daarin opgenomen de standaard Federated Service Connectivity (FSC).

Bron: https://www.forumstandaardisatie.nl/open-standaarden/digikoppeling

## Hoe gevonden

Via de audit-sweep (deze claim kreeg `claim_status: CONTRADICTED` — een bron sprak hem expliciet tegen). Vervolgens **live geverifieerd tegen forumstandaardisatie.nl**, niet alleen op de audit-cache vertrouwd. Dat onderscheid is hier wezenlijk: van de 7 CONTRADICTED-claims in de sweep bleken er 2 audit-false-positives (de skill was correct, de cache verouderd). Deze is een echte: de live bron bevestigt de wijziging.

## Checklist

- [x] Live geverifieerd tegen de autoritatieve bron
- [x] Geen hardcoded paden of persoonlijke gegevens