### PR TITLE
fix(ls-api): scherp implementatiedetails-regel aan naar ADR-formulering

### DIFF
--- a/skills/ls-api/SKILL.md
+++ b/skills/ls-api/SKILL.md
@@ -108,7 +108,7 @@ Geen technische details (stack traces, interne hints) in foutmeldingen.
 - **Meervoud** voor collecties: `/users`, `/orders`
 - **Enkelvoud** voor individuele resources: `/users/{id}`
 - Definieer interfaces in het **Nederlands** tenzij er een officieel Engelstalig begrippenkader bestaat
-- Verberg implementatiedetails (geen framework- of databasenamen)
+- Geen implementatiedetails in URI's: een API SHOULD geen framework-, platform- of databasenamen blootleggen in resource-paden (ADR)
 
 ### OpenAPI Documentatie
 


### PR DESCRIPTION
## Wat

`skills/ls-api/SKILL.md:111`, onder ### Naamgeving:

**Was:** `- Verberg implementatiedetails (geen framework- of databasenamen)`
**Nu:** `- Geen implementatiedetails in URI's: een API SHOULD geen framework-, platform- of databasenamen blootleggen in resource-paden (ADR)`

## Waarom

De oude bullet was vager dan de ADR-regel en had geen expliciete scope of modaliteit. De ADR zegt:

> An API SHOULD not expose implementation details of the underlying application, development platforms/frameworks or database systems/persistence models.

Die regel gaat specifiek over URI's/resource-paden (vandaar de plaatsing onder Naamgeving) en heeft modaliteit SHOULD. De herformulering maakt scope en modaliteit expliciet en gelijk aan de bron. Dat is duidelijker voor de lezer én lost de audit-CONTRADICTED op (de audit las de vage bullet als MUST NOT en botste met het SHOULD van de bron).

Bron: https://gitdocumentatie.logius.nl/publicatie/api/adr/2.1.0

## Hoe gevonden

Audit-sweep, `claim_status: CONTRADICTED`.

## Checklist

- [x] Geen hardcoded paden of persoonlijke gegevens
- [x] Formulering gelijkgetrokken met de autoritatieve bron