### PR TITLE
fix(ls-iam): PKCE verplicht voor alle clients; dynamische registratie aanbevolen

### DIFF
--- a/skills/ls-iam/SKILL.md
+++ b/skills/ls-iam/SKILL.md
@@ -58,7 +58,7 @@ Het Nederlandse OAuth 2.0 profiel scherpt de basisspecificatie (RFC 6749) aan me
 
 ### Verplichte beveiligingseisen
 
-- **PKCE (Proof Key for Code Exchange)** is verplicht voor public clients. Confidential clients die zich authenticeren met `private_key_jwt` of mTLS zijn vrijgesteld. Dit voorkomt authorization code interception aanvallen. Clients genereren een `code_verifier` en sturen een `code_challenge` mee in het authorization request.
+- **PKCE (Proof Key for Code Exchange)** is verplicht voor *alle* clients per het OIDC NL GOV profiel ("Clients MUST use PKCE to protect calls to the Token Endpoint"), inclusief confidential clients die zich met `private_key_jwt` of mTLS authenticeren — er is geen vrijstelling. Dit voorkomt authorization code interception aanvallen. Clients genereren een `code_verifier` en sturen een `code_challenge` mee in het authorization request.
 - **Grant types**: `authorization_code` is verplicht (MUST); `client_credentials` is toegestaan (MAY) voor machine-to-machine communicatie. Implicit grant en Resource Owner Password Credentials zijn expliciet verboden vanwege bekende beveiligingsrisico's.
 - **Tokens als HTTP headers**: access tokens worden als HTTP `Authorization` header (Bearer scheme) meegegeven. Transport via query parameters is verboden (MUST NOT). Form-encoded body parameters (RFC 6750 Section 2.2) zijn wel toegestaan.
 

--- a/skills/ls-iam/reference.md
+++ b/skills/ls-iam/reference.md
@@ -148,7 +148,7 @@ Clients moeten vooraf worden geregistreerd bij de OpenID Provider. Bij registrat
 - **Publieke sleutels**: voor token validatie en client authenticatie
 - **Client metadata**: naam, logo, privacy policy URL, terms of service URL
 
-**Dynamische registratie**: OpenID Connect ondersteunt dynamische client registratie (RFC 7591), maar voor overheidstoepassingen wordt handmatige registratie aanbevolen om strikte controle te behouden.
+**Dynamische registratie**: het OIDC NL GOV profiel beveelt dynamische client registratie (RFC 7591) aan ("Clients SHOULD use Dynamic Registration") om handwerk en configuratiefouten te beperken. Voor native clients met per-instance registratie is dynamische registratie verplicht (MUST); voor web- en browser-applicaties blijft handmatige registratie toegestaan.
 
 **Client credentials**: Bij confidential clients worden credentials uitgegeven:
 - Bij mTLS: een PKIoverheid-certificaat


### PR DESCRIPTION
Twee claims in `ls-iam` spraken het OIDC NL GOV profiel tegen. Beide gaan over authenticatie, dus een review door iemand met kennis van het auth-profiel is welkom. Beide live geverifieerd tegen de spec voordat ik wijzigde.

## 1. PKCE-vrijstelling was verzonnen (SKILL.md:61)

**Was:** "PKCE is verplicht voor public clients. Confidential clients die zich authenticeren met `private_key_jwt` of mTLS zijn vrijgesteld."

**Profiel zegt:**
> Clients _MUST_ use 'Proof Key for Code Exchange' [RFC7636] to protect calls to the Token Endpoint.

En expliciet: ook confidential clients met private_key_jwt of mTLS moeten PKCE implementeren. Er is geen vrijstelling. De carve-out was gefabriceerd — dezelfde klasse fout als de PDOK-API-key die deze hele exercitie startte, maar dan in een auth-profiel.

**Nu:** PKCE verplicht voor alle clients, met de profielcitaat erbij.

## 2. Registratie-advies stond omgekeerd (reference.md:151)

**Was:** "voor overheidstoepassingen wordt handmatige registratie aanbevolen om strikte controle te behouden."

**Profiel zegt:**
> Clients _SHOULD_ use Dynamic Registration as per [RFC7591] to reduce manual labor and the risks of configuration errors.

De skill adviseerde het tegenovergestelde van de standaard. **Nu:** dynamische registratie aanbevolen, met de nuance dat native per-instance clients het MOETEN gebruiken en web/browser-apps handmatig mogen blijven (ook conform de spec).

## Bron

https://gitdocumentatie.logius.nl/publicatie/api/oidc/ — live geverifieerd, niet op de audit-cache vertrouwd. Van de 7 CONTRADICTED-claims uit de sweep waren er 2 audit-false-positives; deze twee zijn echt en door de live spec bevestigd.

## Hoe gevonden

Audit-sweep, beide `claim_status: CONTRADICTED`. Dit is precies het soort fout dat de `UNSUPPORTED_ASSERTION`/audit-zichtbaarheid-wijzigingen moeten opvangen.

## Checklist

- [x] Live geverifieerd tegen de autoritatieve spec
- [x] Nuance van de spec behouden (niet simpelweg omgedraaid)
- [ ] Auth-profiel review gevraagd